### PR TITLE
Fix unnecessary cluster perm requirement

### DIFF
--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -226,13 +226,15 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 				return reconcile.Result{}, err
 			}
 		}
-		// create a secret with OpenShift API crt to be added to keystore that RH SSO will consume
-		baseURL, err := util.GetClusterPublicHostname(isOpenShift4)
-		if err != nil {
-			logrus.Errorf("Failed to get OpenShift cluster public hostname. A secret with API crt will not be created and consumed by RH-SSO/Keycloak")
-		} else {
-			if err := r.CreateTLSSecret(instance, baseURL, "openshift-api-crt"); err != nil {
-				return reconcile.Result{}, err
+		if instance.Spec.Auth.OpenShiftOauth {
+			// create a secret with OpenShift API crt to be added to keystore that RH SSO will consume
+			baseURL, err := util.GetClusterPublicHostname(isOpenShift4)
+			if err != nil {
+				logrus.Errorf("Failed to get OpenShift cluster public hostname. A secret with API crt will not be created and consumed by RH-SSO/Keycloak")
+			} else {
+				if err := r.CreateTLSSecret(instance, baseURL, "openshift-api-crt"); err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 		}
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -108,15 +108,15 @@ func IsTestMode() (isTesting bool) {
 
 func GetClusterPublicHostname(isOpenShift4 bool) (hostname string, err error) {
 	if isOpenShift4 {
-		return GetClusterPublicHostnameForOpenshiftV4()
+		return getClusterPublicHostnameForOpenshiftV4()
 	} else {
-		return GetClusterPublicHostnameForOpenshiftV3()
+		return getClusterPublicHostnameForOpenshiftV3()
 	}
 }
 
-// GetClusterPublicHostnameForOpenshiftV3 is a hacky way to get OpenShift API public DNS/IP
+// getClusterPublicHostnameForOpenshiftV3 is a hacky way to get OpenShift API public DNS/IP
 // to be used in OpenShift oAuth provider as baseURL
-func GetClusterPublicHostnameForOpenshiftV3() (hostname string, err error) {
+func getClusterPublicHostnameForOpenshiftV3() (hostname string, err error) {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	client := &http.Client{}
 	kubeApi := os.Getenv("KUBERNETES_PORT_443_TCP_ADDR")
@@ -143,9 +143,9 @@ func GetClusterPublicHostnameForOpenshiftV3() (hostname string, err error) {
 	return hostname, nil
 }
 
-// GetClusterPublicHostnameForOpenshiftV3 is a way to get OpenShift API public DNS/IP
+// getClusterPublicHostnameForOpenshiftV3 is a way to get OpenShift API public DNS/IP
 // to be used in OpenShift oAuth provider as baseURL
-func GetClusterPublicHostnameForOpenshiftV4() (hostname string, err error) {
+func getClusterPublicHostnameForOpenshiftV4() (hostname string, err error) {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	client := &http.Client{}
 	kubeApi := os.Getenv("KUBERNETES_PORT_443_TCP_ADDR")


### PR DESCRIPTION
This PR is to fix an unnecessary requirement of cluster roles for the `che-operator` running on Openshift 4 without Openshift OAuth.