### PR TITLE
Change an obsolete env variable

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -71,7 +71,7 @@ func GetCustomConfigMapData() (cheEnv map[string]string) {
 		"CHE_INFRA_KUBERNETES_SERVICE__ACCOUNT__NAME":           "che-workspace",
 		"CHE_WORKSPACE_AUTO_START":                              "true",
 		"CHE_INFRA_KUBERNETES_WORKSPACE__UNRECOVERABLE__EVENTS": "FailedMount,FailedScheduling,MountVolume.SetUp failed,Failed to pull image",
-		"CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS":   "-1",
+		"CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT": "-1",
 	}
 	return cheEnv
 


### PR DESCRIPTION
According to a recent discussion on IM, the obsolete `` environment variable should be replaced by a new one in the generated `custom` config map.

Here is  a quote of @skabashnyuk from the discussion:

> `che.workspace.agent.dev.inactive_stop_timeout_ms` is an old property
>> `#     The length of time that a user is idle with their workspace when the system will`
>> `#     suspend the workspace and then stopping it. Idleness is the`
>> `#     length of time that the user has not interacted with the workspace, meaning that`
>> `#     one of our agents has not received interaction. Leaving a browser window open`
>> `#     counts toward idleness.`
> > `che.limits.workspace.idle.timeout=-1`
>
> CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT - is the correct one

