### PR TITLE
Use extensions apiGroup instead of extensions/v1beta1

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: che-operator
 rules:
 - apiGroups:
-  - extensions/v1beta1
+  - extensions
   resources:
   - ingresses
   verbs:


### PR DESCRIPTION
Hey, hope it's alright if I open a PR here! I understand this repo is still in a beta stage.

I've been playing around with the Che operator (really neat stuff by the way!) on a variety of different Kubes, and found that it was failing due to this error:
```
E0424 17:27:48.536731       1 reflector.go:134] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1beta1.Ingress: ingresses.extensions is forbidden: User "system:serviceaccount:che:che-operator" cannot list resource "ingresses" in API group "extensions" in the namespace "che"
E0424 17:27:49.547908       1 reflector.go:134] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1beta1.Ingress: ingresses.extensions is forbidden: User "system:serviceaccount:che:che-operator" cannot list resource "ingresses" in API group "extensions" in the namespace "che"
E0424 17:27:50.568067       1 reflector.go:134] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1beta1.Ingress: ingresses.extensions is forbidden: User "system:serviceaccount:che:che-operator" cannot list resource "ingresses" in API group "extensions" in the namespace "che"
E0424 17:27:51.583266       1 reflector.go:134] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1beta1.Ingress: ingresses.extensions is forbidden: User "system:serviceaccount:che:che-operator" cannot list resource "ingresses" in API group "extensions" in the namespace "che"

```

The issue is that the [role.yaml](https://github.com/eclipse/che-operator/blob/master/deploy/role.yaml) lists `extensions/v1beta1` as the apiGroup instead of `extensions` for ingress. After changing it, I was able to use the operator to deploy Che just fine. So I'm opening a PR to fix this, if that's alright.

**Note:** Oddly enough, Docker Desktop w/ Kube didn't complain about the role using `extensions/v1beta1`, but all the other Kubes I tested did. Must be an anomaly.