### PR TITLE
Fix release scripts after first use

### DIFF
--- a/olm/check-yq.sh
+++ b/olm/check-yq.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/olm/check-yq.sh
+++ b/olm/check-yq.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+if ! which yq &> /dev/null
+then
+  echo
+  echo "#### ERROR ####"
+  echo "####"
+  echo "#### Please install the 'yq' tool before being able to use this script"
+  echo "#### see https://github.com/kislyuk/yq"
+  echo "#### and https://stedolan.github.io/jq/download"
+  echo "####"
+  echo "###############"
+  exit 1
+fi

--- a/olm/prepare-community-operators-update.sh
+++ b/olm/prepare-community-operators-update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/olm/prepare-community-operators-update.sh
+++ b/olm/prepare-community-operators-update.sh
@@ -96,9 +96,15 @@ do
   echo "   - Pushing branch ${branch} to the 'che-incubator/community-operators' GitHub repository"
   if [ -z "${GIT_USER}" ] || [ -z "${GIT_PASSWORD}" ]
   then
+    echo
     echo "#### WARNING ####"
+    echo "####"
     echo "#### You shoud define GIT_USER and GIT_PASSWORD environment variable"
     echo "#### to be able to push release branches to the 'che-incubator/community-operators' repository"
+    echo "####"
+    echo "#### As soon as you have set them, you can push by running the following command:"
+    echo "####    cd \"${communityOperatorsLocalGitFolder}\" && git push \"https://\${GIT_USER}:\${GIT_PASSWORD}@github.com/che-incubator/community-operators.git\" \"${branch}\""
+    echo "####"
     echo "#################"
   else
     git push "https://${GIT_USER}:${GIT_PASSWORD}@github.com/che-incubator/community-operators.git" "${branch}"

--- a/olm/prepare-community-operators-update.sh
+++ b/olm/prepare-community-operators-update.sh
@@ -14,6 +14,7 @@ set -e
 
 CURRENT_DIR=$(pwd)
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)
+source ${BASE_DIR}/check-yq.sh
 
 for platform in 'kubernetes' 'openshift'
 do

--- a/olm/push-olm-files-to-quay.sh
+++ b/olm/push-olm-files-to-quay.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/olm/release-olm-files.sh
+++ b/olm/release-olm-files.sh
@@ -55,7 +55,7 @@ do
   -e 's/"cheImageTag": *"nightly"/"cheImageTag": ""/' \
   -e 's|"identityProviderImage": *"eclipse/che-keycloak:nightly"|"identityProviderImage": ""|' \
   -e 's|"devfileRegistryImage": *"quay.io/eclipse/che-devfile-registry:nightly"|"devfileRegistryImage": ""|' \
-  -e 's|"pluginRegistryImage": *"quay.io/eclipse/che-plugin-registry:nighlty"|"pluginRegistryImage": ""|' \
+  -e 's|"pluginRegistryImage": *"quay.io/eclipse/che-plugin-registry:nightly"|"pluginRegistryImage": ""|' \
   -e "/^  replaces: ${packageName}.v.*/d" \
   -e "s/^  version: ${lastPackageNightlyVersion}/  version: ${RELEASE}/" \
   -e "/^  version: ${RELEASE}/i\ \ replaces: ${packageName}.v${lastPackagePreReleaseVersion}" \

--- a/olm/release-olm-files.sh
+++ b/olm/release-olm-files.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/olm/release-olm-files.sh
+++ b/olm/release-olm-files.sh
@@ -16,6 +16,8 @@ REGEX="^([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-
 
 CURRENT_DIR=$(pwd)
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)
+source ${BASE_DIR}/check-yq.sh
+
 if [[ "$1" =~ $REGEX ]]
 then
   RELEASE="$1"

--- a/olm/update-nightly-olm-files.sh
+++ b/olm/update-nightly-olm-files.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/olm/update-nightly-olm-files.sh
+++ b/olm/update-nightly-olm-files.sh
@@ -14,6 +14,8 @@ set -e
 
 CURRENT_DIR=$(pwd)
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)
+source ${BASE_DIR}/check-yq.sh
+
 for platform in 'kubernetes' 'openshift'
 do
   packageName=eclipse-che-preview-${platform}

--- a/release-operator-code.sh
+++ b/release-operator-code.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2018 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/release-operator-code.sh
+++ b/release-operator-code.sh
@@ -30,8 +30,6 @@ cd "${BASE_DIR}"
 echo
 echo "## Creating release '${RELEASE}' of the Che operator docker image"
 
-DefaultPluginRegistryImage
-
 lastDefaultCheVersion=$(grep 'DefaultCheServerImageTag' "pkg/deploy/defaults.go" | sed -e 's/.*DefaultCheServerImageTag *= *"\([^"]*\)"/\1/')
 lastDefaultKeycloakVersion=$(grep 'DefaultKeycloakUpstreamImage' "pkg/deploy/defaults.go" | sed -e 's/.*DefaultKeycloakUpstreamImage *= *"[^":]*:\([^"]*\)"/\1/')
 lastDefaultPluginRegistryVersion=$(grep 'DefaultPluginRegistryImage' "pkg/deploy/defaults.go" | sed -e 's/.*DefaultPluginRegistryImage *= *"[^":]*:\([^"]*\)"/\1/')


### PR DESCRIPTION
This PR fixes a number of bugs / enhancements found when applying the release scripts during the `7.0.0-rc-4.0` release of Che Operator.

In brief this PR:
- Fixes a bug introduced by a weird copy paste in a script shell file
- Fixes a typo in a regular expression during the `nightly` version replacement in the OLM files releasing script
- Complete PR-preparing script in order to :
  - name the branch with the release number instead of a timestamp
  - clone from the `che-incubator` fork
  - fetch from the upstream (`operator-framework`) repo
  - create the branch starting from the upstream master
  - commit the changes
  - push the branch to the fork if user creds are provided.  