### PR TITLE
Allow configuring pull policy (with `Always` by default for nightlies)

### DIFF
--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -12,8 +12,8 @@
 package v1
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -35,6 +35,8 @@ type CheClusterSpecServer struct {
 	CheImage string `json:"cheImage"`
 	// CheImageTag is a tag of an image used in Che deployment
 	CheImageTag string `json:"cheImageTag"`
+	// CheImagePullPolicy is the image pull policy used in Che registry deployment: default value is Always
+	CheImagePullPolicy corev1.PullPolicy `json:"cheImagePullPolicy"`
 	// CheFlavor is an installation flavor. Can be 'che' - upstream or 'codeready' - CodeReady Workspaces. Defaults to 'che'
 	CheFlavor string `json:"cheFlavor"`
 	// CheHost is an env consumer by server. Detected automatically from Che route
@@ -113,6 +115,8 @@ type CheClusterSpecDB struct {
 	ChePostgresDb string `json:"chePostgresDb"`
 	// PostgresImage is an image used in Postgres deployment in format image:tag. Defaults to registry.redhat.io/rhscl/postgresql-96-rhel7 (see pkg/deploy/defaults.go for latest tag)
 	PostgresImage string `json:"postgresImage"`
+	// PostgresImagePullPolicy is the image pull policy used in Postgres registry deployment: default value is Always
+	PostgresImagePullPolicy corev1.PullPolicy `json:"postgresImagePullPolicy"`
 }
 
 type CheClusterSpecAuth struct {
@@ -143,6 +147,8 @@ type CheClusterSpecAuth struct {
 	OauthSecret string `json:"oAuthSecret"`
 	// KeycloakImage is image:tag used in Keycloak deployment
 	KeycloakImage string `json:"identityProviderImage"`
+	// KeycloakImagePullPolicy is the image pull policy used in Keycloak registry deployment: default value is Always
+	KeycloakImagePullPolicy corev1.PullPolicy `json:"identityProviderImagePullPolicy"`
 }
 
 type CheClusterSpecStorage struct {

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -486,10 +486,11 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 1}, err
 		}
 
+		pluginRegistryImage := util.GetValue(instance.Spec.Server.PluginRegistryImage, deploy.DefaultPluginRegistryImage)
 		result, err := addRegistryDeployment(
 			"plugin",
-			util.GetValue(instance.Spec.Server.PluginRegistryImage, deploy.DefaultPluginRegistryImage),
-			corev1.PullPolicy(util.GetValue(string(instance.Spec.Server.PluginRegistryImagePullPolicy), deploy.DefaultPluginRegistryPullPolicy)),
+			pluginRegistryImage,
+			corev1.PullPolicy(util.GetValue(string(instance.Spec.Server.PluginRegistryImagePullPolicy), deploy.DefaultPullPolicyFromDockerImage(pluginRegistryImage))),
 			util.GetValue(string(instance.Spec.Server.PluginRegistryMemoryLimit), deploy.DefaultPluginRegistryMemoryLimit),
 			util.GetValue(string(instance.Spec.Server.PluginRegistryMemoryRequest), deploy.DefaultPluginRegistryMemoryRequest),
 			"/v3/plugins/",
@@ -512,10 +513,11 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 1}, err
 		}
 
