### PR TITLE
Fix Che operator to upgrade to 7.0.0-beta-5.0

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -110,6 +110,11 @@ spec:
     ingressStrategy: ''
     # secret name used for tls termination
     tlsSecretName: ''
+    # FSGroup the Che POD and Workspace pod containers should run in  
+    securityContextFsGroup: '' 
+    # User the Che POD and Workspace pod containers should run as  
+    securityContextRunAsUser: '' 
+
 
 
 

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -141,6 +141,10 @@ type CheClusterSpecK8SOnly struct {
 	IngressClass string `json:"ingressClass"`
 	// secret name used for tls termination
 	TlsSecretName string `json:"tlsSecretName"`
+	// FSGroup the Che POD and Workspace pod containers should run in  
+	SecurityContextFsGroup string `json:"securityContextFsGroup"` 
+	// User the Che POD and Workspace pod containers should run as  
+	SecurityContextRunAsUser string `json:"securityContextRunAsUser"` 
 }
 
 // CheClusterStatus defines the observed state of CheCluster

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -661,7 +661,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 		cmResourceVersion := cm.ResourceVersion
 		cheDeployment, err := deploy.NewCheDeployment(instance, cheImageRepo, cheImageTag, cmResourceVersion, isOpenShift)
 		if err != nil {
-			return reconcile.Result{}, err
+			logrus.Errorf("An error occurred: %s", err)
 		}
 		if err := controllerutil.SetControllerReference(instance, cheDeployment, r.scheme); err != nil {
 			logrus.Errorf("An error occurred: %s", err)

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -206,11 +206,13 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 	if err != nil {
 		logrus.Errorf("An error occurred when detecting current infra: %s", err)
 	}
-	// delete oAuthClient before CR is deleted
-	doInstallOpenShiftoAuthProvider := instance.Spec.Auth.OpenShiftOauth
-	if doInstallOpenShiftoAuthProvider {
-		if err := r.ReconcileFinalizer(instance); err != nil {
-			return reconcile.Result{}, err
+	if isOpenShift {
+		// delete oAuthClient before CR is deleted
+		doInstallOpenShiftoAuthProvider := instance.Spec.Auth.OpenShiftOauth
+		if doInstallOpenShiftoAuthProvider {
+			if err := r.ReconcileFinalizer(instance); err != nil {
+				return reconcile.Result{}, err
+			}
 		}
 	}
 	// create a secret with router tls cert when on OpenShift infra and router is configured with a self signed certificate

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -308,7 +308,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			}
 		}
 		// Create a new Postgres deployment
-		postgresDeployment := deploy.NewPostgresDeployment(instance, chePostgresPassword)
+		postgresDeployment := deploy.NewPostgresDeployment(instance, chePostgresPassword, isOpenShift)
 		if err := r.CreateNewDeployment(instance, postgresDeployment); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -128,6 +128,8 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 
 	ingressDomain := cr.Spec.K8SOnly.IngressDomain
 	tlsSecretName := cr.Spec.K8SOnly.TlsSecretName
+	securityContextFsGroup := util.GetValue(cr.Spec.K8SOnly.SecurityContextFsGroup, DefaultSecurityContextFsGroup)
+	securityContextRunAsUser := util.GetValue(cr.Spec.K8SOnly.SecurityContextRunAsUser, DefaultSecurityContextRunAsUser)
 	pvcStrategy := util.GetValue(cr.Spec.Storage.PvcStrategy, DefaultPvcStrategy)
 	pvcClaimSize := util.GetValue(cr.Spec.Storage.PvcClaimSize, DefaultPvcClaimSize)
 	workspacePvcStorageClassName := cr.Spec.Storage.WorkspacePVCStorageClassName
@@ -193,8 +195,8 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 
 	// k8s specific envs
 	k8sCheEnv := map[string]string{
-		"CHE_INFRA_KUBERNETES_POD_SECURITY__CONTEXT_FS__GROUP":     "0",
-		"CHE_INFRA_KUBERNETES_POD_SECURITY__CONTEXT_RUN__AS__USER": "0",
+		"CHE_INFRA_KUBERNETES_POD_SECURITY__CONTEXT_FS__GROUP":     securityContextFsGroup,
+		"CHE_INFRA_KUBERNETES_POD_SECURITY__CONTEXT_RUN__AS__USER": securityContextRunAsUser,
 		"CHE_INFRA_KUBERNETES_NAMESPACE":                           workspacesNamespace,
 		"CHE_INFRA_KUBERNETES_INGRESS_DOMAIN":                      ingressDomain,
 		"CHE_INFRA_KUBERNETES_SERVER__STRATEGY":                    ingressStrategy,

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -46,4 +46,6 @@ const (
 		"-Xms20m -Djava.security.egd=file:/dev/./urandom"
 	DefaultServerMemoryRequest = "512Mi"
 	DefaultServerMemoryLimit   = "1Gi"
+	DefaultSecurityContextFsGroup    = "1724"
+	DefaultSecurityContextRunAsUser  = "1724"
 )

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -35,7 +35,7 @@ const (
 	DefaultPostgresImage             = "registry.redhat.io/rhscl/postgresql-96-rhel7:1-40"
 	DefaultPostgresUpstreamImage     = "centos/postgresql-96-centos7:9.6"
 	DefaultKeycloakImage             = "registry.redhat.io/redhat-sso-7/sso73-openshift:1.0-11"
-	DefaultKeycloakUpstreamImage     = "eclipse/che-keycloak:6.19.0"
+	DefaultKeycloakUpstreamImage     = "eclipse/che-keycloak:7.0.0-beta-5.0"
 	DefaultJavaOpts                  = "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 " +
 		"-XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 " +
 		"-XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap " +

--- a/pkg/deploy/deployment_postgres.go
+++ b/pkg/deploy/deployment_postgres.go
@@ -20,14 +20,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewPostgresDeployment(cr *orgv1.CheCluster, chePostgresPassword string) *appsv1.Deployment {
+func NewPostgresDeployment(cr *orgv1.CheCluster, chePostgresPassword string, isOpenshift bool) *appsv1.Deployment {
 	chePostgresUser := util.GetValue(cr.Spec.Database.ChePostgresUser, "pgche")
 	chePostgresDb := util.GetValue(cr.Spec.Database.ChePostgresDb, "dbche")
 	postgresAdminPassword := util.GeneratePasswd(12)
 	postgresImage := util.GetValue(cr.Spec.Database.PostgresImage, DefaultPostgresImage)
 	name := "postgres"
 	labels := GetLabels(cr, name)
-	return &appsv1.Deployment{
+	deployment := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
 			APIVersion: "apps/v1",
@@ -47,6 +47,8 @@ func NewPostgresDeployment(cr *orgv1.CheCluster, chePostgresPassword string) *ap
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+					},
 					Volumes: []corev1.Volume{
 						{
 							Name: name + "-data",
@@ -122,4 +124,12 @@ func NewPostgresDeployment(cr *orgv1.CheCluster, chePostgresPassword string) *ap
 			},
 		},
 	}
+	if ! isOpenshift {
+		var runAsUser int64 = 26
+		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext {
+			RunAsUser: &runAsUser,
+			FSGroup: &runAsUser,
+		}
+	}
+	return &deployment
 }

--- a/pkg/deploy/deployment_postgres.go
+++ b/pkg/deploy/deployment_postgres.go
@@ -47,8 +47,6 @@ func NewPostgresDeployment(cr *orgv1.CheCluster, chePostgresPassword string, isO
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					SecurityContext: &corev1.PodSecurityContext{
-					},
 					Volumes: []corev1.Volume{
 						{
 							Name: name + "-data",

--- a/pkg/deploy/exec_commands.go
+++ b/pkg/deploy/exec_commands.go
@@ -72,7 +72,7 @@ func GetKeycloakProvisionCommand(cr *orgv1.CheCluster, cheHost string) (command 
 	createRealmClientUserCommand := r.Replace(str)
 	command = createRealmClientUserCommand
 	if cheFlavor == "che" {
-		command = "cd /scripts && " +createRealmClientUserCommand
+		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " +createRealmClientUserCommand
 	}
 	return command
 }


### PR DESCRIPTION
This PR fixes some problems encountered during the upgrade of the Che operator to the `7.0.0-beta-5.0` upstream Che release:
- `kcadm.sh` configuration could not be created on the read-only `/opt/jboss` folder in the Keycloak container when running under an arbitrary UID on Openshift.
- Postgres deployment on Kubernetes should contain a security context that avoids it to run as `root`, just as it is done on upstream deployment method: https://github.com/eclipse/che/blob/master/deploy/kubernetes/helm/che/custom-charts/che-postgres/templates/deployment.yaml#L26

This was  tested on both Openshift 4.1 (POC 4.1.0-rc.5) and Minikube 1.1.0