### PR TITLE
backport from master:...

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -22,6 +22,8 @@ rules:
       - get
       - delete
       - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - config.openshift.io


### PR DESCRIPTION
backport from master: https://github.com/eclipse/che-operator/pull/45 eclipse/che#13780 - subset: just update deploy/cluster_role.yaml with 2 new verbs update and patch

Change-Id: I1a51e11be9259e29f4eb4ccdcdcd950601e82c3b
Signed-off-by: nickboldt <nboldt@redhat.com>