### PR TITLE
Enable token exchange

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ LABEL summary="$SUMMARY" \
 
 COPY --from=builder /tmp/che-operator/che-operator /usr/local/bin/che-operator
 COPY --from=builder /go/src/github.com/eclipse/che-operator/deploy/keycloak_provision /tmp/keycloak_provision
+COPY --from=builder /go/src/github.com/eclipse/che-operator/deploy/oauth_provision /tmp/oauth_provision
 # apply CVE fixes, if required
 # RUN microdnf update -y bash vim-minimal pango && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 CMD ["che-operator"]

--- a/README.md
+++ b/README.md
@@ -100,15 +100,16 @@ You can set it in Run configuration in the IDE, or export this env before execut
 
 This applies both to Run and Debug.
 
-### Pre-Reqs: /tmp/keycloak_provision file
+### Pre-Reqs: /tmp/keycloak_provision and oauth_provision files
 
-The operator grabs this file and replaces values to get a string used as exec command to create Keycloak realm, client and user.
+The operator grabs these files and replaces values to get a string used as exec command to configure Keycloak.
 Make sure you run the following before running/debugging:
 
 ```
 cp deploy/keycloak_provision /tmp/keycloak_provision
+cp deploy/oauth_provision /tmp/oauth_provision
 ```
-This file is added to a Docker image, thus this step isn't required when deploying an operator image.
+These files are added to a Docker image, thus this step isn't required when deploying an operator image.
 
 ## E2E Tests
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This applies both to Run and Debug.
 
 ### Pre-Reqs: /tmp/keycloak_provision and oauth_provision files
 
-The operator grabs these files and replaces values to get a string used as exec command to configure Keycloak.
+The Operator takes these files and replaces values to get a string used as the `exec` command to configure Keycloak.
 Make sure you run the following before running/debugging:
 
 ```

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Make sure you run the following before running/debugging:
 cp deploy/keycloak_provision /tmp/keycloak_provision
 cp deploy/oauth_provision /tmp/oauth_provision
 ```
-These files are added to a Docker image, thus this step isn't required when deploying an operator image.
+These files are added to a container image, and thus this step is not required when deploying an Operator image.
 
 ## E2E Tests
 

