### PR TITLE
should we use an official image here,...

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: che-operator
       containers:
         - name: che-operator
-          image: eivantsov/operator
+          image: quay.io/eclipse-che/che-operator:7.0.0-beta-5.0
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
should we use an official image here, instead of https://hub.docker.com/r/eivantsov/operator ? Is there a 6.19.x version somewhere?

Change-Id: I0146059407f787fb90cd2c7e345cbb40f9d106da
Signed-off-by: nickboldt <nboldt@redhat.com>