### PR TITLE
Get crt of OpenShift baseURL for Keycloak

### DIFF
--- a/e2e/run-okd-tests.sh
+++ b/e2e/run-okd-tests.sh
@@ -54,8 +54,8 @@ echo "[INFO] Update OpenShift router tls secret"
 ./oc project default
 ./oc secrets new router-certs tls.crt=ca.crt tls.key=key.pem -o json --type='kubernetes.io/tls' --confirm | ./oc replace -f -
 echo "[INFO] Initiate a new router deployment"
-sleep 10
-./oc rollout latest dc/router -n=default
+sleep 20
+./oc rollout latest dc/router -n=default || true
 
 echo "[INFO] Compile tests binary"
 docker run -t \

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -110,7 +110,7 @@ func GetClusterPublicHostname() (hostname string, err error) {
 	client := &http.Client{}
 	kubeApi := os.Getenv("KUBERNETES_PORT_443_TCP_ADDR")
 	url := "https://" + kubeApi + "/.well-known/oauth-authorization-server"
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	resp, err := client.Do(req)
 	if err != nil {
 		logrus.Errorf("An error occurred when getting API public hostname: %s", err)


### PR DESCRIPTION
This PR adds the following functionality to the operator:

1. Automatically get OpenShift baseURL and extract crt chain.
2. Add this crt to Keycloak container via secret and env variable that gets its values from secret's ca.crt
3. As a result, in Keycloak entrypoint maximum 3 certs are added:
* router crt (if `CHE_SELF__SIGNED__CERT` is not null )
* OpenShift baseURL crt (if `OPENSHIFT_SELF__SIGNED__CERT` is not null - this PR ntroduces it)
* crt mounted at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`

In fact, just `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` should be enough, however, there are use cases when the crt mounted at /var/run/secrets/kubernetes.io/serviceaccount/ca.crt != crt that OpenShiftbaseURL endpoint actually uses. Router crt is added to trus store since in 4.0 baseURL is served over the route.