### PR TITLE
Updating codeowners for Che 7 endgame code reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @nickboldt @davidfestal
+* @nickboldt @davidfestal @l0rd @rhopp @vparfonov


### PR DESCRIPTION
Adding @l0rd @rhopp as global code reviewers as required by eclipse/che#13637