### PR TITLE
Sync default properties with upstream

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -73,6 +73,7 @@ func GetCustomConfigMapData() (cheEnv map[string]string) {
 		"CHE_INFRA_KUBERNETES_SERVICE__ACCOUNT__NAME":           "che-workspace",
 		"CHE_WORKSPACE_AUTO_START":                              "true",
 		"CHE_INFRA_KUBERNETES_WORKSPACE__UNRECOVERABLE__EVENTS": "FailedMount,FailedScheduling,MountVolume.SetUp failed,Failed to pull image",
+		"CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT":                     "1800000",
 	}
 	return cheEnv
 

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -73,7 +73,6 @@ func GetCustomConfigMapData() (cheEnv map[string]string) {
 		"CHE_INFRA_KUBERNETES_SERVICE__ACCOUNT__NAME":           "che-workspace",
 		"CHE_WORKSPACE_AUTO_START":                              "true",
 		"CHE_INFRA_KUBERNETES_WORKSPACE__UNRECOVERABLE__EVENTS": "FailedMount,FailedScheduling,MountVolume.SetUp failed,Failed to pull image",
-		"CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT":                     "-1",
 	}
 	return cheEnv
 

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -69,11 +69,7 @@ type CheConfigMap struct {
 func GetCustomConfigMapData() (cheEnv map[string]string) {
 
 	cheEnv = map[string]string{
-		"CHE_PREDEFINED_STACKS_RELOAD__ON__START":               "true",
 		"CHE_INFRA_KUBERNETES_SERVICE__ACCOUNT__NAME":           "che-workspace",
-		"CHE_WORKSPACE_AUTO_START":                              "true",
-		"CHE_INFRA_KUBERNETES_WORKSPACE__UNRECOVERABLE__EVENTS": "FailedMount,FailedScheduling,MountVolume.SetUp failed,Failed to pull image",
-		"CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT":                     "1800000",
 	}
 	return cheEnv
 


### PR DESCRIPTION
Removed some defaults to be closer to upstream configuration
- CHE_PREDEFINED_STACKS_RELOAD__ON__START - not used in Che 7
- CHE_WORKSPACE_AUTO_START - wrong parameter, has to be CHE_WORKSPACE_AUTO__START, upstream default value - ```true```
- CHE_INFRA_KUBERNETES_WORKSPACE__UNRECOVERABLE__EVENTS - upstream value ```FailedMount,FailedScheduling,MountVolume.SetUp failed,Failed to pull image,FailedCreate```
- CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT - upstream value ```1800000```
- CHE_INFRA_KUBERNETES_SERVICE__ACCOUNT__NAME - Not changed since it has ```NULL``` value in upstream. To remove it we need to investigate if it's safe to do or not.


Refer to https://github.com/eclipse/che/issues/14614