### PR TITLE
Support the new `openshift-v4` identity provider

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -40,7 +40,7 @@ func printVersion() {
 	logrus.Infof(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	logrus.Infof(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	logrus.Infof(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
-	isOpenShift, err := util.DetectOpenShift()
+	isOpenShift, isOpenShift4, err := util.DetectOpenShift()
 	if err != nil {
 		logrus.Fatalf("Operator is exiting. An error occurred when detecting current infra: %s", err)
 
@@ -48,6 +48,11 @@ func printVersion() {
 	infra := "Kubernetes"
 	if isOpenShift {
 		infra = "OpenShift"
+		if isOpenShift4 {
+			infra += " v4.x"
+		} else {
+			infra += " v3.x"
+		}
 	}
 	logrus.Infof(fmt.Sprintf("Operator is running on %v", infra))
 

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -21,6 +21,8 @@ rules:
       - create
       - get
       - delete
+      - list
+      - watch
   - apiGroups:
       - config.openshift.io
     resources:

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -16,6 +16,14 @@ rules:
   - apiGroups:
       - oauth.openshift.io
     resources:
-      - "*"
+      - oauthclients
     verbs:
-      - "*"
+      - create
+      - get
+      - delete
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+    verbs:
+      - get

--- a/pkg/controller/che/che_controller_test.go
+++ b/pkg/controller/che/che_controller_test.go
@@ -167,7 +167,7 @@ func TestCheController(t *testing.T) {
 	}
 
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: cheCR.Name, Namespace: cheCR.Namespace}, cheCR)
-	err = r.CreateIdentityProviderItems(cheCR, req, "che", "keycloak")
+	err = r.CreateIdentityProviderItems(cheCR, req, "che", "keycloak", false)
 	oAuthClientName := cheCR.Spec.Auth.OauthClientName
 	oauthSecret := cheCR.Spec.Auth.OauthSecret
 	if err = r.client.Get(context.TODO(), types.NamespacedName{Name: oAuthClientName, Namespace: ""}, oAuthClient); err != nil {

--- a/pkg/controller/che/create.go
+++ b/pkg/controller/che/create.go
@@ -268,7 +268,7 @@ func (r *ReconcileChe) CreateNewRoleBinding(instance *orgv1.CheCluster, roleBind
 	return nil
 }
 
-func (r *ReconcileChe) CreateIdentityProviderItems(instance *orgv1.CheCluster, request reconcile.Request, cheFlavor string, keycloakDeploymentName string) (err error) {
+func (r *ReconcileChe) CreateIdentityProviderItems(instance *orgv1.CheCluster, request reconcile.Request, cheFlavor string, keycloakDeploymentName string, isOpenShift4 bool) (err error) {
 	tests := r.tests
 	keycloakAdminPassword := instance.Spec.Auth.KeycloakAdminPassword
 	oAuthClientName := instance.Spec.Auth.OauthClientName
@@ -289,13 +289,13 @@ func (r *ReconcileChe) CreateIdentityProviderItems(instance *orgv1.CheCluster, r
 	}
 	keycloakURL := instance.Spec.Auth.KeycloakURL
 	keycloakRealm := util.GetValue(instance.Spec.Auth.KeycloakRealm, cheFlavor)
-	oAuthClient := deploy.NewOAuthClient(oAuthClientName, oauthSecret, keycloakURL, keycloakRealm)
+	oAuthClient := deploy.NewOAuthClient(oAuthClientName, oauthSecret, keycloakURL, keycloakRealm, isOpenShift4)
 	if err := r.CreateNewOauthClient(instance, oAuthClient); err != nil {
 		return err
 	}
 
 	if !tests {
-		openShiftIdentityProviderCommand := deploy.GetOpenShiftIdentityProviderProvisionCommand(instance, oAuthClientName, oauthSecret, keycloakAdminPassword)
+		openShiftIdentityProviderCommand := deploy.GetOpenShiftIdentityProviderProvisionCommand(instance, oAuthClientName, oauthSecret, keycloakAdminPassword, isOpenShift4)
 		podToExec, err := k8sclient.GetDeploymentPod(keycloakDeploymentName, instance.Namespace)
 		if err != nil {
 			logrus.Errorf("Failed to retrieve pod name. Further exec will fail")

--- a/pkg/controller/che/update.go
+++ b/pkg/controller/che/update.go
@@ -180,14 +180,14 @@ func (r *ReconcileChe) ReconcileTLSObjects(instance *orgv1.CheCluster, request r
 	return true, nil
 }
 
-func (r *ReconcileChe) ReconcileIdentityProvider(instance *orgv1.CheCluster) (deleted bool, err error) {
+func (r *ReconcileChe) ReconcileIdentityProvider(instance *orgv1.CheCluster, isOpenShift4 bool) (deleted bool, err error) {
 	if instance.Spec.Auth.OpenShiftOauth == false && instance.Status.OpenShiftoAuthProvisioned == true {
 		keycloakAdminPassword := instance.Spec.Auth.KeycloakAdminPassword
 		keycloakDeployment := &appsv1.Deployment{}
 		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: "keycloak", Namespace: instance.Namespace}, keycloakDeployment); err != nil {
 			logrus.Errorf("Deployment %s not found: %s", keycloakDeployment.Name, err)
 		}
-		deleteOpenShiftIdentityProviderProvisionCommand := deploy.GetDeleteOpenShiftIdentityProviderProvisionCommand(instance, keycloakAdminPassword)
+		deleteOpenShiftIdentityProviderProvisionCommand := deploy.GetDeleteOpenShiftIdentityProviderProvisionCommand(instance, keycloakAdminPassword, isOpenShift4)
 		podToExec, err := k8sclient.GetDeploymentPod(keycloakDeployment.Name, instance.Namespace)
 		if err != nil {
 			logrus.Errorf("Failed to retrieve pod name. Further exec will fail")

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -82,7 +82,7 @@ func GetCustomConfigMapData() (cheEnv map[string]string) {
 func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	cheHost := cr.Spec.Server.CheHost
 	keycloakURL := cr.Spec.Auth.KeycloakURL
-	isOpenShift, err := util.DetectOpenShift()
+	isOpenShift, isOpenshift4, err := util.DetectOpenShift()
 	if err != nil {
 		logrus.Errorf("Failed to get current infra: %s", err)
 	}
@@ -99,6 +99,9 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	if openshiftOAuth && isOpenShift {
 		workspacesNamespace = ""
 		openShiftIdentityProviderId = "openshift-v3"
+		if isOpenshift4 {
+			openShiftIdentityProviderId = "openshift-v4"
+		}
 	}
 	tlsSupport := cr.Spec.Server.TlsSupport
 	protocol := "http"

--- a/pkg/deploy/deployment_keycloak.go
+++ b/pkg/deploy/deployment_keycloak.go
@@ -35,10 +35,10 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 
 	// add various certificates to Java trust store so that Keycloak can connect to OpenShift API
 	// certificate that OpenShift router uses (for 4.0 only)
-	addRouterCrt := "if [ ! -z \"${CHE_SELF__SIGNED__CERT}\" ]; then echo \"${CHE_SELF__SIGNED__CERT}\" > " + jbossDir + "/openshift.crt && " +
+	addRouterCrt := "if [ ! -z \"${CHE_SELF__SIGNED__CERT}\" ]; then echo \"${CHE_SELF__SIGNED__CERT}\" > " + jbossDir + "/che.crt && " +
 		"keytool -importcert -alias ROUTERCRT" +
 		" -keystore " + jbossDir + "/openshift.jks" +
-		" -file " + jbossDir + "/openshift.crt -storepass " + trustpass + " -noprompt; fi"
+		" -file " + jbossDir + "/che.crt -storepass " + trustpass + " -noprompt; fi"
 	// certificate retrieved from http call to OpenShift API endpoint
 	addOpenShiftAPICrt := "if [ ! -z \"${OPENSHIFT_SELF__SIGNED__CERT}\" ]; then echo \"${OPENSHIFT_SELF__SIGNED__CERT}\" > " + jbossDir + "/openshift.crt && " +
 		"keytool -importcert -alias OPENSHIFTAPI" +
@@ -48,21 +48,26 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 	addMountedCrt := " keytool -importcert -alias MOUNTEDCRT" +
 		" -keystore " + jbossDir + "/openshift.jks" +
 		" -file /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -storepass " + trustpass + " -noprompt"
+	addMountedServiceCrt := "if [ -f /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt ]; then " +
+		"keytool -importcert -alias MOUNTEDSERVICECRT" +
+		" -keystore " + jbossDir + "/openshift.jks" +
+		" -file /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt -storepass " + trustpass + " -noprompt; fi"
 	importJavaCacerts := "keytool -importkeystore -srckeystore $JAVA_HOME/jre/lib/security/cacerts" +
 		" -destkeystore " + jbossDir + "/openshift.jks" +
 		" -srcstorepass changeit -deststorepass " + trustpass
 
-	addCertToTrustStoreCommand := addRouterCrt + " && " + addOpenShiftAPICrt + " && " + addMountedCrt + " && " + importJavaCacerts
+	addCertToTrustStoreCommand := addRouterCrt + " && " + addOpenShiftAPICrt + " && " + addMountedCrt + " && " + addMountedServiceCrt + " && " + importJavaCacerts
 
 	startCommand := "sed -i 's/WILDCARD/ANY/g' /opt/eap/bin/launch/keycloak-spi.sh && /opt/eap/bin/openshift-launch.sh -b 0.0.0.0"
 	// upstream Keycloak has a bit different mechanism of adding jks
-	changeConfigCommand := "echo -e \"embed-server --server-config=standalone.xml --std-out=echo \n" +
+	changeConfigCommand := "echo Installing certificates into Keycloak && " +
+	  "echo -e \"embed-server --server-config=standalone.xml --std-out=echo \n" +
 		"/subsystem=keycloak-server/spi=truststore/:add \n" +
 		"/subsystem=keycloak-server/spi=truststore/provider=file/:add(properties={file => " +
 		"\"" + jbossDir + "/openshift.jks\", password => \"" + trustpass + "\", disabled => \"false\" },enabled=true) \n" +
 		"stop-embedded-server\" > /scripts/add_openshift_certificate.cli && " +
 		"/opt/jboss/keycloak/bin/jboss-cli.sh --file=/scripts/add_openshift_certificate.cli"
-	keycloakAdminUserName := util.GetValue(cr.Spec.Auth.KeycloakAdminUserName, DefaultKeycloakAdminUserName)
+  keycloakAdminUserName := util.GetValue(cr.Spec.Auth.KeycloakAdminUserName, DefaultKeycloakAdminUserName)
 	keycloakEnv := []corev1.EnvVar{
 		{
 			Name:  "PROXY_ADDRESS_FORWARDING",
@@ -86,6 +91,10 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 		},
 		{
 			Name:  "POSTGRES_PORT_5432_TCP_PORT",
+			Value: "5432",
+		},
+		{
+			Name:  "POSTGRES_PORT",
 			Value: "5432",
 		},
 		{
@@ -205,7 +214,7 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 			},
 		}
 	}
-	command := addCertToTrustStoreCommand + " && " + changeConfigCommand + " && /opt/jboss/docker-entrypoint.sh -b 0.0.0.0"
+	command := addCertToTrustStoreCommand + " && " + changeConfigCommand + " && /opt/jboss/docker-entrypoint.sh -b 0.0.0.0 -c standalone.xml"
 	if cheFlavor == "codeready" {
 		command = addCertToTrustStoreCommand + " && " + startCommand
 	}

--- a/pkg/deploy/deployment_keycloak.go
+++ b/pkg/deploy/deployment_keycloak.go
@@ -67,7 +67,7 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 		"\"" + jbossDir + "/openshift.jks\", password => \"" + trustpass + "\", disabled => \"false\" },enabled=true) \n" +
 		"stop-embedded-server\" > /scripts/add_openshift_certificate.cli && " +
 		"/opt/jboss/keycloak/bin/jboss-cli.sh --file=/scripts/add_openshift_certificate.cli"
-  keycloakAdminUserName := util.GetValue(cr.Spec.Auth.KeycloakAdminUserName, DefaultKeycloakAdminUserName)
+	keycloakAdminUserName := util.GetValue(cr.Spec.Auth.KeycloakAdminUserName, DefaultKeycloakAdminUserName)
 	keycloakEnv := []corev1.EnvVar{
 		{
 			Name:  "PROXY_ADDRESS_FORWARDING",

--- a/pkg/deploy/exec_commands.go
+++ b/pkg/deploy/exec_commands.go
@@ -77,9 +77,9 @@ func GetKeycloakProvisionCommand(cr *orgv1.CheCluster, cheHost string) (command 
 	return command
 }
 
-func GetOpenShiftIdentityProviderProvisionCommand(cr *orgv1.CheCluster, oAuthClientName string, oauthSecret string, keycloakAdminPassword string) (command string) {
+func GetOpenShiftIdentityProviderProvisionCommand(cr *orgv1.CheCluster, oAuthClientName string, oauthSecret string, keycloakAdminPassword string, isOpenShift4 bool) (command string) {
 	cheFlavor := util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor)
-	openShiftApiUrl, err := util.GetClusterPublicHostname()
+	openShiftApiUrl, err := util.GetClusterPublicHostname(isOpenShift4)
 	if err != nil {
 		logrus.Errorf("Failed to auto-detect public OpenShift API URL. Configure it in Identity provider details page in Keycloak admin console: %s", err)
 		openShiftApiUrl = "RECPLACE_ME"
@@ -93,25 +93,30 @@ func GetOpenShiftIdentityProviderProvisionCommand(cr *orgv1.CheCluster, oAuthCli
 
 	}
 
+	providerId := "openshift-v3"
+	if isOpenShift4 {
+		providerId = "openshift-v4"
+	}
+
 	createOpenShiftIdentityProviderCommand :=
 		script + " config credentials --server http://0.0.0.0:8080/auth " +
 			"--realm master --user " + keycloakAdminUserName + " --password " + keycloakAdminPassword + " && " + script +
-			" get identity-provider/instances/openshift-v3 -r " + keycloakRealm + "; " +
+			" get identity-provider/instances/" + providerId + " -r " + keycloakRealm + "; " +
 			"if [ $? -eq 0 ]; then echo \"Provider exists\"; exit 0; fi && " + script +
 			" create identity-provider/instances -r " + keycloakRealm +
-			" -s alias=openshift-v3 -s providerId=openshift-v3 -s enabled=true -s storeToken=true" +
+			" -s alias=" + providerId + " -s providerId=" + providerId + " -s enabled=true -s storeToken=true" +
 			" -s addReadTokenRoleOnCreate=true -s config.useJwksUrl=true" +
 			" -s config.clientId=" + oAuthClientName + " -s config.clientSecret=" + oauthSecret +
 			" -s config.baseUrl=" + openShiftApiUrl +
 			" -s config.defaultScope=user:full"
 	command = createOpenShiftIdentityProviderCommand
 	if cheFlavor == "che" {
-		command = "cd /scripts && " + createOpenShiftIdentityProviderCommand
+		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " + createOpenShiftIdentityProviderCommand
 	}
 	return command
 }
 
-func GetDeleteOpenShiftIdentityProviderProvisionCommand(cr *orgv1.CheCluster, keycloakAdminPassword string) (command string) {
+func GetDeleteOpenShiftIdentityProviderProvisionCommand(cr *orgv1.CheCluster, keycloakAdminPassword string, isOpenShift4 bool) (command string) {
 	cheFlavor := util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor)
 	keycloakRealm := util.GetValue(cr.Spec.Auth.KeycloakRealm, cheFlavor)
 	keycloakAdminUserName := util.GetValue(cr.Spec.Auth.KeycloakAdminUserName, DefaultKeycloakAdminUserName)
@@ -121,10 +126,14 @@ func GetDeleteOpenShiftIdentityProviderProvisionCommand(cr *orgv1.CheCluster, ke
 
 	}
 
+	providerName := "openshift-v3"
+	if isOpenShift4 {
+		providerName = "openshift-v4"
+	}
 	deleteOpenShiftIdentityProviderCommand :=
 		script + " config credentials --server http://0.0.0.0:8080/auth " +
 			"--realm master --user " + keycloakAdminUserName + " --password " + keycloakAdminPassword + " && " +
-			script + " delete identity-provider/instances/openshift-v3 -r " + keycloakRealm
+			script + " delete identity-provider/instances/" + providerName + " -r " + keycloakRealm
 	command = deleteOpenShiftIdentityProviderCommand
 	if cheFlavor == "che" {
 		command = "cd /scripts && " + deleteOpenShiftIdentityProviderCommand

--- a/pkg/deploy/oauthclient.go
+++ b/pkg/deploy/oauthclient.go
@@ -17,7 +17,11 @@ import (
 )
 
 
-func NewOAuthClient(name string, oauthSecret string, keycloakURL string, keycloakRealm string) *oauth.OAuthClient {
+func NewOAuthClient(name string, oauthSecret string, keycloakURL string, keycloakRealm string, isOpenShift4 bool) *oauth.OAuthClient {
+	providerName := "openshift-v3"
+	if isOpenShift4 {
+		providerName = "openshift-v4"
+	}
 	return &oauth.OAuthClient{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "OAuthClient",
@@ -30,7 +34,7 @@ func NewOAuthClient(name string, oauthSecret string, keycloakURL string, keycloa
 
 		Secret: oauthSecret,
 		RedirectURIs: []string{
-			keycloakURL + "/auth/realms/" + keycloakRealm +"/broker/openshift-v3/endpoint",
+			keycloakURL + "/auth/realms/" + keycloakRealm +"/broker/" + providerName + "/endpoint",
 		},
 		GrantMethod: oauth.GrantHandlerPrompt,
 	}


### PR DESCRIPTION
This PR introduces required changes to support the new Openshift v4 identity provider that will be provided by PR https://github.com/eclipse/che/pull/13554.

Along with the mentioned upstream Che PR, this work is the upstream fix for the following CRW issue: https://issues.jboss.org/browse/CRW-202.

In order to integrate this fix into downstream CRW, we should:
- Wait for the new openshift v4 provider fix (https://github.com/slaskawi/KEYCLOAK-10169-OpenShift4-User-Provider) to be integrated in the next RHSSO release 
- Do some work / testing to identify any required adjustments related to the use of RHSSO instead of upstream Keycloak.