### PR TITLE
Directly login through the `openshift` provider when OpenShift OAut is enabled

### DIFF
--- a/pkg/controller/che/create.go
+++ b/pkg/controller/che/create.go
@@ -296,7 +296,11 @@ func (r *ReconcileChe) CreateIdentityProviderItems(instance *orgv1.CheCluster, r
 	}
 
 	if !tests {
-		openShiftIdentityProviderCommand := deploy.GetOpenShiftIdentityProviderProvisionCommand(instance, oAuthClientName, oauthSecret, keycloakAdminPassword, isOpenShift4)
+		openShiftIdentityProviderCommand, err := deploy.GetOpenShiftIdentityProviderProvisionCommand(instance, oAuthClientName, oauthSecret, keycloakAdminPassword, isOpenShift4)
+		if err != nil {
+			logrus.Errorf("Failed to build identity provider provisioning command")
+			return err
+		}
 		podToExec, err := k8sclient.GetDeploymentPod(keycloakDeploymentName, instance.Namespace)
 		if err != nil {
 			logrus.Errorf("Failed to retrieve pod name. Further exec will fail")


### PR DESCRIPTION
This PR is the implementation of issue https://github.com/eclipse/che/issues/14012

When the Openshift OAuth is configured, it configure the Keycloak server so that it directly uses the OpenShift login page when connecting to Che. 