### PR TITLE
remove DefaultCodereadyPluginRegistryUrl...

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -46,8 +46,6 @@ spec:
     proxyPassword: ''
     # a list of non-proxy hosts. Use | as delimiter, eg localhost|my.host.com|123.42.12.32
     nonProxyHosts: ''
-    # an endpoint serving plugin definitions. Defaults to https://che-plugin-registry.openshift.io
-    pluginRegistryUrl: ''
     # sets mem request for server deployment. Defaults to 512Mi
     serverMemoryRequest: ''
     # sets mem limit for server deployment. Defaults to 1Gi

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -51,7 +51,7 @@ type CheClusterSpecServer struct {
 	SelfSignedCert bool `json:"selfSignedCert"`
 	// TlsSupport instructs an operator to deploy Che in TLS mode, ie with TLS routes or ingresses
 	TlsSupport bool `json:"tlsSupport"`
-	// DevfileRegistryUrl is an endpoint serving sample ready-to-use devfiles. Defaults to https://che-devfile-registry.openshift.io
+	// DevfileRegistryUrl is an endpoint serving sample ready-to-use devfiles. Defaults to generated route
 	DevfileRegistryUrl string `json:"devfileRegistryUrl"`
 	// DevfileRegistryImage is image:tag used in Devfile registry deployment
 	DevfileRegistryImage string `json:"devfileRegistryImage"`
@@ -65,7 +65,7 @@ type CheClusterSpecServer struct {
 	// By default a dedicated devfile registry server is started.
 	// But if ExternalDevfileRegistry is `true`, then no such dedicated server will be started by the operator
 	ExternalDevfileRegistry bool `json:"externalDevfileRegistry"`
-	// PluginRegistryUrl is an endpoint serving plugin definitions. Defaults to https://che-plugin-registry.openshift.io
+	// PluginRegistryUrl is an endpoint serving plugin definitions. Defaults to generated route
 	PluginRegistryUrl string `json:"pluginRegistryUrl"`
 	// PluginRegistryImage is image:tag used in Plugin registry deployment
 	PluginRegistryImage string `json:"pluginRegistryImage"`

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -158,9 +158,6 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	ingressClass := util.GetValue(cr.Spec.K8SOnly.IngressClass, DefaultIngressClass)
 	devfileRegistryUrl := cr.Status.DevfileRegistryURL
 	pluginRegistryUrl := cr.Status.PluginRegistryURL
-	if pluginRegistryUrl == "" && cheFlavor == "codeready" {
-		pluginRegistryUrl = DefaultCodereadyPluginRegistryUrl
-	}
 	cheLogLevel := util.GetValue(cr.Spec.Server.CheLogLevel, DefaultCheLogLevel)
 	cheDebug := util.GetValue(cr.Spec.Server.CheDebug, DefaultCheDebug)
 

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -30,7 +30,6 @@ const (
 	DefaultPluginRegistryPullPolicy     = "Always"
 	DefaultPluginRegistryMemoryLimit    = "32Mi"
 	DefaultPluginRegistryMemoryRequest  = "16Mi"
-	DefaultCodereadyPluginRegistryUrl   = "https://che-plugin-registry.openshift.io"
 	DefaultDevfileRegistryImage         = "quay.io/eclipse/che-devfile-registry:7.0.0-RC-2.0"
 	DefaultDevfileRegistryPullPolicy    = "Always"
 	DefaultDevfileRegistryMemoryLimit   = "32Mi"


### PR DESCRIPTION
remove `DefaultCodereadyPluginRegistryUrl` from pkg/deploy/defaults.go and `pluginRegistryUrl` from deploy/crds/org_v1_che_cr.yaml as these are no longer used/needed

Change-Id: I8bf17e40d7ed55c30fe28f640614fe6202cf66a5
Signed-off-by: nickboldt <nboldt@redhat.com>