### PR TITLE
Add field for workspace cluster role to operator

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -1,3 +1,4 @@
+
 #
 #  Copyright (c) 2012-2019 Red Hat, Inc.
 #    This program and the accompanying materials are made
@@ -22,6 +23,9 @@ spec:
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: ''
+    # specifies a custom cluster role to user for the Che workspaces
+    # Uses the default roles if left blank.
+    cheWorkspaceClusterRole: ''
     # when set to true the operator will attempt to get a secret in OpenShift router namespace
     # to add it to Java trust store of Che server. Requires cluster-admin privileges for operator service account
     selfSignedCert:

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -22,11 +22,11 @@ import (
 type CheClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	Server CheClusterSpecServer `json:"server"`
-	Database CheClusterSpecDB `json:"database"`
-	Auth CheClusterSpecAuth `json:"auth"`
-	Storage CheClusterSpecStorage `json:"storage"`
-	K8SOnly CheClusterSpecK8SOnly `json:"k8s"`
+	Server   CheClusterSpecServer  `json:"server"`
+	Database CheClusterSpecDB      `json:"database"`
+	Auth     CheClusterSpecAuth    `json:"auth"`
+	Storage  CheClusterSpecStorage `json:"storage"`
+	K8SOnly  CheClusterSpecK8SOnly `json:"k8s"`
 }
 
 type CheClusterSpecServer struct {
@@ -42,6 +42,9 @@ type CheClusterSpecServer struct {
 	CheLogLevel string `json:"cheLogLevel"`
 	// CheDebug is debug mode for Che server. Defaults to false
 	CheDebug string `json:"cheDebug"`
+	// CustomClusterRoleName specifies a custom cluster role to user for the Che workspaces
+	// The default roles are used if this is left blank.
+	CheWorkspaceClusterRole string `json:"cheWorkspaceClusterRole"`
 	// SelfSignedCert signal about the necessity to get OpenShift router tls secret
 	// and extract certificate to add it to Java trust store for Che server
 	SelfSignedCert bool `json:"selfSignedCert"`

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -279,6 +279,17 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 	if err := r.CreateNewRoleBinding(instance, viewRoleBinding); err != nil {
 		return reconcile.Result{}, err
 	}
+
+	// If the user specified an additional cluster role to use for the Che workspace, create a role binding for it
+	// Use a role binding instead of a cluster role binding to keep the additional access scoped to the workspace's namespace
+	workspaceClusterRole := instance.Spec.Server.CheWorkspaceClusterRole
+	if workspaceClusterRole != "" {
+		customRoleBinding := deploy.NewRoleBinding(instance, "che-workspace-custom", workspaceServiceAccount.Name, workspaceClusterRole, "ClusterRole")
+		if err = r.CreateNewRoleBinding(instance, customRoleBinding); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	if err := r.GenerateAndSaveFields(instance, request); err != nil {
 		instance, _ = r.GetCR(request)
 		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 1}, err
@@ -472,7 +483,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			if deployment.Spec.Template.Spec.Containers[0].Image != instance.Spec.Auth.KeycloakImage {
 				keycloakDeployment := deploy.NewKeycloakDeployment(instance, keycloakPostgresPassword, keycloakAdminPassword, cheFlavor)
 				logrus.Infof("Updating Keycloak deployment with an image %s", instance.Spec.Auth.KeycloakImage)
-				if err := r.client.Update(context.TODO(),keycloakDeployment); err!= nil {
+				if err := r.client.Update(context.TODO(), keycloakDeployment); err != nil {
 					logrus.Errorf("Failed to update Keycloak deployment: %s", err)
 				}
 
@@ -484,8 +495,6 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 				}
 			}
 		}
-
-
 
 		if isOpenShift {
 			doInstallOpenShiftoAuthProvider := instance.Spec.Auth.OpenShiftOauth
@@ -674,7 +683,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 		if err := controllerutil.SetControllerReference(instance, cheDeployment, r.scheme); err != nil {
 			logrus.Errorf("An error occurred: %s", err)
 		}
-		logrus.Infof("Updating deployment %s with new memory settings. Request: %s, limit: %s",cheDeployment.Name, desiredRequest, desiredLimit)
+		logrus.Infof("Updating deployment %s with new memory settings. Request: %s, limit: %s", cheDeployment.Name, desiredRequest, desiredLimit)
 		if err := r.client.Update(context.TODO(), cheDeployment); err != nil {
 			logrus.Errorf("Failed to update deployment: %s", err)
 			return reconcile.Result{}, err


### PR DESCRIPTION
Ports https://github.com/eclipse/che/pull/13178 to the Che operator

Adds an option for the user to specify an additional cluster role for workspaces.

This allows the user to create/use workspaces that require further roles than are provided by default (such as sidecar that needs to list/edit ConfigMaps, creating a service, etc).

**Note:** Some of the changes are from VS Code running `gofmt` upon save. I couldn't find a way to disable it.