### PR TITLE
Don't hard-code the `che` realm !

### DIFF
--- a/deploy/keycloak_provision
+++ b/deploy/keycloak_provision
@@ -32,5 +32,5 @@ if [ $? -eq 0 ]; then echo "Realm exists"; exit 0; fi \
                                         --uusername admin \
                                         --cclientid broker \
                                         --rolename read-token \
-&& CLIENT_ID=$($script get clients -r che -q clientId=broker | sed -n 's/.*"id" *: *"\([^"]\+\).*/\1/p') \
-&& $script update clients/$CLIENT_ID -r che -s "defaultRoles+=read-token"
+&& CLIENT_ID=$($script get clients -r '$keycloakRealm' -q clientId=broker | sed -n 's/.*"id" *: *"\([^"]\+\).*/\1/p') \
+&& $script update clients/$CLIENT_ID -r '$keycloakRealm' -s "defaultRoles+=read-token"


### PR DESCRIPTION
The addition of the `read-token` permission by default, that had been cherry-picked recently from the master branch, had the `che` realm hard-coded, instead of using a configurable realm according to the custom resource Che flavor. And it prevents the CRW server to start correctly.

This PR is fixing this and should unblock issue https://github.com/redhat-developer/codeready-workspaces-deprecated/pull/44#issuecomment-529869654