### PR TITLE
Add the `read-token` role by default for new users

### DIFF
--- a/deploy/keycloak_provision
+++ b/deploy/keycloak_provision
@@ -31,4 +31,6 @@ if [ $? -eq 0 ]; then echo "Realm exists"; exit 0; fi \
 && $script add-roles      -r '$keycloakRealm' \
                                         --uusername admin \
                                         --cclientid broker \
-                                        --rolename read-token
+                                        --rolename read-token \
+&& CLIENT_ID=$($script get clients -r che -q clientId=broker | sed -n 's/.*"id" : "\([^"]\+\).*/\1/p') \
+&& $script update clients/$CLIENT_ID -r che -s "defaultRoles+=read-token"

--- a/deploy/keycloak_provision
+++ b/deploy/keycloak_provision
@@ -32,5 +32,5 @@ if [ $? -eq 0 ]; then echo "Realm exists"; exit 0; fi \
                                         --uusername admin \
                                         --cclientid broker \
                                         --rolename read-token \
-&& CLIENT_ID=$($script get clients -r che -q clientId=broker | sed -n 's/.*"id" : "\([^"]\+\).*/\1/p') \
+&& CLIENT_ID=$($script get clients -r che -q clientId=broker | sed -n 's/.*"id" *: *"\([^"]\+\).*/\1/p') \
 && $script update clients/$CLIENT_ID -r che -s "defaultRoles+=read-token"


### PR DESCRIPTION
This PR fixes issue https://github.com/eclipse/che/issues/13975:
Weird Login flow when Che is installed from the Operator with Openshift OAuth 
