### PR TITLE
Update to the `7.0.0-RC-2.0` release after some last fixes

### DIFF
--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -661,6 +661,10 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 	// but OpenShiftoAuthProvisioned is true in CR status, e.g. when oAuth has been turned on and then turned off
 	deleted, err := r.ReconcileIdentityProvider(instance, isOpenShift4)
 	if deleted {
+		if err := r.DeleteFinalizer(instance); err != nil {
+			instance, _ = r.GetCR(request)
+			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 1}, err
+		}
 		instance.Status.OpenShiftoAuthProvisioned = false
 		if err := r.UpdateCheCRStatus(instance, "provisioned with OpenShift oAuth", "false"); err != nil {
 			instance, _ = r.GetCR(request)

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -497,6 +497,9 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			openshiftApiCertSecretVersion != deployment.Annotations["che.openshift-api-crt.version"] {
 				keycloakDeployment := deploy.NewKeycloakDeployment(instance, keycloakPostgresPassword, keycloakAdminPassword, cheFlavor, cheCertSecretVersion, openshiftApiCertSecretVersion)
 				logrus.Infof("Updating Keycloak deployment with an image %s", instance.Spec.Auth.KeycloakImage)
+				if err := controllerutil.SetControllerReference(instance, keycloakDeployment, r.scheme); err != nil {
+					logrus.Errorf("An error occurred: %s", err)
+				}
 				if err := r.client.Update(context.TODO(), keycloakDeployment); err != nil {
 					logrus.Errorf("Failed to update Keycloak deployment: %s", err)
 				}

--- a/pkg/controller/che/finalizer.go
+++ b/pkg/controller/che/finalizer.go
@@ -27,7 +27,7 @@ func (r *ReconcileChe) ReconcileFinalizer(instance *orgv1.CheCluster) (err error
 			if err := r.client.Delete(context.TODO(), oAuthClient); err != nil {
 				logrus.Errorf("Failed to delete %s oAuthClient: %s", oAuthClientName, err)
 				return err
-			}
+			}		
 			instance.ObjectMeta.Finalizers = util.DoRemoveString(instance.ObjectMeta.Finalizers, oAuthFinalizerName)
 			logrus.Infof("Updating %s CR", instance.Name)
 
@@ -37,6 +37,16 @@ func (r *ReconcileChe) ReconcileFinalizer(instance *orgv1.CheCluster) (err error
 			}
 		}
 		return nil
+	}
+	return nil
+}
+
+func (r *ReconcileChe) DeleteFinalizer(instance *orgv1.CheCluster) (err error) {
+	instance.ObjectMeta.Finalizers = util.DoRemoveString(instance.ObjectMeta.Finalizers, oAuthFinalizerName)
+	logrus.Infof("Removing OAuth finalizer on %s CR", instance.Name)
+	if err := r.client.Update(context.Background(), instance); err != nil {
+		logrus.Errorf("Failed to update %s CR: %s", instance.Name, err)
+		return err
 	}
 	return nil
 }

--- a/pkg/controller/che/finalizer.go
+++ b/pkg/controller/che/finalizer.go
@@ -27,7 +27,7 @@ func (r *ReconcileChe) ReconcileFinalizer(instance *orgv1.CheCluster) (err error
 			if err := r.client.Delete(context.TODO(), oAuthClient); err != nil {
 				logrus.Errorf("Failed to delete %s oAuthClient: %s", oAuthClientName, err)
 				return err
-			}		
+			}
 			instance.ObjectMeta.Finalizers = util.DoRemoveString(instance.ObjectMeta.Finalizers, oAuthFinalizerName)
 			logrus.Infof("Updating %s CR", instance.Name)
 

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -15,7 +15,7 @@ package deploy
 const (
 	DefaultCheServerImageRepo        = "eclipse/che-server"
 	DefaultCodeReadyServerImageRepo  = "registry.redhat.io/codeready-workspaces/server-rhel8"
-	DefaultCheServerImageTag         = "7.0.0-beta-5.0"
+	DefaultCheServerImageTag         = "7.0.0-RC-2.0"
 	DefaultCodeReadyServerImageTag   = "1.2"
 	DefaultCheFlavor                 = "che"
 	DefaultChePostgresUser           = "pgche"
@@ -36,7 +36,7 @@ const (
 	DefaultPostgresImage             = "registry.redhat.io/rhscl/postgresql-96-rhel7:1-40"
 	DefaultPostgresUpstreamImage     = "centos/postgresql-96-centos7:9.6"
 	DefaultKeycloakImage             = "registry.redhat.io/redhat-sso-7/sso73-openshift:1.0-11"
-	DefaultKeycloakUpstreamImage     = "eclipse/che-keycloak:7.0.0-beta-5.0"
+	DefaultKeycloakUpstreamImage     = "eclipse/che-keycloak:7.0.0-RC-2.0"
 	DefaultJavaOpts                  = "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 " +
 		"-XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 " +
 		"-XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap " +

--- a/pkg/deploy/deployment_keycloak.go
+++ b/pkg/deploy/deployment_keycloak.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string, keycloakAdminPassword string, cheFlavor string) *appsv1.Deployment {
+func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string, keycloakAdminPassword string, cheFlavor string, cheCertSecretVersion string, openshiftCertSecretVersion string) *appsv1.Deployment {
 	optionalEnv := true
 	keycloakName := "keycloak"
 	labels := GetLabels(cr, keycloakName)
@@ -227,6 +227,10 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 			Name:      keycloakName,
 			Namespace: cr.Namespace,
 			Labels:    labels,
+			Annotations: map[string]string {
+				"che.self-signed-certificate.version": cheCertSecretVersion,
+				"che.openshift-api-crt.version": openshiftCertSecretVersion,
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},

--- a/pkg/deploy/exec_commands.go
+++ b/pkg/deploy/exec_commands.go
@@ -136,7 +136,7 @@ func GetDeleteOpenShiftIdentityProviderProvisionCommand(cr *orgv1.CheCluster, ke
 			script + " delete identity-provider/instances/" + providerName + " -r " + keycloakRealm
 	command = deleteOpenShiftIdentityProviderCommand
 	if cheFlavor == "che" {
-		command = "cd /scripts && " + deleteOpenShiftIdentityProviderCommand
+		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " + deleteOpenShiftIdentityProviderCommand
 	}
 	return command
 }


### PR DESCRIPTION
This PR updates the default tags for images the Che and keycloak images to the `7.0.0-RC-2.0`.

But it also fixes a number of bugs found in the last round of tests performed for the RC 2 update:
- The Che operator did crash badly on Openshift V4 when enabling Openshift OAuth without the related cluster permissions. Implemented graceful failure => commit 34a9c62
- When disabling Openshift AOuth, the command run inside the Keycloak POD was failing due to file system permissions => commit 46803d8
- When enabling Openshift OAuth (=> adding the OS API certificate for Keycloak), the Keycloac server was not automatically restarted, and Openshift OAuth was failing => commit 7cc07ca
- After a rolling update of the Keycloak deployment, the controller reference was lost on the Keycloak deployment, so that it would not be deleted when deleting the `CheCluster` CR => commit e17c388
- When disabling Openshift OAuth, the related finalizer was not removed, which finally prevented the deletion of the `CheCluster` CR => commit e2d1801
