### PR TITLE
Reintegrate the `7.0.0 rc 4.0` release branch to master

### DIFF
--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.0.0-rc-4.0/eclipse-che-preview-kubernetes.crd.yaml
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.0.0-rc-4.0/eclipse-che-preview-kubernetes.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: checlusters.org.eclipse.che
+spec:
+  group: org.eclipse.che
+  names:
+    kind: CheCluster
+    listKind: CheClusterList
+    plural: checlusters
+    singular: checluster
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}

--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.0.0-rc-4.0/eclipse-che-preview-kubernetes.v7.0.0-rc-4.0.clusterserviceversion.yaml
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.0.0-rc-4.0/eclipse-che-preview-kubernetes.v7.0.0-rc-4.0.clusterserviceversion.yaml
@@ -16,9 +16,9 @@ metadata:
                 "tlsSecretName": ""
               },
              "server": {
-                "cheImageTag": "nightly",
-                "devfileRegistryImage": "quay.io/eclipse/che-devfile-registry:nightly",
-                "pluginRegistryImage": "quay.io/eclipse/che-plugin-registry:nightly",
+                "cheImageTag": "",
+                "devfileRegistryImage": "",
+                "pluginRegistryImage": "",
                 "tlsSupport": false,
                 "selfSignedCert": false
              },
