### PR TITLE
Inconsistent probes prevented deploying on RHPDS

### DIFF
--- a/pkg/deploy/deployment_che.go
+++ b/pkg/deploy/deployment_che.go
@@ -112,12 +112,13 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
+								// After POD start, the POD will be declared as either ready or failed after a minimum of 60 seconds and a maximum of 200 seconds
+								// 200 s = InitialDelaySeconds + TimeoutSeconds * FailureThreshold + PeriodSeconds * (FailureThreshold - 1)
 								InitialDelaySeconds: 60,
 								FailureThreshold:    10,
 								TimeoutSeconds:      5,
 								PeriodSeconds:       10,
-							},	// After POD start, the POD will be declared as either ready or failed after a minimum of 60 seconds and a maximum of 200 seconds
-									// 200 s = InitialDelaySeconds + TimeoutSeconds * FailureThreshold + PeriodSeconds * (FailureThreshold - 1)
+							},
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -129,7 +130,8 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
-								InitialDelaySeconds: 200, // After POD start, don't initiate liveness probe before the POD has been declared ready or failed by the readiness probe
+								// After POD start, don't initiate liveness probe before the POD has been declared ready or failed by the readiness probe
+								InitialDelaySeconds: 200,
 								FailureThreshold:    3,
 								TimeoutSeconds:      3,
 								PeriodSeconds:       10,

--- a/pkg/deploy/deployment_che.go
+++ b/pkg/deploy/deployment_che.go
@@ -112,10 +112,10 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
-								// After POD start, the POD will be declared as either ready or failed after a minimum of 60 seconds and a maximum of 200 seconds
-								// 200 s = InitialDelaySeconds + TimeoutSeconds * FailureThreshold + PeriodSeconds * (FailureThreshold - 1)
-								InitialDelaySeconds: 60,
-								FailureThreshold:    10,
+								// After POD start, the POD will be seen as ready after a minimum of 15 seconds and we expect it to be seen as ready until a maximum of 200 seconds
+								// 200 s = InitialDelaySeconds + PeriodSeconds * (FailureThreshold - 1) + TimeoutSeconds
+								InitialDelaySeconds: 25,
+								FailureThreshold:    18,
 								TimeoutSeconds:      5,
 								PeriodSeconds:       10,
 							},
@@ -130,7 +130,7 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
-								// After POD start, don't initiate liveness probe before the POD has been declared ready or failed by the readiness probe
+								// After POD start, don't initiate liveness probe while the POD is still expected to be declared as ready by the readiness probe
 								InitialDelaySeconds: 200,
 								FailureThreshold:    3,
 								TimeoutSeconds:      3,

--- a/pkg/deploy/deployment_che.go
+++ b/pkg/deploy/deployment_che.go
@@ -116,7 +116,8 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 								FailureThreshold:    10,
 								TimeoutSeconds:      5,
 								PeriodSeconds:       10,
-							}, // Will stop testing readiness after a minimum of 65 seconds and a maximum of 200 seconds (60 + 10*5 + 9*10)
+							},	// After POD start, the POD will be declared as either ready or failed after a minimum of 60 seconds and a maximum of 200 seconds
+									// 200 s = InitialDelaySeconds + TimeoutSeconds * FailureThreshold + PeriodSeconds * (FailureThreshold - 1)
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -128,7 +129,7 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
-								InitialDelaySeconds: 200, // Start liveness probe after readiness probe has finished
+								InitialDelaySeconds: 200, // After POD start, don't initiate liveness probe before the POD has been declared ready or failed by the readiness probe
 								FailureThreshold:    3,
 								TimeoutSeconds:      3,
 								PeriodSeconds:       10,

--- a/pkg/deploy/deployment_che.go
+++ b/pkg/deploy/deployment_che.go
@@ -112,10 +112,11 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
-								InitialDelaySeconds: 25,
-								FailureThreshold:    5,
+								InitialDelaySeconds: 60,
+								FailureThreshold:    10,
 								TimeoutSeconds:      5,
-							},
+								PeriodSeconds:       10,
+							}, // Will stop testing readiness after a minimum of 65 seconds and a maximum of 200 seconds (60 + 10*5 + 9*10)
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -127,9 +128,10 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
-								InitialDelaySeconds: 50,
+								InitialDelaySeconds: 200, // Start liveness probe after readiness probe has finished
 								FailureThreshold:    3,
 								TimeoutSeconds:      3,
+								PeriodSeconds:       10,
 							},
 							EnvFrom: []corev1.EnvFromSource{
 								{


### PR DESCRIPTION
This PR aims at fixing an inconsistency in Che deployment readiness and liveness probes that used to prevent correct Che deployment on RHPDS Openshift 4 clusters.

The root cause was that Che start was quite long, and liveness probe was expired before the expiration of the readiness probe, which cause the Che POD to be constantly restarted.

@slemeur Did you have created an issue for your initial problem ? We could link it to the PR, and add it for triage to include it in 7.0.0 if you think it is critical.
