### PR TITLE
Fix registry labels and probes

### DIFF
--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -378,7 +378,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 	}
 
 	addRegistryRoute := func (registryType string) (string, error) {
-		registryName := "che-" + registryType + "-registry"
+		registryName := registryType + "-registry"
 		host := ""
 		if !isOpenShift {
 			ingress := deploy.NewIngress(instance, registryName, registryName, 8080)
@@ -412,8 +412,9 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 		registryImagePullPolicy corev1.PullPolicy,
 		registryMemoryLimit string,
 		registryMemoryRequest string,
+		probePath string,
 	) (*reconcile.Result, error) {
-		registryName := "che-" + registryType + "-registry"
+		registryName := registryType + "-registry"
 
 		// Create a new registry service
 		registryLabels := deploy.GetLabels(instance, registryName)
@@ -429,6 +430,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			registryImagePullPolicy,
 			registryMemoryLimit,
 			registryMemoryRequest,
+			probePath,
 		)
 		if err := r.CreateNewDeployment(instance, registryDeployment); err != nil {
 			return &reconcile.Result{}, err
@@ -454,6 +456,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 					registryImagePullPolicy,
 					registryMemoryLimit,
 					registryMemoryRequest,
+					probePath,
 				)
 				logrus.Infof("Updating %s registry deployment with an image %s", registryType, registryImage)
 				if err := controllerutil.SetControllerReference(instance, newDeployment, r.scheme); err != nil {
@@ -489,6 +492,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			corev1.PullPolicy(util.GetValue(string(instance.Spec.Server.PluginRegistryImagePullPolicy), deploy.DefaultPluginRegistryPullPolicy)),
 			util.GetValue(string(instance.Spec.Server.PluginRegistryMemoryLimit), deploy.DefaultPluginRegistryMemoryLimit),
 			util.GetValue(string(instance.Spec.Server.PluginRegistryMemoryRequest), deploy.DefaultPluginRegistryMemoryRequest),
+			"/v3/plugins/",
 		)
 		if err != nil || result != nil {
 			return *result, err
@@ -514,6 +518,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			corev1.PullPolicy(util.GetValue(string(instance.Spec.Server.DevfileRegistryImagePullPolicy), deploy.DefaultDevfileRegistryPullPolicy)),
 			util.GetValue(string(instance.Spec.Server.DevfileRegistryMemoryLimit), deploy.DefaultDevfileRegistryMemoryLimit),
 			util.GetValue(string(instance.Spec.Server.DevfileRegistryMemoryRequest), deploy.DefaultDevfileRegistryMemoryRequest),
+			"/devfiles/",
 		)
 		if err != nil || result != nil {
 			return *result, err

--- a/pkg/deploy/deployment_devfile_registry.go
+++ b/pkg/deploy/deployment_devfile_registry.go
@@ -27,8 +27,9 @@ func NewRegistryDeployment(
 		registryImagePullPolicy corev1.PullPolicy,
 		registryMemoryLimit string,
 		registryMemoryRequest string,
+		probePath string,
 	) *appsv1.Deployment {
-	name := "che-" + registryType + "-registry"
+	name := registryType + "-registry"
 	labels := GetLabels(cr, name)
 	_25Percent := intstr.FromString("25%")
 	_1 := int32(1)
@@ -61,7 +62,7 @@ func NewRegistryDeployment(
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:            name,
+							Name:            "che-" + name,
 							Image:           registryImage,
 							ImagePullPolicy: registryImagePullPolicy,
 							Ports: []corev1.ContainerPort{


### PR DESCRIPTION
This PR fixes the labels and names of the registry deployments, as well as the plugin registry probe path, to be consistent with the change made in the [corresponding Helm PR](https://github.com/eclipse/che/pull/13890) in commits:
https://github.com/eclipse/che/pull/13890/commits/bb0af81a7d5144d6d38190ba00bc3603480f56c5
and
https://github.com/eclipse/che/pull/13890/commits/56c9f831a184e6d9b528cdd34da8ab8e46f7b4cc

Signed-off-by: David Festal <dfestal@redhat.com>