@@ -31,7 +31,7 @@ metadata:
                 "chePostgresDb": ""
              },
              "auth": {
-                "identityProviderImage": "eclipse/che-keycloak:nightly",
+                "identityProviderImage": "",
                 "externalIdentityProvider": false,
                 "identityProviderURL": "",
                 "identityProviderRealm": "",
@@ -48,13 +48,13 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools
     certified: "false"
-    containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2019-07-23T12:03:26Z"
+    containerImage: quay.io/eclipse/che-operator:7.0.0-rc-4.0
+    createdAt: "2019-07-25T17:20:26Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     repository: https://github.com/eclipse/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v9.9.9-nightly.1563883405
+  name: eclipse-che-preview-kubernetes.v7.0.0-rc-4.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -220,8 +220,8 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: che-operator
-                image: quay.io/eclipse/che-operator:nightly
-                imagePullPolicy: Always
+                image: quay.io/eclipse/che-operator:7.0.0-rc-4.0
+                imagePullPolicy: IfNotPresent
                 name: che-operator
                 ports:
                 - containerPort: 60000
@@ -323,5 +323,5 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  replaces: eclipse-che-preview-kubernetes.v9.9.9-nightly.1563804656
-  version: 9.9.9-nightly.1563883405
+  replaces: eclipse-che-preview-kubernetes.v7.0.0-rc-2.0
+  version: 7.0.0-rc-4.0

--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/eclipse-che-preview-kubernetes.package.yaml
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/eclipse-che-preview-kubernetes.package.yaml
@@ -1,7 +1,7 @@
 packageName: eclipse-che-preview-kubernetes
 channels:
 - name: stable
-  currentCSV: eclipse-che-preview-kubernetes.v7.0.0-rc-2.0
+  currentCSV: eclipse-che-preview-kubernetes.v7.0.0-rc-4.0
 - name: nightly
   currentCSV: eclipse-che-preview-kubernetes.v9.9.9-nightly.1563883405
 defaultChannel: stable

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.0.0-rc-4.0/eclipse-che-preview-openshift.crd.yaml
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.0.0-rc-4.0/eclipse-che-preview-openshift.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: checlusters.org.eclipse.che
+spec:
+  group: org.eclipse.che
+  names:
+    kind: CheCluster
+    listKind: CheClusterList
+    plural: checlusters
+    singular: checluster
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.0.0-rc-4.0/eclipse-che-preview-openshift.v7.0.0-rc-4.0.clusterserviceversion.yaml
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.0.0-rc-4.0/eclipse-che-preview-openshift.v7.0.0-rc-4.0.clusterserviceversion.yaml
@@ -11,14 +11,10 @@ metadata:
              "name": "eclipse-che"
           },
           "spec": {
-            "k8s": {
-                "ingressDomain": "",
-                "tlsSecretName": ""
-              },
              "server": {
-                "cheImageTag": "nightly",
-                "devfileRegistryImage": "quay.io/eclipse/che-devfile-registry:nightly",
-                "pluginRegistryImage": "quay.io/eclipse/che-plugin-registry:nightly",
+                "cheImageTag": "",
+                "devfileRegistryImage": "",
+                "pluginRegistryImage": "",
                 "tlsSupport": false,
                 "selfSignedCert": false
              },
@@ -31,7 +27,8 @@ metadata:
                 "chePostgresDb": ""
              },
              "auth": {
-                "identityProviderImage": "eclipse/che-keycloak:nightly",
+                "openShiftoAuth": true,
+                "identityProviderImage": "",
                 "externalIdentityProvider": false,
                 "identityProviderURL": "",
                 "identityProviderRealm": "",
@@ -46,15 +43,15 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    categories: Developer Tools
+    categories: Developer Tools, OpenShift Optional
     certified: "false"
-    containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2019-07-23T12:03:26Z"
+    containerImage: quay.io/eclipse/che-operator:7.0.0-rc-4.0
+    createdAt: "2019-07-25T17:20:27Z"
     description: A Kube-native development solution that delivers portable and collaborative
-      developer workspaces.
+      developer workspaces in OpenShift.
     repository: https://github.com/eclipse/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v9.9.9-nightly.1563883405
+  name: eclipse-che-preview-openshift.v7.0.0-rc-4.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -65,18 +62,23 @@ spec:
       kind: CheCluster
       name: checlusters.org.eclipse.che
       specDescriptors:
+      - description: Log in to Eclipse Che with OpenShift credentials
+        displayName: OpenShift oAuth
+        path: auth.openShiftoAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: TLS routes
         displayName: TLS Mode
         path: server.tlsSupport
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       statusDescriptors:
-      - description: Ingress to access Eclipse Che
+      - description: Route to access Eclipse Che
         displayName: Eclipse Che URL
         path: cheURL
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
-      - description: Ingress to access Keycloak Admin Console
+      - description: Route to access Keycloak Admin Console
         displayName: Keycloak Admin Console URL
         path: keycloakURL
         x-descriptors:
@@ -93,16 +95,15 @@ spec:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1
   description: |
-    A collaborative Kubernetes-native development solution that delivers Kubernetes workspaces and in-browser IDE for rapid cloud application development.
+    A collaborative Kubernetes-native development solution that delivers OpenShift workspaces and in-browser IDE for rapid cloud application development.
     This operator installs PostgreSQL, Keycloak, and the Eclipse Che server, as well as configures all three services.
 
     ## How to Install
 
-    When the operator is installed (ie you have created a subscription and there us operaotr deployment), create a new CR of Kind CheCluster (click the **Create New** button).
+    Press the **Install** button, choose the upgrade strategy, and wait for the **Installed** Operator status.
+
+    When the operator is installed, create a new CR of Kind CheCluster (click the **Create New** button).
     The CR spec contains all defaults (see below).
-
-
-    **Important!** Make sure you provide **ingressDomain** which is a global ingress domain of your k8s cluster, for example, mycluster.com, 172.234.433.23.nip.io.
 
     You can start using Eclipse Che when the CR status is set to **Available**, and you see a URL to Eclipse Che.
 
@@ -116,7 +117,9 @@ spec:
 
     * Auto-generated passwords
 
-    * HTTP mode (non-secure ingresses)
+    * HTTP mode (non-secure routes)
+
+    * Regular login extended with OpenShift OAuth authentication
 
     ## Installation Options
 
@@ -142,28 +145,34 @@ spec:
 
 
 
-      ```
-      externalDb: true
+      `externalDb: true`
 
-      chePostgresHostname: 'yourPostgresHost'
 
-      chePostgresPort: '5432'
+      `chePostgresHostname: 'yourPostgresHost'`
 
-      chePostgresUser: 'myuser'
 
-      chePostgresPassword: 'mypass'
+      `chePostgresPort: '5432'`
 
-      chePostgresDb: 'mydb'
 
-      externalIdentityProvider: true
+      `chePostgresUser: 'myuser'`
 
-      identityProviderURL: 'https://my-keycloak.com'
 
-      identityProviderRealm: 'myrealm'
+      `chePostgresPassword: 'mypass'`
 
-      identityProviderClientId: 'myClient'
 
-      ```
+      `chePostgresDb: 'mydb'`
+
+
+      `externalIdentityProvider: true`
+
+
+      `identityProviderURL: 'https://my-keycloak.com'`
+
+
+      `identityProviderRealm: 'myrealm'`
+
+
+      `identityProviderClientId: 'myClient'`
 
 
     ### TLS Mode
@@ -171,21 +180,26 @@ spec:
     To activate TLS mode, set the respective field in the CR spec to `true` (in the `server` block):
 
 
-
     ```
-
     tlsSupport: true
-
     ```
 
-    You will also need to provide name of tls secret that will be used for Eclipse Che and workspaces ingresses:
+    #### Self-signed Certificates
+
+    To use Eclipse Che with TLS enabled, but the OpenShift router does not use certificates signed by a public authority, you can use self-signed certificates, which the operator can fetch for you:
+
+
+    ```
+    selfSignedCert: true
+    ```
+
+
+    You can also manually create a secret:
 
 
 
     ```
-
-    tlsSecretName: 'my-ingress-tls-secret'
-
+    oc create secret self-signed-certificate generic --from-file=/path/to/certificate/ca.crt -n=$codeReadyNamespace
     ```
   displayName: Eclipse Che
   icon:
@@ -193,6 +207,27 @@ spec:
     mediatype: image/png
   install:
     spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - get
+          - delete
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          verbs:
+          - get
+        serviceAccountName: che-operator
       deployments:
       - name: che-operator
         spec:
@@ -220,8 +255,8 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: che-operator
-                image: quay.io/eclipse/che-operator:nightly
-                imagePullPolicy: Always
+                image: quay.io/eclipse/che-operator:7.0.0-rc-4.0
+                imagePullPolicy: IfNotPresent
                 name: che-operator
                 ports:
                 - containerPort: 60000
@@ -236,6 +271,12 @@ spec:
           - extensions
           resources:
           - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
           verbs:
           - '*'
         - apiGroups:
@@ -304,7 +345,6 @@ spec:
   - supported: false
     type: AllNamespaces
   keywords:
-  - eclipse che
   - workspaces
   - devtools
   - developer
@@ -323,5 +363,5 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  replaces: eclipse-che-preview-kubernetes.v9.9.9-nightly.1563804656
-  version: 9.9.9-nightly.1563883405
+  replaces: eclipse-che-preview-openshift.v7.0.0-rc-2.0
+  version: 7.0.0-rc-4.0

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/eclipse-che-preview-openshift.package.yaml
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/eclipse-che-preview-openshift.package.yaml
@@ -1,7 +1,7 @@
 packageName: eclipse-che-preview-openshift
 channels:
 - name: stable
-  currentCSV: eclipse-che-preview-openshift.v7.0.0-rc-2.0
+  currentCSV: eclipse-che-preview-openshift.v7.0.0-rc-4.0
 - name: nightly
   currentCSV: eclipse-che-preview-openshift.v9.9.9-nightly.1563883406
 defaultChannel: stable

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -15,7 +15,7 @@ package deploy
 const (
 	DefaultCheServerImageRepo           = "eclipse/che-server"
 	DefaultCodeReadyServerImageRepo     = "registry.redhat.io/codeready-workspaces/server-rhel8"
-	DefaultCheServerImageTag            = "7.0.0-RC-2.0"
+	DefaultCheServerImageTag            = "7.0.0-rc-4.0"
 	DefaultCodeReadyServerImageTag      = "1.2"
 	DefaultCheFlavor                    = "che"
 	DefaultChePostgresUser              = "pgche"
@@ -26,12 +26,12 @@ const (
 	DefaultPvcClaimSize                 = "1Gi"
 	DefaultIngressStrategy              = "multi-host"
 	DefaultIngressClass                 = "nginx"
-	DefaultPluginRegistryImage          = "quay.io/eclipse/che-plugin-registry:7.0.0-RC-2.0"
+	DefaultPluginRegistryImage          = "quay.io/eclipse/che-plugin-registry:7.0.0-rc-4.0"
 	DefaultPluginRegistryPullPolicy     = "Always"
 	DefaultPluginRegistryMemoryLimit    = "32Mi"
 	DefaultPluginRegistryMemoryRequest  = "16Mi"
 	DefaultCodereadyPluginRegistryUrl   = "https://che-plugin-registry.openshift.io"
-	DefaultDevfileRegistryImage         = "quay.io/eclipse/che-devfile-registry:7.0.0-RC-2.0"
+	DefaultDevfileRegistryImage         = "quay.io/eclipse/che-devfile-registry:7.0.0-rc-4.0"
 	DefaultDevfileRegistryPullPolicy    = "Always"
 	DefaultDevfileRegistryMemoryLimit   = "32Mi"
 	DefaultDevfileRegistryMemoryRequest = "16Mi"
@@ -43,7 +43,7 @@ const (
 	DefaultPostgresImage                = "registry.redhat.io/rhscl/postgresql-96-rhel7:1-40"
 	DefaultPostgresUpstreamImage        = "centos/postgresql-96-centos7:9.6"
 	DefaultKeycloakImage                = "registry.redhat.io/redhat-sso-7/sso73-openshift:1.0-11"
-	DefaultKeycloakUpstreamImage        = "eclipse/che-keycloak:7.0.0-RC-2.0"
+	DefaultKeycloakUpstreamImage        = "eclipse/che-keycloak:7.0.0-rc-4.0"
 	DefaultJavaOpts                     = "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 " +
 		"-XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 " +
 		"-XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap " +


### PR DESCRIPTION
This is required to keep the history of previous OLM package versions, as well as update the defaults in the operator Go code.