### PR TITLE
CRW-282 should the var for SSO admin pwd be...

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -85,7 +85,7 @@ spec:
     # desired admin username of Keycloak admin user (applicable only when externalIdentityProvider is false)
     identityProviderAdminUserName: ''
     # desired password of Keycloak admin user (applicable only when externalIdentityProvider is false)
-    identityProviderPassword: 'admin'
+    identityProviderAdminPassword: 'admin'
     # name of a keycloak realm. This realm will be created, when externalIdentityProvider is true, otherwise passed to Che server
     identityProviderRealm: ''
     # id of a keycloak client. This client will be created, when externalIdentityProvider is false, otherwise passed to Che server

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -95,7 +95,7 @@ type CheClusterSpecAuth struct {
 	// KeycloakAdminUserName is a desired admin username of Keycloak admin user (applicable only when externalIdentityProvider is false)
 	KeycloakAdminUserName string `json:"identityProviderAdminUserName"`
 	// KeycloakAdminPassword is a desired password of Keycloak admin user (applicable only when externalIdentityProvider is false)
-	KeycloakAdminPassword string `json:"identityProviderPassword"`
+	KeycloakAdminPassword string `json:"identityProviderAdminPassword"`
 	// KeycloakRealm is name of a keycloak realm. When externalIdentityProvider is false this realm will be created, otherwise passed to Che server
 	KeycloakRealm string `json:"identityProviderRealm"`
 	// KeycloakClientId is id of a keycloak client. When externalIdentityProvider is false this client will be created, otherwise passed to Che server


### PR DESCRIPTION
CRW-282 should the var for SSO admin pwd be **identityProviderAdminPassword** (to be consistent with **identityProviderAdminUserName**, or **identityProviderPassword**, because reasons?

Change-Id: I2ba3623f06e9f1154e05e0cef9c055f54b317007
Signed-off-by: nickboldt <nboldt@redhat.com>