### PR TITLE
Fix typo in CheCluster CR yaml

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -29,7 +29,7 @@ spec:
     cheFlavor: ''
     # specifies a custom cluster role to user for the Che workspaces
     # Uses the default roles if left blank.
-    cheWorkspaceClusterRole: 'eclipse-codewind'
+    cheWorkspaceClusterRole: ''
     # when set to true the operator will attempt to get a secret in OpenShift router namespace
     # to add it to Java trust store of Che server. Requires cluster-admin privileges for operator service account
     selfSignedCert: false
@@ -69,7 +69,7 @@ spec:
   storage:
     # persistent volume claim strategy for Che server. Can be common (all workspaces PVCs in one volume),
     # per-workspace (one PVC per workspace for all declared volumes) and unique (one PVC per declared volume). Defaults to common
-    pvcStrategy: 'common'
+    pvcStrategy: 'per-workspace'
     # size of a persistent volume claim for workspaces. Defaults to 1Gi
     pvcClaimSize: '1Gi'
     # instruct Che server to launch a special pod to precreate a subpath in a PV

--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -23,13 +23,13 @@ spec:
     # image:tag used in Devfile registry deployment
     devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:nightly'
     # image:tag used in plugin registry deployment
-    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:nighlty'
+    pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:nightly'
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: ''
     # specifies a custom cluster role to user for the Che workspaces
     # Uses the default roles if left blank.
-    cheWorkspaceClusterRole: ''
+    cheWorkspaceClusterRole: 'eclipse-codewind'
     # when set to true the operator will attempt to get a secret in OpenShift router namespace
     # to add it to Java trust store of Che server. Requires cluster-admin privileges for operator service account
     selfSignedCert: false
@@ -69,7 +69,7 @@ spec:
   storage:
     # persistent volume claim strategy for Che server. Can be common (all workspaces PVCs in one volume),
     # per-workspace (one PVC per workspace for all declared volumes) and unique (one PVC per declared volume). Defaults to common
-    pvcStrategy: 'per-workspace'
+    pvcStrategy: 'common'
     # size of a persistent volume claim for workspaces. Defaults to 1Gi
     pvcClaimSize: '1Gi'
     # instruct Che server to launch a special pod to precreate a subpath in a PV


### PR DESCRIPTION
I noticed that the `che-plugin-registry` was failing with an ImagePullBackOff error for me. I looked into it and saw that the `pluginRegistryImage` had a slight typo in it. This PR fixes it.