### PR TITLE
Fix issue #32 (Che install fails due to failed image pulls from registry.redhat.io)

### DIFF
--- a/pkg/controller/che/create.go
+++ b/pkg/controller/che/create.go
@@ -509,7 +509,11 @@ func (r *ReconcileChe) GenerateAndSaveFields(instance *orgv1.CheCluster, request
 			return err
 		}
 	}
-	pvcJobsImage := util.GetValue(instance.Spec.Storage.PvcJobsImage, deploy.DefaultPvcJobsImage)
+	defaultPVCJobsImage := deploy.DefaultPvcJobsUpstreamImage
+	if cheFlavor == "codeready" {
+		defaultPVCJobsImage = deploy.DefaultPvcJobsImage
+	}
+	pvcJobsImage := util.GetValue(instance.Spec.Storage.PvcJobsImage, defaultPVCJobsImage)
 	if len(instance.Spec.Storage.PvcJobsImage) < 1 {
 		instance.Spec.Storage.PvcJobsImage = pvcJobsImage
 		if err := r.UpdateCheCRSpec(instance, "pvc jobs image", pvcJobsImage); err != nil {

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -136,7 +136,12 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	pvcStrategy := util.GetValue(cr.Spec.Storage.PvcStrategy, DefaultPvcStrategy)
 	pvcClaimSize := util.GetValue(cr.Spec.Storage.PvcClaimSize, DefaultPvcClaimSize)
 	workspacePvcStorageClassName := cr.Spec.Storage.WorkspacePVCStorageClassName
-	pvcJobsImage := util.GetValue(cr.Spec.Storage.PvcJobsImage, DefaultPvcJobsImage)
+	
+	defaultPVCJobsImage := DefaultPvcJobsUpstreamImage
+	if cheFlavor == "codeready" {
+		defaultPVCJobsImage = DefaultPvcJobsImage
+	}
+	pvcJobsImage := util.GetValue(cr.Spec.Storage.PvcJobsImage, defaultPVCJobsImage)
 	preCreateSubPaths := "true"
 	if !cr.Spec.Storage.PreCreateSubPaths {
 		preCreateSubPaths = "false"

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -32,6 +32,7 @@ const (
 	DefaultCheLogLevel               = "INFO"
 	DefaultCheDebug                  = "false"
 	DefaultPvcJobsImage              = "registry.redhat.io/ubi8-minimal:8.0-127"
+	DefaultPvcJobsUpstreamImage      = "registry.access.redhat.com/ubi8-minimal:8.0-127"
 	DefaultPostgresImage             = "registry.redhat.io/rhscl/postgresql-96-rhel7:1-40"
 	DefaultPostgresUpstreamImage     = "centos/postgresql-96-centos7:9.6"
 	DefaultKeycloakImage             = "registry.redhat.io/redhat-sso-7/sso73-openshift:1.0-11"


### PR DESCRIPTION
This PR fixes the issue for the community Che operator (the bug was only in the community Eclipse Che operator).

This PR is flagged WIP since I build it against the `openshift-v4-support`. I'll update it as soon as PR https://github.com/eclipse/che-operator/pull/34 is merged.