### PR TITLE
Smarter svc and route functions. Configurable mem settings

### DIFF
--- a/build_deploy_local.sh
+++ b/build_deploy_local.sh
@@ -14,7 +14,7 @@
 
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 
-#docker build -t che/operator .
+docker build -t che/operator .
 kubectl apply -f ${BASE_DIR}/deploy/service_account.yaml -n=$1
 kubectl apply -f ${BASE_DIR}/deploy/role.yaml -n=$1
 kubectl apply -f ${BASE_DIR}/deploy/role_binding.yaml -n=$1

--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -40,6 +40,10 @@ spec:
     nonProxyHosts: ''
     # an endpoint serving plugin definitions. Defaults to https://che-plugin-registry.openshift.io
     pluginRegistryUrl: ''
+    # sets mem request for server deployment. Defaults to 512Mi
+    serverMemoryRequest: ''
+    # sets mem limit for server deployment. Defaults to 1Gi
+    serverMemoryLimit: ''
   database:
     # when set to true, the operator skips deploying Postgres, and passes connection details of existing DB to Che server
     # otherwise a Postgres deployment is created

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -60,6 +60,10 @@ type CheClusterSpecServer struct {
 	ProxyUser string `json:"proxyUser"`
 	// ProxyPassword is password for a proxy user
 	ProxyPassword string `json:"proxyPassword"`
+	// ServerMemoryRequest sets mem request for server deployment. Defaults to 512Mi
+	ServerMemoryRequest string `json:"serverMemoryRequest"`
+	// ServerMemoryLimit sets mem limit for server deployment. Defaults to 1Gi
+	ServerMemoryLimit string `json:"serverMemoryLimit"`
 }
 
 type CheClusterSpecDB struct {

--- a/pkg/controller/che/create.go
+++ b/pkg/controller/che/create.go
@@ -204,8 +204,7 @@ func (r *ReconcileChe) CreateNewOauthClient(instance *orgv1.CheCluster, oAuthCli
 }
 
 // CreateService creates a service with a given name, port, selector and labels
-func (r *ReconcileChe) CreateService(cr *orgv1.CheCluster, name string, labels map[string]string, portName string, portNumber int32) error {
-	service := deploy.NewService(cr, name, labels, portName, portNumber)
+func (r *ReconcileChe) CreateService(cr *orgv1.CheCluster, service *corev1.Service) error {
 	if err := controllerutil.SetControllerReference(cr, service, r.scheme); err != nil {
 		logrus.Errorf("An error occurred %s", err)
 		return err

--- a/pkg/controller/che/k8s_helpers.go
+++ b/pkg/controller/che/k8s_helpers.go
@@ -258,7 +258,7 @@ func (cl *k8s) GetDeploymentPod(name string, ns string) (podName string, err err
 func (r *ReconcileChe) GetEndpointTlsCrt(instance *orgv1.CheCluster, url string) (certificate []byte, err error) {
 	testRoute := &routev1.Route{}
 	if len(url) < 1 {
-		testRoute = deploy.NewTlsRoute(instance, "test", "test")
+		testRoute = deploy.NewTlsRoute(instance, "test", "test", 8080)
 		logrus.Infof("Creating a test route %s to extract routes crt", testRoute.Name)
 		if err := r.CreateNewRoute(instance, testRoute); err != nil {
 			logrus.Errorf("Failed to create test route %s: %s", testRoute.Name, err)

--- a/pkg/controller/che/update.go
+++ b/pkg/controller/che/update.go
@@ -138,10 +138,10 @@ func (r *ReconcileChe) ReconcileTLSObjects(instance *orgv1.CheCluster, request r
 		logrus.Errorf("Failed to delete %s route: %s", currentCheRoute.Name, err)
 		return false, err
 	}
-	cheRoute := deploy.NewRoute(instance, cheFlavor, "che-host")
+	cheRoute := deploy.NewRoute(instance, cheFlavor, "che-host", 8080)
 
 	if tlsSupport {
-		cheRoute = deploy.NewTlsRoute(instance, cheFlavor, "che-host")
+		cheRoute = deploy.NewTlsRoute(instance, cheFlavor, "che-host", 8080)
 		protocol = "https"
 	}
 
@@ -168,10 +168,10 @@ func (r *ReconcileChe) ReconcileTLSObjects(instance *orgv1.CheCluster, request r
 		logrus.Errorf("Failed to delete %s route: %s", currentKeycloakRoute.Name, err)
 		return false, err
 	}
-	keycloakRoute := deploy.NewRoute(instance, "keycloak", "keycloak")
+	keycloakRoute := deploy.NewRoute(instance, "keycloak", "keycloak", 8080)
 
 	if tlsSupport {
-		keycloakRoute = deploy.NewTlsRoute(instance, "keycloak", "keycloak")
+		keycloakRoute = deploy.NewTlsRoute(instance, "keycloak", "keycloak", 8080)
 	}
 	if err := r.CreateNewRoute(instance, keycloakRoute); err != nil {
 		logrus.Errorf("Failed to create Keycloak route: %s", err)

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -42,4 +42,6 @@ const (
 		"-XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 " +
 		"-Dsun.zip.disableMemoryMapping=true " +
 		"-Xms20m -Djava.security.egd=file:/dev/./urandom"
+	DefaultServerMemoryRequest = "512Mi"
+	DefaultServerMemoryLimit   = "1Gi"
 )

--- a/pkg/deploy/deployment_che.go
+++ b/pkg/deploy/deployment_che.go
@@ -25,6 +25,8 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 	labels := GetLabels(cr, util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor))
 	optionalEnv := true
 	cheFlavor := util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor)
+	memRequest := util.GetValue(cr.Spec.Server.ServerMemoryRequest, DefaultServerMemoryRequest)
+	memLimit := util.GetValue(cr.Spec.Server.ServerMemoryLimit, DefaultServerMemoryLimit)
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -70,10 +72,10 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("512Mi"),
+									corev1.ResourceMemory: resource.MustParse(memRequest),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("1Gi"),
+									corev1.ResourceMemory: resource.MustParse(memLimit),
 								},
 							},
 							ReadinessProbe: &corev1.Probe{

--- a/pkg/deploy/route.go
+++ b/pkg/deploy/route.go
@@ -16,12 +16,17 @@ import (
 	"github.com/eclipse/che-operator/pkg/util"
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func NewRoute(cr *orgv1.CheCluster, name string, serviceName string) *routev1.Route {
+func NewRoute(cr *orgv1.CheCluster, name string, serviceName string, port int32) *routev1.Route {
 	labels := GetLabels(cr, util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor))
 	if name == "keycloak" {
 		labels = GetLabels(cr, name)
+	}
+	targetPort := intstr.IntOrString{
+		Type:   intstr.Int,
+		IntVal: int32(port),
 	}
 	return &routev1.Route{
 		TypeMeta: metav1.TypeMeta{
@@ -39,14 +44,21 @@ func NewRoute(cr *orgv1.CheCluster, name string, serviceName string) *routev1.Ro
 				Kind: "Service",
 				Name: serviceName,
 			},
+			Port:&routev1.RoutePort{
+				targetPort,
+			},
 		},
 	}
 }
 
-func NewTlsRoute(cr *orgv1.CheCluster, name string, serviceName string) *routev1.Route {
+func NewTlsRoute(cr *orgv1.CheCluster, name string, serviceName string, port int32) *routev1.Route {
 	labels := GetLabels(cr, util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor))
 	if name == "keycloak" {
 		labels = GetLabels(cr, name)
+	}
+	targetPort := intstr.IntOrString{
+		Type:   intstr.Int,
+		IntVal: int32(port),
 	}
 	return &routev1.Route{
 		TypeMeta: metav1.TypeMeta{
@@ -63,6 +75,9 @@ func NewTlsRoute(cr *orgv1.CheCluster, name string, serviceName string) *routev1
 			To: routev1.RouteTargetReference{
 				Kind: "Service",
 				Name: serviceName,
+			},
+			Port:&routev1.RoutePort{
+				targetPort,
 			},
 			TLS: &routev1.TLSConfig{
 				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,

--- a/pkg/deploy/service.go
+++ b/pkg/deploy/service.go
@@ -17,29 +17,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewService(cr *orgv1.CheCluster, name string, labels map[string]string, portName string, portNumber int32) *corev1.Service {
-
+func NewService(cr *orgv1.CheCluster, name string, portName []string, portNumber []int32, labels map[string]string) *corev1.Service {
+	ports := []corev1.ServicePort{}
+	for i := range portName {
+		port := corev1.ServicePort{
+			Name:     portName[i],
+			Port:     portNumber[i],
+			Protocol: "TCP",
+		}
+		ports = append(ports, port)
+	}
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:     name,
+			Name:      name,
 			Namespace: cr.Namespace,
 			Labels:    labels,
-
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name:     portName,
-					Port:     portNumber,
-					Protocol: "TCP",
-				},
-			},
+			Ports:    ports,
 			Selector: labels,
 		},
 	}
 }
-


### PR DESCRIPTION
This PR:

1. Changes the way services and routes are created (slice of ports and names for services, target port for routes)
2. Makes mem request and limit for Che deployment configurable with  `serverMemoryRequest` and `serverMemoryLimit` spec.server fields, as well as updated Che deployment when those are updated in runtime (after installation).