### PR TITLE
update to latest defaults postgres,...

### DIFF
--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -41,11 +41,11 @@ const (
 	DefaultKeycloakAdminUserName        = "admin"
 	DefaultCheLogLevel                  = "INFO"
 	DefaultCheDebug                     = "false"
-	defaultPvcJobsImage                 = "registry.redhat.io/ubi8-minimal:8.0-159"
-	defaultPvcJobsUpstreamImage         = "registry.access.redhat.com/ubi8-minimal:8.0-159"
-	defaultPostgresImage                = "registry.redhat.io/rhscl/postgresql-96-rhel7:1-46"
+	defaultPvcJobsImage                 = "registry.redhat.io/ubi8-minimal:8.0-213"
+	defaultPvcJobsUpstreamImage         = "registry.access.redhat.com/ubi8-minimal:8.0-213"
+	defaultPostgresImage                = "registry.redhat.io/rhscl/postgresql-96-rhel7:1-47"
 	defaultPostgresUpstreamImage        = "centos/postgresql-96-centos7:9.6"
-	defaultKeycloakImage                = "registry.redhat.io/redhat-sso-7/sso73-openshift:1.0-13"
+	defaultKeycloakImage                = "registry.redhat.io/redhat-sso-7/sso73-openshift:1.0-13.1567588155"
 	defaultKeycloakUpstreamImage        = "eclipse/che-keycloak:7.2.0"
 	DefaultJavaOpts                     = "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 " +
 		"-XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 " +

--- a/pkg/deploy/defaults.go.update.sh
+++ b/pkg/deploy/defaults.go.update.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# check for latest tags in upstream container repos
+
+defaultsFile=${0%/*}/defaults.go
+
+if [[ ! -f ${defaultsFile} ]]; then
+    echo "$defaultsFile not found, downloading from master..."
+    defaultsFile="/tmp/defaults.go"
+    curl -ssL https://raw.githubusercontent.com/eclipse/che-operator/master/pkg/deploy/defaults.go -o ${defaultsFile}
+fi
+
+excludes="eclipse/che-keycloak|centos/postgresql-96-centos7"
+for d in $(cat /tmp/defaults.go | egrep "Keycloak|Postgres|Pvc" | egrep Image | egrep -v "func|return|Old|ToDetect|$excludes" | sed -e "s#.\+= \"\(.\+\)\"#\1#"); do
+    echo "- ${d}"
+    echo -n "+ ${d%:*}:"; 
+    e=$(skopeo inspect docker://${d%:*}  | yq .RepoTags | egrep -v "\[|\]|latest" | tr -d ",\" " | sort -V | tail -1)
+    echo ${e}
+    sed -i ${defaultsFile} -e "s@${d}@${d%:*}:${e}@g"
+done
+
+echo "Defaults updated in ${defaultsFile}. Don't forget to commit your changes!"


### PR DESCRIPTION
update to latest defaults postgres, keycloak/sso, and PVC/UBI images; add script to poll for new images automatically and offer changes to be committed

If you don't like the location of the script, happy to move it elsewhere. 

Also we need to cherrypick this to 1.x branch to update containers in CRW 1.x.

Change-Id: I7c59d3aa25b816d0787157c921bc594ac8019b86
Signed-off-by: nickboldt <nboldt@redhat.com>