+		devfileRegistryImage := util.GetValue(instance.Spec.Server.DevfileRegistryImage, deploy.DefaultDevfileRegistryImage)
 		result, err := addRegistryDeployment(
 			"devfile",
-			util.GetValue(instance.Spec.Server.DevfileRegistryImage, deploy.DefaultDevfileRegistryImage),
-			corev1.PullPolicy(util.GetValue(string(instance.Spec.Server.DevfileRegistryImagePullPolicy), deploy.DefaultDevfileRegistryPullPolicy)),
+			devfileRegistryImage,
+			corev1.PullPolicy(util.GetValue(string(instance.Spec.Server.PluginRegistryImagePullPolicy), deploy.DefaultPullPolicyFromDockerImage(devfileRegistryImage))),
 			util.GetValue(string(instance.Spec.Server.DevfileRegistryMemoryLimit), deploy.DefaultDevfileRegistryMemoryLimit),
 			util.GetValue(string(instance.Spec.Server.DevfileRegistryMemoryRequest), deploy.DefaultDevfileRegistryMemoryRequest),
 			"/devfiles/",

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -12,13 +12,15 @@
 // REMINDER: when updating versions below, see also pkg/apis/org/v1/che_types.go and deploy/crds/org_v1_che_cr.yaml
 package deploy
 
+import (
+	"strings"
+)
+
 const (
 	DefaultCheServerImageRepo           = "eclipse/che-server"
 	DefaultCodeReadyServerImageRepo     = "registry.redhat.io/codeready-workspaces/server-rhel8"
 	DefaultCheServerImageTag            = "7.0.0-RC-2.0"
 	DefaultCodeReadyServerImageTag      = "1.2"
-	DefaultCheServerPullPolicy          = "Always"
-	DefaultCodeReadyServerPullPolicy    = "IfNotPresent"
 	DefaultCheFlavor                    = "che"
 	DefaultChePostgresUser              = "pgche"
 	DefaultChePostgresHostName          = "postgres"
@@ -29,12 +31,10 @@ const (
 	DefaultIngressStrategy              = "multi-host"
 	DefaultIngressClass                 = "nginx"
 	DefaultPluginRegistryImage          = "quay.io/eclipse/che-plugin-registry:7.0.0-RC-2.0"
-	DefaultPluginRegistryPullPolicy     = "Always"
 	DefaultPluginRegistryMemoryLimit    = "32Mi"
 	DefaultPluginRegistryMemoryRequest  = "16Mi"
 	DefaultCodereadyPluginRegistryUrl   = "https://che-plugin-registry.openshift.io"
 	DefaultDevfileRegistryImage         = "quay.io/eclipse/che-devfile-registry:7.0.0-RC-2.0"
-	DefaultDevfileRegistryPullPolicy    = "Always"
 	DefaultDevfileRegistryMemoryLimit   = "32Mi"
 	DefaultDevfileRegistryMemoryRequest = "16Mi"
 	DefaultKeycloakAdminUserName        = "admin"
@@ -44,11 +44,8 @@ const (
 	DefaultPvcJobsUpstreamImage         = "registry.access.redhat.com/ubi8-minimal:8.0-127"
 	DefaultPostgresImage                = "registry.redhat.io/rhscl/postgresql-96-rhel7:1-40"
 	DefaultPostgresUpstreamImage        = "centos/postgresql-96-centos7:9.6"
-	DefaultPostgresPullPolicy           = "IfNotPresent"
 	DefaultKeycloakImage                = "registry.redhat.io/redhat-sso-7/sso73-openshift:1.0-11"
 	DefaultKeycloakUpstreamImage        = "eclipse/che-keycloak:7.0.0-RC-2.0"
-	DefaultKeycloakPullPolicy           = "IfNotPresent"
-	DefaultKeycloakUpstreamPullPolicy   = "Always"
 	DefaultJavaOpts                     = "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 " +
 		"-XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 " +
 		"-XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap " +
@@ -62,3 +59,15 @@ const (
 	DefaultSecurityContextFsGroup       = "1724"
 	DefaultSecurityContextRunAsUser     = "1724"
 )
+
+func DefaultPullPolicyFromDockerImage(dockerImage string) string {
+	tag := "latest"
+	parts := strings.Split(dockerImage, ":")
+	if len(parts) > 1 {
+		tag = parts[1]
+	}
+	if tag == "latest" || tag == "nightly" {
+		return "Always"
+	}
+	return "IfNotPresent"
+}

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -17,6 +17,8 @@ const (
 	DefaultCodeReadyServerImageRepo     = "registry.redhat.io/codeready-workspaces/server-rhel8"
 	DefaultCheServerImageTag            = "7.0.0-RC-2.0"
 	DefaultCodeReadyServerImageTag      = "1.2"
+	DefaultCheServerPullPolicy          = "Always"
+	DefaultCodeReadyServerPullPolicy    = "IfNotPresent"
 	DefaultCheFlavor                    = "che"
 	DefaultChePostgresUser              = "pgche"
 	DefaultChePostgresHostName          = "postgres"
@@ -42,8 +44,11 @@ const (
 	DefaultPvcJobsUpstreamImage         = "registry.access.redhat.com/ubi8-minimal:8.0-127"
 	DefaultPostgresImage                = "registry.redhat.io/rhscl/postgresql-96-rhel7:1-40"
 	DefaultPostgresUpstreamImage        = "centos/postgresql-96-centos7:9.6"
+	DefaultPostgresPullPolicy           = "IfNotPresent"
 	DefaultKeycloakImage                = "registry.redhat.io/redhat-sso-7/sso73-openshift:1.0-11"
 	DefaultKeycloakUpstreamImage        = "eclipse/che-keycloak:7.0.0-RC-2.0"
+	DefaultKeycloakPullPolicy           = "IfNotPresent"
+	DefaultKeycloakUpstreamPullPolicy   = "Always"
 	DefaultJavaOpts                     = "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 " +
 		"-XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 " +
 		"-XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap " +

--- a/pkg/deploy/deployment_che.go
+++ b/pkg/deploy/deployment_che.go
@@ -47,6 +47,12 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 		}
 	}
 	memLimit := util.GetValue(cr.Spec.Server.ServerMemoryLimit, DefaultServerMemoryLimit)
+	defaultPullPolicy := DefaultCheServerPullPolicy
+	if cheFlavor == "codeready" {
+		defaultPullPolicy = DefaultCodeReadyServerPullPolicy
+	}
+	pullPolicy := corev1.PullPolicy(util.GetValue(string(cr.Spec.Server.CheImagePullPolicy), defaultPullPolicy))
+
 	cheDeployment := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -71,7 +77,7 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 					Containers: []corev1.Container{
 						{
 							Name:            cheFlavor,
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							ImagePullPolicy: pullPolicy,
 							Image:           cheImage + ":" + cheTag,
 							Ports: []corev1.ContainerPort{
 								{

--- a/pkg/deploy/deployment_che.go
+++ b/pkg/deploy/deployment_che.go
@@ -26,6 +26,7 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 	labels := GetLabels(cr, util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor))
 	optionalEnv := true
 	cheFlavor := util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor)
+	cheImageAndTag := cheImage + ":" + cheTag
 	memRequest := util.GetValue(cr.Spec.Server.ServerMemoryRequest, DefaultServerMemoryRequest)
 	selfSignedCertEnv := corev1.EnvVar{
 		Name: "CHE_SELF__SIGNED__CERT",
@@ -47,11 +48,7 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 		}
 	}
 	memLimit := util.GetValue(cr.Spec.Server.ServerMemoryLimit, DefaultServerMemoryLimit)
-	defaultPullPolicy := DefaultCheServerPullPolicy
-	if cheFlavor == "codeready" {
-		defaultPullPolicy = DefaultCodeReadyServerPullPolicy
-	}
-	pullPolicy := corev1.PullPolicy(util.GetValue(string(cr.Spec.Server.CheImagePullPolicy), defaultPullPolicy))
+	pullPolicy := corev1.PullPolicy(util.GetValue(string(cr.Spec.Server.CheImagePullPolicy), DefaultPullPolicyFromDockerImage(cheImageAndTag)))
 
 	cheDeployment := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -78,7 +75,7 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 						{
 							Name:            cheFlavor,
 							ImagePullPolicy: pullPolicy,
-							Image:           cheImage + ":" + cheTag,
+							Image:           cheImageAndTag,
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "http",

--- a/pkg/deploy/deployment_keycloak.go
+++ b/pkg/deploy/deployment_keycloak.go
@@ -26,6 +26,11 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 	keycloakName := "keycloak"
 	labels := GetLabels(cr, keycloakName)
 	keycloakImage := util.GetValue(cr.Spec.Auth.KeycloakImage, DefaultKeycloakImage)
+	defaultPullPolicy := DefaultKeycloakUpstreamPullPolicy
+	if cheFlavor == "codeready" {
+		defaultPullPolicy = DefaultKeycloakPullPolicy
+	}
+	pullPolicy := corev1.PullPolicy(util.GetValue(string(cr.Spec.Auth.KeycloakImagePullPolicy), defaultPullPolicy))
 	trustpass := util.GeneratePasswd(12)
 	jbossDir := "/opt/eap"
 	if cheFlavor == "che" {
@@ -246,7 +251,7 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 						{
 							Name:            keycloakName,
 							Image:           keycloakImage,
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							ImagePullPolicy: pullPolicy,
 							Command: []string{
 								"/bin/sh",
 							},

--- a/pkg/deploy/deployment_keycloak.go
+++ b/pkg/deploy/deployment_keycloak.go
@@ -26,11 +26,7 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 	keycloakName := "keycloak"
 	labels := GetLabels(cr, keycloakName)
 	keycloakImage := util.GetValue(cr.Spec.Auth.KeycloakImage, DefaultKeycloakImage)
-	defaultPullPolicy := DefaultKeycloakUpstreamPullPolicy
-	if cheFlavor == "codeready" {
-		defaultPullPolicy = DefaultKeycloakPullPolicy
-	}
-	pullPolicy := corev1.PullPolicy(util.GetValue(string(cr.Spec.Auth.KeycloakImagePullPolicy), defaultPullPolicy))
+	pullPolicy := corev1.PullPolicy(util.GetValue(string(cr.Spec.Auth.KeycloakImagePullPolicy), DefaultPullPolicyFromDockerImage(keycloakImage)))
 	trustpass := util.GeneratePasswd(12)
 	jbossDir := "/opt/eap"
 	if cheFlavor == "che" {

--- a/pkg/deploy/deployment_postgres.go
+++ b/pkg/deploy/deployment_postgres.go
@@ -25,6 +25,9 @@ func NewPostgresDeployment(cr *orgv1.CheCluster, chePostgresPassword string, isO
 	chePostgresDb := util.GetValue(cr.Spec.Database.ChePostgresDb, "dbche")
 	postgresAdminPassword := util.GeneratePasswd(12)
 	postgresImage := util.GetValue(cr.Spec.Database.PostgresImage, DefaultPostgresImage)
+	defaultPullPolicy := DefaultPostgresPullPolicy
+	pullPolicy := corev1.PullPolicy(util.GetValue(string(cr.Spec.Database.PostgresImagePullPolicy), defaultPullPolicy))
+
 	name := "postgres"
 	labels := GetLabels(cr, name)
 	deployment := appsv1.Deployment{
@@ -61,7 +64,7 @@ func NewPostgresDeployment(cr *orgv1.CheCluster, chePostgresPassword string, isO
 						{
 							Name:            name,
 							Image:           postgresImage,
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							ImagePullPolicy: pullPolicy,
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          name,

--- a/pkg/deploy/deployment_postgres.go
+++ b/pkg/deploy/deployment_postgres.go
@@ -25,8 +25,7 @@ func NewPostgresDeployment(cr *orgv1.CheCluster, chePostgresPassword string, isO
 	chePostgresDb := util.GetValue(cr.Spec.Database.ChePostgresDb, "dbche")
 	postgresAdminPassword := util.GeneratePasswd(12)
 	postgresImage := util.GetValue(cr.Spec.Database.PostgresImage, DefaultPostgresImage)
-	defaultPullPolicy := DefaultPostgresPullPolicy
-	pullPolicy := corev1.PullPolicy(util.GetValue(string(cr.Spec.Database.PostgresImagePullPolicy), defaultPullPolicy))
+	pullPolicy := corev1.PullPolicy(util.GetValue(string(cr.Spec.Database.PostgresImagePullPolicy), DefaultPullPolicyFromDockerImage(postgresImage)))
 
 	name := "postgres"
 	labels := GetLabels(cr, name)


### PR DESCRIPTION
Currently, the pull policy for the Che, Keycloak and Postgres containers is fixed and set at `IfNotPresent`.
Obviously this make the use of the `nightly` operator (and nightly Che components) useless.

This PR:
- adds fields in the `CheCluster` custom resource to drive the image pull policy of the various Che components (Che, Keycloak, etc...)
- If those fields are not set (or set to empty string) then a default pull policy is applied according to the following rule:
  - use `Always` if the related docker image tag is `latest` or `nightly`
  - use `IfNotPresent` in other cases

Please consider this PR as a followup of issue https://github.com/eclipse/che/issues/13780 that was part of endgame plan.