--- a/deploy/oauth_provision
+++ b/deploy/oauth_provision
@@ -43,20 +43,20 @@ enable_openshift_token-exchange() {
     echo "token exchange permissions not found"
     return 1
   fi
-  TOKEN_EXCHANGE_RESOURCE=$(echo ${TOKEN_EXCHANGE_PERMISSIONS} | jq --raw-output '.resource')
-  TOKEN_EXCHANGE_PERMISSION_ID=$(echo ${TOKEN_EXCHANGE_PERMISSIONS} | jq --raw-output '.scopePermissions["token-exchange"]')
+  TOKEN_EXCHANGE_RESOURCE=$(echo ${TOKEN_EXCHANGE_PERMISSIONS} | jq --raw-output '.resource | strings')
+  TOKEN_EXCHANGE_PERMISSION_ID=$(echo ${TOKEN_EXCHANGE_PERMISSIONS} | jq --raw-output '.scopePermissions["token-exchange"] | strings')
   if [ "${TOKEN_EXCHANGE_RESOURCE}" == "" ] || [ "${TOKEN_EXCHANGE_PERMISSION_ID}" == "" ]
   then
     echo "token exchange permissions do not contain expected values"
     return 1
   fi
-  REALM_MGMT_CLIENT_ID=$({{ .Script }} get -r {{ .KeycloakRealm }} clients | jq --raw-output '.[] | select(.clientId == "realm-management") | .id')
+  REALM_MGMT_CLIENT_ID=$({{ .Script }} get -r {{ .KeycloakRealm }} clients | jq --raw-output '.[] | select(.clientId == "realm-management") | .id | strings')
   if [ "${REALM_MGMT_CLIENT_ID}" == "" ]
   then
     echo "Realm management client ID not found"
     return 1
   fi
-  EXISTING_POLICY=$({{ .Script }} get -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/policy/client -q 'name={{ .ProviderId }}')
+  EXISTING_POLICY=$({{ .Script }} get -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/policy/client -q 'name={{ .ProviderId }}' | jq --raw-output '.[0].id | strings')
   if [ "${EXISTING_POLICY}" == "" ]
   then
     echo '{"type":"client","logic":"POSITIVE","decisionStrategy":"UNANIMOUS","name":"{{ .ProviderId }}","clients":["che-public"]}' | {{ .Script }} create -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/policy/client -f -
@@ -66,19 +66,19 @@ enable_openshift_token-exchange() {
       return 1
     fi
   fi
-  TOKEN_EXCHANGE_POLICY=$({{ .Script }} get -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/policy/client -q 'name={{ .ProviderId }}' | jq --raw-output '.[0].id')
+  TOKEN_EXCHANGE_POLICY=$({{ .Script }} get -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/policy/client -q 'name={{ .ProviderId }}' | jq --raw-output '.[0].id | strings')
   if [ "${TOKEN_EXCHANGE_POLICY}" == "" ]
   then
     echo "Token exchange policy not found"
     return 1
   fi
   TOKEN_EXCHANGE_PERMISSION=$({{ .Script }} get -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/permission/scope/${TOKEN_EXCHANGE_PERMISSION_ID})
-  if [ ${TOKEN_EXCHANGE_PERMISSION} == "" ]
+  if [ "${TOKEN_EXCHANGE_PERMISSION}" == "" ]
   then
     echo "Token exchange permission not found"
     return 1
   fi
-  TOKEN_EXCHANGE_SCOPE=$({{ .Script }} get -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/resource/${TOKEN_EXCHANGE_RESOURCE}/scopes | jq --raw-output '.[] | select( .name == "token-exchange") | .id')
+  TOKEN_EXCHANGE_SCOPE=$({{ .Script }} get -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/resource/${TOKEN_EXCHANGE_RESOURCE}/scopes | jq --raw-output '.[] | select( .name == "token-exchange") | .id | strings')
   if [ "${TOKEN_EXCHANGE_PERMISSION}" == "" ]
   then
     echo "Token exchange scope not found"

--- a/deploy/oauth_provision
+++ b/deploy/oauth_provision
@@ -1,0 +1,91 @@
+connect_to_keycloak() {
+  {{ .Script }} config credentials --server http://0.0.0.0:8080/auth --realm master --user {{ .KeycloakAdminUserName }} --password {{ .KeycloakAdminPassword }}
+}
+
+create_identity_provider() {
+  {{ .Script }} get identity-provider/instances/{{ .ProviderId }} -r {{ .KeycloakRealm }}
+  if [ $? -eq 0 ]
+  then echo "Provider exists"
+  else {{ .Script }} create identity-provider/instances -r {{ .KeycloakRealm }} -s alias={{ .ProviderId }} -s providerId={{ .ProviderId }} -s enabled=true -s storeToken=true -s addReadTokenRoleOnCreate=true -s config.useJwksUrl=true -s config.clientId={{ .OAuthClientName}} -s config.clientSecret={{ .OauthSecret}} -s config.baseUrl={{ .OpenShiftApiUrl }} -s config.defaultScope=user:full
+  fi
+}
+
+default_to_openshift_login() {
+  EXECUTION_ID=$({{ .Script }} get authentication/flows/browser/executions -r {{ .KeycloakRealm }} -c | sed -e 's/.*\({[^}]\+"identity-provider-redirector"[^}]\+}\).*/\1/' -e 's/.*"id":"\([^"]\+\)".*/\1/')
+  ALIAS=$({{ .Script }} get authentication/flows/browser/executions -r {{ .KeycloakRealm }} -c | sed -e 's/.*\({[^}]\+"identity-provider-redirector"[^}]\+}\).*/\1/' | grep '"alias":"' | sed -e 's/.*"alias":"\([^"]\+\)".*/\1/')
+  if [ "${EXECUTION_ID}" == "" ]
+  then
+    echo "Could not find the identity provider redirector"
+    return 1
+  fi
+  if [ -z ${ALIAS} ];
+  then
+    echo '{"config":{"defaultProvider":"{{ .ProviderId }}"},"alias":"{{ .ProviderId }}"}' | {{ .Script }} create -r {{ .KeycloakRealm }} authentication/executions/${EXECUTION_ID}/config -f -
+  fi
+}
+
+enable_openshift_token-exchange() {
+  IDENTITY_PROVIDER_ID=$({{ .Script }} get -r {{ .KeycloakRealm }} identity-provider/instances/{{ .ProviderId }} | jq --raw-output '.internalId')
+  if [ "${IDENTITY_PROVIDER_ID}" == "" ]
+  then
+    echo "identity provider not found"
+    return 1
+  fi
+  echo '{"enabled": true}' | {{ .Script }} update -r {{ .KeycloakRealm }} identity-provider/instances/{{ .ProviderId }}/management/permissions -f -
+  if [ $? -ne 0 ]
+  then
+    echo "failed to enable permissions on identity provider"
+    return 1
+  fi
+  TOKEN_EXCHANGE_PERMISSIONS=$({{ .Script }} get -r {{ .KeycloakRealm }} identity-provider/instances/{{ .ProviderId }}/management/permissions)
+  if [ "${TOKEN_EXCHANGE_PERMISSIONS}" == "" ]
+  then
+    echo "token exchange permissions not found"
+    return 1
+  fi
+  TOKEN_EXCHANGE_RESOURCE=$(echo ${TOKEN_EXCHANGE_PERMISSIONS} | jq --raw-output '.resource')
+  TOKEN_EXCHANGE_PERMISSION_ID=$(echo ${TOKEN_EXCHANGE_PERMISSIONS} | jq --raw-output '.scopePermissions["token-exchange"]')
+  if [ "${TOKEN_EXCHANGE_RESOURCE}" == "" ] || [ "${TOKEN_EXCHANGE_PERMISSION_ID}" == "" ]
+  then
+    echo "token exchange permissions do not contain expected values"
+    return 1
+  fi
+  REALM_MGMT_CLIENT_ID=$({{ .Script }} get -r {{ .KeycloakRealm }} clients | jq --raw-output '.[] | select(.clientId == "realm-management") | .id')
+  if [ "${REALM_MGMT_CLIENT_ID}" == "" ]
+  then
+    echo "Realm management client ID not found"
+    return 1
+  fi
+  EXISTING_POLICY=$({{ .Script }} get -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/policy/client -q 'name={{ .ProviderId }}')
+  if [ "${EXISTING_POLICY}" == "" ]
+  then
+    echo '{"type":"client","logic":"POSITIVE","decisionStrategy":"UNANIMOUS","name":"{{ .ProviderId }}","clients":["che-public"]}' | {{ .Script }} create -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/policy/client -f -
+    if [ $? -ne 0 ]
+    then
+      echo "Failed to create policy"
+      return 1
+    fi
+  fi
+  TOKEN_EXCHANGE_POLICY=$({{ .Script }} get -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/policy/client -q 'name={{ .ProviderId }}' | jq --raw-output '.[0].id')
+  if [ "${TOKEN_EXCHANGE_POLICY}" == "" ]
+  then
+    echo "Token exchange policy not found"
+    return 1
+  fi
+  TOKEN_EXCHANGE_PERMISSION=$({{ .Script }} get -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/permission/scope/${TOKEN_EXCHANGE_PERMISSION_ID})
+  if [ ${TOKEN_EXCHANGE_PERMISSION} == "" ]
+  then
+    echo "Token exchange permission not found"
+    return 1
+  fi
+  TOKEN_EXCHANGE_SCOPE=$({{ .Script }} get -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/resource/${TOKEN_EXCHANGE_RESOURCE}/scopes | jq --raw-output '.[] | select( .name == "token-exchange") | .id')
+  if [ "${TOKEN_EXCHANGE_PERMISSION}" == "" ]
+  then
+    echo "Token exchange scope not found"
+    return 1
+  fi
+  echo ${TOKEN_EXCHANGE_PERMISSION} | jq --arg resource "${TOKEN_EXCHANGE_RESOURCE}" --arg scope "${TOKEN_EXCHANGE_SCOPE}" --arg policy "${TOKEN_EXCHANGE_POLICY}" '. + {resources:[$resource],scopes:[$scope],policies:[$policy]}' | {{ .Script }} update -r {{ .KeycloakRealm }} clients/${REALM_MGMT_CLIENT_ID}/authz/resource-server/permission/scope/${TOKEN_EXCHANGE_PERMISSION_ID} -f -
+}
+
+set -x
+connect_to_keycloak && create_identity_provider && default_to_openshift_login && enable_openshift_token-exchange

--- a/pkg/controller/che/create.go
+++ b/pkg/controller/che/create.go
@@ -310,11 +310,12 @@ func (r *ReconcileChe) CreateIdentityProviderItems(instance *orgv1.CheCluster, r
 		if provisioned {
 			for {
 				instance.Status.OpenShiftoAuthProvisioned = true
-				if err := r.UpdateCheCRStatus(instance, "status: provisioned with OpenShift identity provider", "true"); err != nil {
+				if err := r.UpdateCheCRStatus(instance, "status: provisioned with OpenShift identity provider", "true"); err != nil &&
+				errors.IsConflict(err) {
 					instance, _ = r.GetCR(request)
-				} else {
-					break
+					continue
 				}
+				break
 			}
 		}
 		return nil

--- a/pkg/controller/che/exec.go
+++ b/pkg/controller/che/exec.go
@@ -98,11 +98,12 @@ func (r *ReconcileChe) CreateKyecloakResources(instance *orgv1.CheCluster, reque
 		}
 		for {
 			instance.Status.KeycloakProvisoned = true
-			if err := r.UpdateCheCRStatus(instance, "status: provisioned with Keycloak", "true"); err != nil {
+			if err := r.UpdateCheCRStatus(instance, "status: provisioned with Keycloak", "true"); err != nil &&
+			errors.IsConflict(err) {
 				instance, _ = r.GetCR(request)
-			} else {
-				break
+				continue
 			}
+			break
 		}
 
 		return nil

--- a/pkg/deploy/deployment_keycloak.go
+++ b/pkg/deploy/deployment_keycloak.go
@@ -219,6 +219,8 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 	if cheFlavor == "codeready" {
 		command = addCertToTrustStoreCommand + " && " + startCommand
 	}
+	command += " -Dkeycloak.profile.feature.token_exchange=enabled -Dkeycloak.profile.feature.admin_fine_grained_authz=enabled"
+
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",

--- a/pkg/deploy/exec_commands.go
+++ b/pkg/deploy/exec_commands.go
@@ -119,6 +119,13 @@ if [ -z ${ALIAS} ]; \
 then echo '{"config":{"defaultProvider":"{{ .ProviderId }}"},"alias":"{{ .ProviderId }}"}' | {{ .Script }} create -r che authentication/executions/${EXECUTION_ID}/config -f - ; \
 fi\
 `
+	/*
+			However in order to have this working, we should (in case of Keycloak) be able to
+			- Automatically redirect the user to its Keycloak account page to set those required values when the email is empty (instead of failing here: https://github.com/eclipse/che/blob/master/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakEnvironmentInitalizationFilter.java#L125)
+			- Or at least point with a link to the place where it can be set (the KeycloakSettings PROFILE_ENDPOINT_SETTING value)
+			  (cf. here: https://github.com/eclipse/che/blob/master/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakSettings.java#L117)
+	*/
+	
 	template, err := template.New("IdentityProviderProvisioning").Parse(createOpenShiftIdentityProviderTemplate)
 	if err != nil {
 		return "", err
@@ -150,6 +157,7 @@ fi\
 	}
 
 	command = buffer.String()
+	
 	if cheFlavor == "che" {
 		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " + command
 	}

--- a/pkg/deploy/exec_commands.go
+++ b/pkg/deploy/exec_commands.go
@@ -168,7 +168,8 @@ func GetDeleteOpenShiftIdentityProviderProvisionCommand(cr *orgv1.CheCluster, ke
 	deleteOpenShiftIdentityProviderCommand :=
 		script + " config credentials --server http://0.0.0.0:8080/auth " +
 			"--realm master --user " + keycloakAdminUserName + " --password " + keycloakAdminPassword + " && " +
-			script + " delete identity-provider/instances/" + providerName + " -r " + keycloakRealm
+			"if " + script + " get identity-provider/instances/" + providerName + " -r " + keycloakRealm + " ; then " +
+			script + " delete identity-provider/instances/" + providerName + " -r " + keycloakRealm + " ; fi"
 	command = deleteOpenShiftIdentityProviderCommand
 	if cheFlavor == "che" {
 		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " + deleteOpenShiftIdentityProviderCommand


### PR DESCRIPTION
## Description

This PR allows enabling the Keycloak Token Exchange feature in the Che setup when the OpenShift OAuth integration is enabled.

This allows grabbing a Che authentication token from the OpenShift token of a user, making it easier to integrate Che with third-party tools running in a overall OpenShift environment.

## Related issues

https://github.com/eclipse/che/issues/14390

## Linked Documentation Pull Request:

https://github.com/eclipse/che-docs/pull/826
