### PR TITLE
Auto fill non proxy with kube api url

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
 )
 
 func addMap(a map[string]string, b map[string]string) {
@@ -110,8 +111,14 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	proxyJavaOpts := ""
 	proxyUser := cr.Spec.Server.ProxyUser
 	proxyPassword := cr.Spec.Server.ProxyPassword
+	nonProxyHosts := cr.Spec.Server.NonProxyHosts
+	if len(nonProxyHosts) < 1 && len(cr.Spec.Server.ProxyURL) > 1 {
+		nonProxyHosts = os.Getenv("KUBERNETES_SERVICE_HOST")
+	} else {
+		nonProxyHosts = nonProxyHosts + "|" + os.Getenv("KUBERNETES_SERVICE_HOST")
+	}
 	if len(cr.Spec.Server.ProxyURL) > 1 {
-		proxyJavaOpts = util.GenerateProxyJavaOpts(cr.Spec.Server.ProxyURL, cr.Spec.Server.ProxyPort, cr.Spec.Server.NonProxyHosts, proxyUser, proxyPassword)
+		proxyJavaOpts = util.GenerateProxyJavaOpts(cr.Spec.Server.ProxyURL, cr.Spec.Server.ProxyPort, nonProxyHosts, proxyUser, proxyPassword)
 	}
 	cheWorkspaceHttpProxy := ""
 	cheWorkspaceNoProxy := ""

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -144,7 +144,7 @@ func GenerateProxyJavaOpts(proxyURL string, proxyPort string, nonProxyHosts stri
 	javaOpts =
 		" -Dhttp.proxyHost=" + proxyHost + " -Dhttp.proxyPort=" + proxyPort +
 			" -Dhttps.proxyHost=" + proxyHost + " -Dhttps.proxyPort=" + proxyPort +
-			" -Dhttp.nonProxyHosts='" + nonProxyHosts + "|172.30.0.1'" + proxyUserPassword
+			" -Dhttp.nonProxyHosts='" + nonProxyHosts + "'" + proxyUserPassword
 	return javaOpts
 }
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -12,6 +12,8 @@
 package util
 
 import (
+	"github.com/sirupsen/logrus"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -48,10 +50,13 @@ func TestGenerateProxyEnvs(t *testing.T) {
 }
 
 func TestGenerateProxyJavaOpts(t *testing.T) {
+	if err := os.Setenv("KUBERNETES_SERVICE_HOST", "172.30.0.1"); err != nil {
+		logrus.Errorf("Failed to set env %s", err)
+	}
 
 	javaOpts := GenerateProxyJavaOpts(proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword)
 	expectedJavaOpts := " -Dhttp.proxyHost=myproxy.com -Dhttp.proxyPort=1234 -Dhttps.proxyHost=myproxy.com " +
-		"-Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts='localhost|myhost.com|172.30.0.1' -Dhttp.proxyUser=user " +
+		"-Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts='localhost|myhost.com' -Dhttp.proxyUser=user " +
 		"-Dhttp.proxyPassword=password -Dhttps.proxyUser=user -Dhttps.proxyPassword=password"
 	if !reflect.DeepEqual(javaOpts,expectedJavaOpts) {
 		t.Errorf("Test failed. Expected '%s' but got '%s'", expectedJavaOpts, javaOpts)
@@ -60,7 +65,7 @@ func TestGenerateProxyJavaOpts(t *testing.T) {
 
 	javaOpts = GenerateProxyJavaOpts(proxyHost, proxyPort, nonProxyHosts, "", proxyPassword)
 	expectedJavaOptsWithoutUsernamePassword := " -Dhttp.proxyHost=myproxy.com -Dhttp.proxyPort=1234 -Dhttps.proxyHost=myproxy.com " +
-		"-Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts='localhost|myhost.com|172.30.0.1'"
+		"-Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts='localhost|myhost.com'"
 
 	if !reflect.DeepEqual(javaOpts ,expectedJavaOptsWithoutUsernamePassword) {
 		t.Errorf("Test failed. Expected '%s' but got '%s'", expectedJavaOptsWithoutUsernamePassword, javaOpts)


### PR DESCRIPTION
This PR automatically adds value of `KUBERNETES_SERVICE_HOST` to non proxy hosts for a workspace master. This makes it possible not to worry about workspace master talking to OpenShift API when https proxy is defined.