### PR TITLE
Add airgap mode

### DIFF
--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -31,12 +31,10 @@ type CheClusterSpec struct {
 }
 
 type CheClusterSpecServer struct {
-	// AirGapMode is a flag to tell Che server that it is running in an air-gapped environment
-	AirGapMode bool `json:"airGapMode"`
 	// AirGapContainerRegistryHostname is the hostname to the internal registry to pull images from in the air-gapped environment
 	AirGapContainerRegistryHostname string `json:"airGapContainerRegistryHostname"`
-	// AirGapContainerRegistryRepository is the repository name in the registry to pull images from in the air-gapped environment
-	AirGapContainerRegistryRepository string `json:"airGapContainerRegistryRepository"`
+	// AirGapContainerRegistryOrganization is the repository name in the registry to pull images from in the air-gapped environment
+	AirGapContainerRegistryOrganization string `json:"airGapContainerRegistryOrganization"`
 	// CheImage is a server image used in Che deployment
 	CheImage string `json:"cheImage"`
 	// CheImageTag is a tag of an image used in Che deployment
@@ -254,7 +252,6 @@ func init() {
 }
 
 func (c *CheCluster) IsAirGapMode() bool {
-	return c.Spec.Server.AirGapMode &&
-		c.Spec.Server.AirGapContainerRegistryHostname != "" &&
-		c.Spec.Server.AirGapContainerRegistryRepository != ""
+	return c.Spec.Server.AirGapContainerRegistryHostname != "" ||
+		c.Spec.Server.AirGapContainerRegistryOrganization != ""
 }

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -20,6 +20,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // CheClusterSpec defines the desired state of CheCluster
+// +k8s:openapi-gen=true
 type CheClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
@@ -27,9 +28,10 @@ type CheClusterSpec struct {
 	Database CheClusterSpecDB      `json:"database"`
 	Auth     CheClusterSpecAuth    `json:"auth"`
 	Storage  CheClusterSpecStorage `json:"storage"`
-	K8SOnly  CheClusterSpecK8SOnly `json:"k8s"`
+	K8s      CheClusterSpecK8SOnly `json:"k8s"`
 }
 
+// +k8s:openapi-gen=true
 type CheClusterSpecServer struct {
 	// AirGapMode is a flag to tell Che server that it is running in an air-gapped environment
 	AirGapMode bool `json:"airGapMode"`
@@ -109,6 +111,7 @@ type CheClusterSpecServer struct {
 	ServerMemoryLimit string `json:"serverMemoryLimit"`
 }
 
+// +k8s:openapi-gen=true
 type CheClusterSpecDB struct {
 	// ExternalDB instructs the operator either to skip deploying Postgres,
 	// and passes connection details of existing DB to Che server (when set to true)
@@ -130,6 +133,7 @@ type CheClusterSpecDB struct {
 	PostgresImagePullPolicy corev1.PullPolicy `json:"postgresImagePullPolicy"`
 }
 
+// +k8s:openapi-gen=true
 type CheClusterSpecAuth struct {
 	// ExternalKeycloak instructs operator on whether or not to deploy Keycloak/RH SSO instance. When set to true provision connection details
 	ExternalKeycloak bool `json:"externalIdentityProvider"`
@@ -162,6 +166,7 @@ type CheClusterSpecAuth struct {
 	KeycloakImagePullPolicy corev1.PullPolicy `json:"identityProviderImagePullPolicy"`
 }
 
+// +k8s:openapi-gen=true
 type CheClusterSpecStorage struct {
 	// PvcStrategy is a persistent volume claim strategy for Che server. Can be common (all workspaces PVCs in one volume),
 	// per-workspace (one PVC per workspace for all declared volumes) and unique (one PVC per declared volume). Defaults to common
@@ -178,6 +183,7 @@ type CheClusterSpecStorage struct {
 	WorkspacePVCStorageClassName string `json:"workspacePVCStorageClassName"`
 }
 
+// +k8s:openapi-gen=true
 type CheClusterSpecK8SOnly struct {
 	// IngressDomain is a global ingress domain for a k8s cluster. Must be explicitly specified in CR. There are no defaults
 	IngressDomain string `json:"ingressDomain"`
@@ -195,6 +201,7 @@ type CheClusterSpecK8SOnly struct {
 }
 
 // CheClusterStatus defines the observed state of CheCluster
+// +k8s:openapi-gen=true
 type CheClusterStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -252,3 +252,9 @@ type CheClusterList struct {
 func init() {
 	SchemeBuilder.Register(&CheCluster{}, &CheClusterList{})
 }
+
+func (c *CheCluster) IsAirGapMode() bool {
+	return c.Spec.Server.AirGapMode &&
+		c.Spec.Server.AirGapContainerRegistryHostname != "" &&
+		c.Spec.Server.AirGapContainerRegistryRepository != ""
+}

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -231,6 +231,7 @@ type CheClusterStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CheCluster is the Schema for the ches API
+// +k8s:openapi-gen=true
 type CheCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -31,6 +31,12 @@ type CheClusterSpec struct {
 }
 
 type CheClusterSpecServer struct {
+	// AirGapMode is a flag to tell Che server that it is running in an air-gapped environment
+	AirGapMode bool `json:"airGapMode"`
+	// AirGapContainerRegistryHostname is the hostname to the internal registry to pull images from in the air-gapped environment
+	AirGapContainerRegistryHostname string `json:"airGapContainerRegistryHostname"`
+	// AirGapContainerRegistryRepository is the repository name in the registry to pull images from in the air-gapped environment
+	AirGapContainerRegistryRepository string `json:"airGapContainerRegistryRepository"`
 	// CheImage is a server image used in Che deployment
 	CheImage string `json:"cheImage"`
 	// CheImageTag is a tag of an image used in Che deployment

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -20,7 +20,6 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // CheClusterSpec defines the desired state of CheCluster
-// +k8s:openapi-gen=true
 type CheClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
@@ -28,10 +27,9 @@ type CheClusterSpec struct {
 	Database CheClusterSpecDB      `json:"database"`
 	Auth     CheClusterSpecAuth    `json:"auth"`
 	Storage  CheClusterSpecStorage `json:"storage"`
-	K8s      CheClusterSpecK8SOnly `json:"k8s"`
+	K8SOnly  CheClusterSpecK8SOnly `json:"k8s"`
 }
 
-// +k8s:openapi-gen=true
 type CheClusterSpecServer struct {
 	// AirGapMode is a flag to tell Che server that it is running in an air-gapped environment
 	AirGapMode bool `json:"airGapMode"`
@@ -111,7 +109,6 @@ type CheClusterSpecServer struct {
 	ServerMemoryLimit string `json:"serverMemoryLimit"`
 }
 
-// +k8s:openapi-gen=true
 type CheClusterSpecDB struct {
 	// ExternalDB instructs the operator either to skip deploying Postgres,
 	// and passes connection details of existing DB to Che server (when set to true)
@@ -133,7 +130,6 @@ type CheClusterSpecDB struct {
 	PostgresImagePullPolicy corev1.PullPolicy `json:"postgresImagePullPolicy"`
 }
 
-// +k8s:openapi-gen=true
 type CheClusterSpecAuth struct {
 	// ExternalKeycloak instructs operator on whether or not to deploy Keycloak/RH SSO instance. When set to true provision connection details
 	ExternalKeycloak bool `json:"externalIdentityProvider"`
@@ -166,7 +162,6 @@ type CheClusterSpecAuth struct {
 	KeycloakImagePullPolicy corev1.PullPolicy `json:"identityProviderImagePullPolicy"`
 }
 
-// +k8s:openapi-gen=true
 type CheClusterSpecStorage struct {
 	// PvcStrategy is a persistent volume claim strategy for Che server. Can be common (all workspaces PVCs in one volume),
 	// per-workspace (one PVC per workspace for all declared volumes) and unique (one PVC per declared volume). Defaults to common
@@ -183,7 +178,6 @@ type CheClusterSpecStorage struct {
 	WorkspacePVCStorageClassName string `json:"workspacePVCStorageClassName"`
 }
 
-// +k8s:openapi-gen=true
 type CheClusterSpecK8SOnly struct {
 	// IngressDomain is a global ingress domain for a k8s cluster. Must be explicitly specified in CR. There are no defaults
 	IngressDomain string `json:"ingressDomain"`
@@ -201,7 +195,6 @@ type CheClusterSpecK8SOnly struct {
 }
 
 // CheClusterStatus defines the observed state of CheCluster
-// +k8s:openapi-gen=true
 type CheClusterStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
@@ -238,7 +231,6 @@ type CheClusterStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CheCluster is the Schema for the ches API
-// +k8s:openapi-gen=true
 type CheCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -419,6 +419,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 		}
 		// Create a new Postgres deployment
 		postgresDeployment := deploy.NewPostgresDeployment(instance, chePostgresPassword, isOpenShift, cheFlavor)
+
 		if err := r.CreateNewDeployment(instance, postgresDeployment); err != nil {
 			return reconcile.Result{}, err
 		}
@@ -436,7 +437,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 				}
 			}
 
-			desiredImage := util.GetValue(instance.Spec.Database.PostgresImage, deploy.DefaultPostgresImage(cheFlavor))
+			desiredImage := util.GetValue(instance.Spec.Database.PostgresImage, deploy.DefaultPostgresImage(instance, cheFlavor))
 			effectiveImage := pgDeployment.Spec.Template.Spec.Containers[0].Image
 			desiredImagePullPolicy := util.GetValue(string(instance.Spec.Database.PostgresImagePullPolicy), deploy.DefaultPullPolicyFromDockerImage(desiredImage))
 			effectiveImagePullPolicy := string(pgDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -614,7 +614,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 				k8sclient.GetDeploymentRollingUpdateStatus("keycloak", instance.Namespace)
 			}
 
-			desiredImage := util.GetValue(instance.Spec.Auth.KeycloakImage, deploy.DefaultKeycloakImage(cheFlavor))
+			desiredImage := util.GetValue(instance.Spec.Auth.KeycloakImage, deploy.DefaultKeycloakImage(instance, cheFlavor))
 			effectiveImage := effectiveKeycloakDeployment.Spec.Template.Spec.Containers[0].Image
 			desiredImagePullPolicy := util.GetValue(string(instance.Spec.Auth.KeycloakImagePullPolicy), deploy.DefaultPullPolicyFromDockerImage(desiredImage))
 			effectiveImagePullPolicy := string(effectiveKeycloakDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
@@ -804,7 +804,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			devfileRegistryURL = guessedDevfileRegistryURL
 		}
 
-		devfileRegistryImage := util.GetValue(instance.Spec.Server.DevfileRegistryImage, deploy.DefaultDevfileRegistryImage(cheFlavor))
+		devfileRegistryImage := util.GetValue(instance.Spec.Server.DevfileRegistryImage, deploy.DefaultDevfileRegistryImage(instance, cheFlavor))
 		result, err := addRegistryDeployment(
 			"devfile",
 			devfileRegistryImage,
@@ -840,7 +840,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			pluginRegistryURL = guessedPluginRegistryURL
 		}
 
-		pluginRegistryImage := util.GetValue(instance.Spec.Server.PluginRegistryImage, deploy.DefaultPluginRegistryImage(cheFlavor))
+		pluginRegistryImage := util.GetValue(instance.Spec.Server.PluginRegistryImage, deploy.DefaultPluginRegistryImage(instance, cheFlavor))
 		result, err := addRegistryDeployment(
 			"plugin",
 			pluginRegistryImage,
@@ -874,7 +874,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 	// which will automatically trigger Che rolling update
 	cmResourceVersion := cheConfigMap.ResourceVersion
 	// create Che deployment
-	cheImageRepo := util.GetValue(instance.Spec.Server.CheImage, deploy.DefaultCheServerImageRepo(cheFlavor))
+	cheImageRepo := util.GetValue(instance.Spec.Server.CheImage, deploy.DefaultCheServerImageRepo(instance, cheFlavor))
 	cheImageTag := util.GetValue(instance.Spec.Server.CheImageTag, deploy.DefaultCheServerImageTag(cheFlavor))
 	cheDeploymentToCreate, err := deploy.NewCheDeployment(instance, cheImageRepo, cheImageTag, cmResourceVersion, isOpenShift)
 	if err != nil {

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -67,7 +67,9 @@ type CheConfigMap struct {
 	WebSocketEndpointMinor               string `json:"CHE_WEBSOCKET_ENDPOINT__MINOR"`
 	CheWorkspacePluginBrokerInitImage    string `json:"CHE_WORKSPACE_PLUGIN__BROKER_INIT_IMAGE,omitempty"`
 	CheWorkspacePluginBrokerUnifiedImage string `json:"CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE,omitempty"`
-	CheServerSecureExposesJwtProxyImage  string `json:"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE,omitempty"`
+	CheServerSecureExposerJwtProxyImage  string `json:"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE,omitempty"`
+	CheWorkspaceSidecarImagePullPolicy   string `json:"CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY,omitempty"`
+	CheDockerAlwaysPullImage             string `json:"CHE_DOCKER_ALWAYS__PULL__IMAGE,omitempty"`
 }
 
 // GetConfigMapData gets env values from CR spec and returns a map with key:value
@@ -157,6 +159,8 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 		CheWebSocketEndpoint:                 wsprotocol + "://" + cheHost + "/api/websocket",
 		WebSocketEndpointMinor:               wsprotocol + "://" + cheHost + "/api/websocket-minor",
 		CheDebugServer:                       cheDebug,
+		CheDockerAlwaysPullImage:             cheDockerAlwaysPullImage,
+		CheWorkspaceSidecarImagePullPolicy:   cheWorkspaceSidecarImagePullPolicy,
 		CheInfrastructureActive:              infra,
 		CheInfraKubernetesServiceAccountName: "che-workspace",
 		BootstrapperBinaryUrl:                protocol + "://" + cheHost + "/agent-binaries/linux_amd64/bootstrapper/bootstrapper",
@@ -210,7 +214,9 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	}
 
 	addMap(cheEnv, cr.Spec.Server.CustomCheProperties)
-	addMap(cheEnv, extraImagesConfig(cr))
+	if cr.Spec.Server.AirGapMode {
+		addMap(cheEnv, extraImagesConfig(cr))
+	}
 	return cheEnv
 }
 
@@ -235,6 +241,8 @@ func extraImagesConfig(cr *orgv1.CheCluster) map[string]string {
 		"CHE_WORKSPACE_PLUGIN__BROKER_INIT_IMAGE":    patchDefaultImageName(cr, cheWorkspacePluginBrokerInitImage),
 		"CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE": patchDefaultImageName(cr, cheWorkspacePluginBrokerUnifiedImage),
 		"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE":  patchDefaultImageName(cr, cheServerSecureExposerJwtProxyImage),
+		"CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY":  cheWorkspaceSidecarImagePullPolicy,
+		"CHE_DOCKER_ALWAYS__PULL__IMAGE":             cheDockerAlwaysPullImage,
 	}
 	return extraImages
 }

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -210,7 +210,7 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	}
 
 	addMap(cheEnv, cr.Spec.Server.CustomCheProperties)
-	if cr.Spec.Server.AirGapMode {
+	if cr.IsAirGapMode() {
 		addMap(cheEnv, extraImagesConfig(cr))
 	}
 	return cheEnv

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -68,8 +68,6 @@ type CheConfigMap struct {
 	CheWorkspacePluginBrokerInitImage    string `json:"CHE_WORKSPACE_PLUGIN__BROKER_INIT_IMAGE,omitempty"`
 	CheWorkspacePluginBrokerUnifiedImage string `json:"CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE,omitempty"`
 	CheServerSecureExposerJwtProxyImage  string `json:"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE,omitempty"`
-	CheWorkspaceSidecarImagePullPolicy   string `json:"CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY,omitempty"`
-	CheDockerAlwaysPullImage             string `json:"CHE_DOCKER_ALWAYS__PULL__IMAGE,omitempty"`
 }
 
 // GetConfigMapData gets env values from CR spec and returns a map with key:value
@@ -159,8 +157,6 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 		CheWebSocketEndpoint:                 wsprotocol + "://" + cheHost + "/api/websocket",
 		WebSocketEndpointMinor:               wsprotocol + "://" + cheHost + "/api/websocket-minor",
 		CheDebugServer:                       cheDebug,
-		CheDockerAlwaysPullImage:             cheDockerAlwaysPullImage,
-		CheWorkspaceSidecarImagePullPolicy:   cheWorkspaceSidecarImagePullPolicy,
 		CheInfrastructureActive:              infra,
 		CheInfraKubernetesServiceAccountName: "che-workspace",
 		BootstrapperBinaryUrl:                protocol + "://" + cheHost + "/agent-binaries/linux_amd64/bootstrapper/bootstrapper",
@@ -241,8 +237,6 @@ func extraImagesConfig(cr *orgv1.CheCluster) map[string]string {
 		"CHE_WORKSPACE_PLUGIN__BROKER_INIT_IMAGE":    patchDefaultImageName(cr, cheWorkspacePluginBrokerInitImage),
 		"CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE": patchDefaultImageName(cr, cheWorkspacePluginBrokerUnifiedImage),
 		"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE":  patchDefaultImageName(cr, cheServerSecureExposerJwtProxyImage),
-		"CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY":  cheWorkspaceSidecarImagePullPolicy,
-		"CHE_DOCKER_ALWAYS__PULL__IMAGE":             cheDockerAlwaysPullImage,
 	}
 	return extraImages
 }

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -65,6 +65,9 @@ type CheConfigMap struct {
 	PluginRegistryUrl                    string `json:"CHE_WORKSPACE_PLUGIN__REGISTRY__URL,omitempty"`
 	DevfileRegistryUrl                   string `json:"CHE_WORKSPACE_DEVFILE__REGISTRY__URL,omitempty"`
 	WebSocketEndpointMinor               string `json:"CHE_WEBSOCKET_ENDPOINT__MINOR"`
+	CheWorkspacePluginBrokerInitImage    string `json:"CHE_WORKSPACE_PLUGIN__BROKER_INIT_IMAGE,omitempty"`
+	CheWorkspacePluginBrokerUnifiedImage string `json:"CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE,omitempty"`
+	CheServerSecureExposesJwtProxyImage  string `json:"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE,omitempty"`
 }
 
 // GetConfigMapData gets env values from CR spec and returns a map with key:value
@@ -207,6 +210,7 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	}
 
 	addMap(cheEnv, cr.Spec.Server.CustomCheProperties)
+	addMap(cheEnv, extraImagesConfig(cr))
 	return cheEnv
 }
 
@@ -224,4 +228,13 @@ func NewCheConfigMap(cr *orgv1.CheCluster, cheEnv map[string]string) *corev1.Con
 		},
 		Data: cheEnv,
 	}
+}
+
+func extraImagesConfig(cr *orgv1.CheCluster) map[string]string {
+	extraImages := map[string]string{
+		"CHE_WORKSPACE_PLUGIN__BROKER_INIT_IMAGE":    patchDefaultImageName(cr, cheWorkspacePluginBrokerInitImage),
+		"CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE": patchDefaultImageName(cr, cheWorkspacePluginBrokerUnifiedImage),
+		"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE":  patchDefaultImageName(cr, cheServerSecureExposerJwtProxyImage),
+	}
+	return extraImages
 }

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -144,7 +144,7 @@ func DefaultPullPolicyFromDockerImage(dockerImage string) string {
 }
 
 func patchDefaultImageName(cr *orgv1.CheCluster, imageName string) string {
-	if !cr.Spec.Server.AirGapMode {
+	if !cr.IsAirGapMode() {
 		return imageName
 	}
 

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -84,11 +84,12 @@ func DefaultCheServerImageTag(cheFlavor string) string {
 	return defaultCheServerImageTag
 }
 
-func DefaultCheServerImageRepo(cheFlavor string) string {
+func DefaultCheServerImageRepo(cr *orgv1.CheCluster, cheFlavor string) string {
 	if cheFlavor == "codeready" {
-		return defaultCodeReadyServerImageRepo
+		return patchDefaultImageName(cr, defaultCodeReadyServerImageRepo)
+	} else {
+		return patchDefaultImageName(cr, defaultCheServerImageRepo)
 	}
-	return defaultCheServerImageRepo
 }
 
 func DefaultPvcJobsImage(cheFlavor string) string {
@@ -106,25 +107,28 @@ func DefaultPostgresImage(cr *orgv1.CheCluster, cheFlavor string) string {
 	}
 }
 
-func DefaultKeycloakImage(cheFlavor string) string {
+func DefaultKeycloakImage(cr *orgv1.CheCluster, cheFlavor string) string {
 	if cheFlavor == "codeready" {
-		return defaultKeycloakImage
+		return patchDefaultImageName(cr, defaultKeycloakImage)
+	} else {
+		return patchDefaultImageName(cr, defaultKeycloakUpstreamImage)
 	}
-	return defaultKeycloakUpstreamImage
 }
 
-func DefaultPluginRegistryImage(cheFlavor string) string {
+func DefaultPluginRegistryImage(cr *orgv1.CheCluster, cheFlavor string) string {
 	if cheFlavor == "codeready" {
-		return defaultPluginRegistryImage
+		return patchDefaultImageName(cr, defaultPluginRegistryImage)
+	} else {
+		return patchDefaultImageName(cr, defaultPluginRegistryUpstreamImage)
 	}
-	return defaultPluginRegistryUpstreamImage
 }
 
-func DefaultDevfileRegistryImage(cheFlavor string) string {
+func DefaultDevfileRegistryImage(cr *orgv1.CheCluster, cheFlavor string) string {
 	if cheFlavor == "codeready" {
-		return defaultDevfileRegistryImage
+		return patchDefaultImageName(cr, defaultDevfileRegistryImage)
+	} else {
+		return patchDefaultImageName(cr, defaultDevfileRegistryUpstreamImage)
 	}
-	return defaultDevfileRegistryUpstreamImage
 }
 
 func DefaultPullPolicyFromDockerImage(dockerImage string) string {

--- a/pkg/deploy/defaults_test.go
+++ b/pkg/deploy/defaults_test.go
@@ -42,27 +42,60 @@ func TestCorrectAirGapPatchedImage(t *testing.T) {
 	airGapUpstream := &orgv1.CheCluster{
 		Spec: orgv1.CheClusterSpec{
 			Server: orgv1.CheClusterSpecServer{
-				AirGapMode:                        true,
-				AirGapContainerRegistryHostname:   "bigcorp.net",
-				AirGapContainerRegistryRepository: "che-images",
+				AirGapContainerRegistryHostname:     "bigcorp.net",
+				AirGapContainerRegistryOrganization: "che-images",
 			},
 		},
 	}
 	airGapCRW := &orgv1.CheCluster{
 		Spec: orgv1.CheClusterSpec{
 			Server: orgv1.CheClusterSpecServer{
-				AirGapMode:                        true,
-				AirGapContainerRegistryHostname:   "bigcorp.net",
-				AirGapContainerRegistryRepository: "che-images",
-				CheFlavor:                         "codeready",
+				AirGapContainerRegistryHostname:     "bigcorp.net",
+				AirGapContainerRegistryOrganization: "che-images",
+				CheFlavor:                           "codeready",
 			},
 		},
 	}
+	upstreamOnlyOrg := &orgv1.CheCluster{
+		Spec: orgv1.CheClusterSpec{
+			Server: orgv1.CheClusterSpecServer{
+				AirGapContainerRegistryOrganization: "che-images",
+			},
+		},
+	}
+	upstreamOnlyHostname := &orgv1.CheCluster{
+		Spec: orgv1.CheClusterSpec{
+			Server: orgv1.CheClusterSpecServer{
+				AirGapContainerRegistryHostname: "bigcorp.net",
+			},
+		},
+	}
+	crwOnlyOrg := &orgv1.CheCluster{
+		Spec: orgv1.CheClusterSpec{
+			Server: orgv1.CheClusterSpecServer{
+				AirGapContainerRegistryOrganization: "che-images",
+				CheFlavor:                           "codeready",
+			},
+		},
+	}
+	crwOnlyHostname := &orgv1.CheCluster{
+		Spec: orgv1.CheClusterSpec{
+			Server: orgv1.CheClusterSpecServer{
+				AirGapContainerRegistryHostname: "bigcorp.net",
+				CheFlavor:                       "codeready",
+			},
+		},
+	}
+
 	testCases := map[string]testcase{
-		"upstream default postgres": {image: defaultPostgresUpstreamImage, expected: defaultPostgresUpstreamImage, cr: upstream},
-		"airgap upstream postgres":  {image: defaultPostgresUpstreamImage, expected: "bigcorp.net/che-images/postgresql-96-centos7:9.6", cr: airGapUpstream},
-		"CRW postgres":              {image: defaultPostgresImage, expected: defaultPostgresImage, cr: crw},
-		"CRW airgap postgres":       {image: defaultPostgresImage, expected: "bigcorp.net/che-images/postgresql-96-rhel7:1-47", cr: airGapCRW},
+		"upstream default postgres":                           {image: defaultPostgresUpstreamImage, expected: defaultPostgresUpstreamImage, cr: upstream},
+		"airgap upstream postgres":                            {image: defaultPostgresUpstreamImage, expected: "bigcorp.net/che-images/postgresql-96-centos7:9.6", cr: airGapUpstream},
+		"upstream with only the org changed":                  {image: defaultPostgresUpstreamImage, expected: "docker.io/che-images/postgresql-96-centos7:9.6", cr: upstreamOnlyOrg},
+		"codeready plugin registry with only the org changed": {image: defaultPluginRegistryImage, expected: "registry.redhat.io/che-images/pluginregistry-rhel8:2.0", cr: crwOnlyOrg},
+		"CRW postgres":                                        {image: defaultPostgresImage, expected: defaultPostgresImage, cr: crw},
+		"CRW airgap postgres":                                 {image: defaultPostgresImage, expected: "bigcorp.net/che-images/postgresql-96-rhel7:1-47", cr: airGapCRW},
+		"upstream airgap with only hostname defined":          {image: defaultKeycloakUpstreamImage, expected: "bigcorp.net/eclipse/che-keycloak:7.2.0", cr: upstreamOnlyHostname},
+		"crw airgap with only hostname defined":               {image: defaultDevfileRegistryImage, expected: "bigcorp.net/codeready-workspaces/devfileregistry-rhel8:2.0", cr: crwOnlyHostname},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(*testing.T) {

--- a/pkg/deploy/defaults_test.go
+++ b/pkg/deploy/defaults_test.go
@@ -62,7 +62,7 @@ func TestCorrectAirGapPatchedImage(t *testing.T) {
 		"upstream default postgres": {image: defaultPostgresUpstreamImage, expected: defaultPostgresUpstreamImage, cr: upstream},
 		"airgap upstream postgres":  {image: defaultPostgresUpstreamImage, expected: "bigcorp.net/che-images/postgresql-96-centos7:9.6", cr: airGapUpstream},
 		"CRW postgres":              {image: defaultPostgresImage, expected: defaultPostgresImage, cr: crw},
-		"CRW airgap postgres":       {image: defaultPostgresImage, expected: "bigcorp.net/che-images/postgresql-96-rhel7:1-46", cr: airGapCRW},
+		"CRW airgap postgres":       {image: defaultPostgresImage, expected: "bigcorp.net/che-images/postgresql-96-rhel7:1-47", cr: airGapCRW},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(*testing.T) {

--- a/pkg/deploy/defaults_test.go
+++ b/pkg/deploy/defaults_test.go
@@ -1,0 +1,75 @@
+package deploy
+
+import (
+	orgv1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
+	"testing"
+)
+
+func TestCorrectImageName(t *testing.T) {
+	testCases := map[string]string{
+		"docker.io/eclipse/che-operator:latest": "che-operator:latest",
+		"eclipse/che-operator:7.1.0":            "che-operator:7.1.0",
+		"che-operator:7.2.0":                    "che-operator:7.2.0",
+	}
+	for k, v := range testCases {
+		t.Run(k, func(*testing.T) {
+			actual := getImageNameFromFullImage(k)
+			if actual != v {
+				t.Errorf("Expected %s but was %s", v, actual)
+			}
+		})
+	}
+}
+
+func TestCorrectAirGapPatchedImage(t *testing.T) {
+	type testcase struct {
+		image    string
+		expected string
+		cr       *orgv1.CheCluster
+	}
+	upstream := &orgv1.CheCluster{
+		Spec: orgv1.CheClusterSpec{
+			Server: orgv1.CheClusterSpecServer{},
+		},
+	}
+	crw := &orgv1.CheCluster{
+		Spec: orgv1.CheClusterSpec{
+			Server: orgv1.CheClusterSpecServer{
+				CheFlavor: "codeready",
+			},
+		},
+	}
+	airGapUpstream := &orgv1.CheCluster{
+		Spec: orgv1.CheClusterSpec{
+			Server: orgv1.CheClusterSpecServer{
+				AirGapMode:                        true,
+				AirGapContainerRegistryHostname:   "bigcorp.net",
+				AirGapContainerRegistryRepository: "che-images",
+			},
+		},
+	}
+	airGapCRW := &orgv1.CheCluster{
+		Spec: orgv1.CheClusterSpec{
+			Server: orgv1.CheClusterSpecServer{
+				AirGapMode:                        true,
+				AirGapContainerRegistryHostname:   "bigcorp.net",
+				AirGapContainerRegistryRepository: "che-images",
+				CheFlavor:                         "codeready",
+			},
+		},
+	}
+	testCases := map[string]testcase{
+		"upstream default postgres": {image: defaultPostgresUpstreamImage, expected: defaultPostgresUpstreamImage, cr: upstream},
+		"airgap upstream postgres":  {image: defaultPostgresUpstreamImage, expected: "bigcorp.net/che-images/postgresql-96-centos7:9.6", cr: airGapUpstream},
+		"CRW postgres":              {image: defaultPostgresImage, expected: defaultPostgresImage, cr: crw},
+		"CRW airgap postgres":       {image: defaultPostgresImage, expected: "bigcorp.net/che-images/postgresql-96-rhel7:1-46", cr: airGapCRW},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(*testing.T) {
+			actual := patchDefaultImageName(tc.cr, tc.image)
+			if actual != tc.expected {
+				t.Errorf("Expected %s but was %s", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/deploy/deployment_keycloak.go
+++ b/pkg/deploy/deployment_keycloak.go
@@ -25,7 +25,7 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 	optionalEnv := true
 	keycloakName := "keycloak"
 	labels := GetLabels(cr, keycloakName)
-	keycloakImage := util.GetValue(cr.Spec.Auth.KeycloakImage, DefaultKeycloakImage(cheFlavor))
+	keycloakImage := util.GetValue(cr.Spec.Auth.KeycloakImage, DefaultKeycloakImage(cr, cheFlavor))
 	pullPolicy := corev1.PullPolicy(util.GetValue(string(cr.Spec.Auth.KeycloakImagePullPolicy), DefaultPullPolicyFromDockerImage(keycloakImage)))
 	trustpass := util.GeneratePasswd(12)
 	jbossDir := "/opt/eap"
@@ -62,7 +62,7 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 	startCommand := "sed -i 's/WILDCARD/ANY/g' /opt/eap/bin/launch/keycloak-spi.sh && /opt/eap/bin/openshift-launch.sh -b 0.0.0.0"
 	// upstream Keycloak has a bit different mechanism of adding jks
 	changeConfigCommand := "echo Installing certificates into Keycloak && " +
-	  "echo -e \"embed-server --server-config=standalone.xml --std-out=echo \n" +
+		"echo -e \"embed-server --server-config=standalone.xml --std-out=echo \n" +
 		"/subsystem=keycloak-server/spi=truststore/:add \n" +
 		"/subsystem=keycloak-server/spi=truststore/provider=file/:add(properties={file => " +
 		"\"" + jbossDir + "/openshift.jks\", password => \"" + trustpass + "\", disabled => \"false\" },enabled=true) \n" +
@@ -230,9 +230,9 @@ func NewKeycloakDeployment(cr *orgv1.CheCluster, keycloakPostgresPassword string
 			Name:      keycloakName,
 			Namespace: cr.Namespace,
 			Labels:    labels,
-			Annotations: map[string]string {
+			Annotations: map[string]string{
 				"che.self-signed-certificate.version": cheCertSecretVersion,
-				"che.openshift-api-crt.version": openshiftCertSecretVersion,
+				"che.openshift-api-crt.version":       openshiftCertSecretVersion,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/deploy/deployment_postgres.go
+++ b/pkg/deploy/deployment_postgres.go
@@ -24,7 +24,7 @@ func NewPostgresDeployment(cr *orgv1.CheCluster, chePostgresPassword string, isO
 	chePostgresUser := util.GetValue(cr.Spec.Database.ChePostgresUser, "pgche")
 	chePostgresDb := util.GetValue(cr.Spec.Database.ChePostgresDb, "dbche")
 	postgresAdminPassword := util.GeneratePasswd(12)
-	postgresImage := util.GetValue(cr.Spec.Database.PostgresImage, DefaultPostgresImage(cheFlavor))
+	postgresImage := util.GetValue(cr.Spec.Database.PostgresImage, DefaultPostgresImage(cr, cheFlavor))
 	pullPolicy := corev1.PullPolicy(util.GetValue(string(cr.Spec.Database.PostgresImagePullPolicy), DefaultPullPolicyFromDockerImage(postgresImage)))
 
 	name := "postgres"
@@ -124,11 +124,11 @@ func NewPostgresDeployment(cr *orgv1.CheCluster, chePostgresPassword string, isO
 			},
 		},
 	}
-	if ! isOpenshift {
+	if !isOpenshift {
 		var runAsUser int64 = 26
-		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext {
+		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
 			RunAsUser: &runAsUser,
-			FSGroup: &runAsUser,
+			FSGroup:   &runAsUser,
 		}
 	}
 	return &deployment

--- a/pkg/deploy/extra_images.go
+++ b/pkg/deploy/extra_images.go
@@ -1,0 +1,7 @@
+package deploy
+
+const (
+	cheWorkspacePluginBrokerInitImage    = "eclipse/che-init-plugin-broker:v0.21"
+	cheWorkspacePluginBrokerUnifiedImage = "eclipse/che-unified-plugin-broker:v0.21"
+	cheServerSecureExposerJwtProxyImage  = "quay.io/eclipse/che-jwtproxy:dbd0578"
+)

--- a/pkg/deploy/extra_images.go
+++ b/pkg/deploy/extra_images.go
@@ -1,7 +1,10 @@
+// This file is generated, and contains the latest versions of certain properties from che.properties
 package deploy
 
 const (
 	cheWorkspacePluginBrokerInitImage    = "eclipse/che-init-plugin-broker:v0.21"
 	cheWorkspacePluginBrokerUnifiedImage = "eclipse/che-unified-plugin-broker:v0.21"
 	cheServerSecureExposerJwtProxyImage  = "quay.io/eclipse/che-jwtproxy:dbd0578"
+	cheWorkspaceSidecarImagePullPolicy   = "Always"
+	cheDockerAlwaysPullImage             = "true"
 )

--- a/pkg/deploy/extra_images.go
+++ b/pkg/deploy/extra_images.go
@@ -5,6 +5,4 @@ const (
 	cheWorkspacePluginBrokerInitImage    = "eclipse/che-init-plugin-broker:v0.21"
 	cheWorkspacePluginBrokerUnifiedImage = "eclipse/che-unified-plugin-broker:v0.21"
 	cheServerSecureExposerJwtProxyImage  = "quay.io/eclipse/che-jwtproxy:dbd0578"
-	cheWorkspaceSidecarImagePullPolicy   = "Always"
-	cheDockerAlwaysPullImage             = "true"
 )

--- a/release-operator-code.sh
+++ b/release-operator-code.sh
@@ -66,7 +66,7 @@ pkg/deploy/defaults.go \
 > pkg/deploy/defaults.go.new
 mv pkg/deploy/defaults.go.new pkg/deploy/defaults.go
 
-wget https://raw.githubusercontent.com/eclipse/che/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties -q -O /tmp/che.properties
+wget https://raw.githubusercontent.com/eclipse/che/${RELEASE}/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties -q -O /tmp/che.properties
 latestCheWorkspacePluginBrokerInitImage=$(cat /tmp/che.properties| grep "che.workspace.plugin_broker.init.image" | cut -d = -f2)
 latestCheWorkspacePluginBrokerUnifiedImage=$(cat /tmp/che.properties | grep "che.workspace.plugin_broker.unified.image" | cut -d = -f2)
 latestCheServerSecureExposerJwtProxyImage=$(cat /tmp/che.properties | grep "che.server.secure_exposer.jwtproxy.image" | cut -d = -f2)

--- a/release-operator-code.sh
+++ b/release-operator-code.sh
@@ -66,6 +66,29 @@ pkg/deploy/defaults.go \
 > pkg/deploy/defaults.go.new
 mv pkg/deploy/defaults.go.new pkg/deploy/defaults.go
 
+wget https://raw.githubusercontent.com/eclipse/che/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties -q -O /tmp/che.properties
+latestCheWorkspacePluginBrokerInitImage=$(cat /tmp/che.properties| grep "che.workspace.plugin_broker.init.image" | cut -d = -f2)
+latestCheWorkspacePluginBrokerUnifiedImage=$(cat /tmp/che.properties | grep "che.workspace.plugin_broker.unified.image" | cut -d = -f2)
+latestCheServerSecureExposerJwtProxyImage=$(cat /tmp/che.properties | grep "che.server.secure_exposer.jwtproxy.image" | cut -d = -f2)
+latestCheWorkspaceSidecarImagePullPolicy=$(cat /tmp/che.properties | grep "che.workspace.sidecar.image_pull_policy" | cut -d = -f2)
+latestCheDockerAlwaysPullImage=$(cat /tmp/che.properties | grep "che.docker.always_pull_image" | cut -d = -f2)
+
+cat << EOF > pkg/deploy/extra_images.go
+// This file is generated, and contains the latest versions of certain properties from che.properties
+package deploy
+
+const (
+	cheWorkspacePluginBrokerInitImage    = "${latestCheWorkspacePluginBrokerInitImage}"
+	cheWorkspacePluginBrokerUnifiedImage = "${latestCheWorkspacePluginBrokerUnifiedImage}"
+	cheServerSecureExposerJwtProxyImage  = "${latestCheServerSecureExposerJwtProxyImage}"
+	cheWorkspaceSidecarImagePullPolicy   = "${latestCheWorkspaceSidecarImagePullPolicy}"
+	cheDockerAlwaysPullImage             = "${latestCheDockerAlwaysPullImage}"
+)
+EOF
+
+gofmt -w pkg/deploy/extra_images.go
+rm /tmp/che.properties
+
 dockerImage="quay.io/eclipse/che-operator:${RELEASE}"
 echo "   - Building Che Operator docker image for new release ${RELEASE}"
 docker build -t "quay.io/eclipse/che-operator:${RELEASE}" .

--- a/release-operator-code.sh
+++ b/release-operator-code.sh
@@ -70,8 +70,6 @@ wget https://raw.githubusercontent.com/eclipse/che/${RELEASE}/assembly/assembly-
 latestCheWorkspacePluginBrokerInitImage=$(cat /tmp/che.properties| grep "che.workspace.plugin_broker.init.image" | cut -d = -f2)
 latestCheWorkspacePluginBrokerUnifiedImage=$(cat /tmp/che.properties | grep "che.workspace.plugin_broker.unified.image" | cut -d = -f2)
 latestCheServerSecureExposerJwtProxyImage=$(cat /tmp/che.properties | grep "che.server.secure_exposer.jwtproxy.image" | cut -d = -f2)
-latestCheWorkspaceSidecarImagePullPolicy=$(cat /tmp/che.properties | grep "che.workspace.sidecar.image_pull_policy" | cut -d = -f2)
-latestCheDockerAlwaysPullImage=$(cat /tmp/che.properties | grep "che.docker.always_pull_image" | cut -d = -f2)
 
 cat << EOF > pkg/deploy/extra_images.go
 // This file is generated, and contains the latest versions of certain properties from che.properties
@@ -81,8 +79,6 @@ const (
 	cheWorkspacePluginBrokerInitImage    = "${latestCheWorkspacePluginBrokerInitImage}"
 	cheWorkspacePluginBrokerUnifiedImage = "${latestCheWorkspacePluginBrokerUnifiedImage}"
 	cheServerSecureExposerJwtProxyImage  = "${latestCheServerSecureExposerJwtProxyImage}"
-	cheWorkspaceSidecarImagePullPolicy   = "${latestCheWorkspaceSidecarImagePullPolicy}"
-	cheDockerAlwaysPullImage             = "${latestCheDockerAlwaysPullImage}"
 )
 EOF
 


### PR DESCRIPTION
This PR addresses https://github.com/eclipse/che/issues/14734

- Add 3 CR fields, `airGapMode`, `airGapContainerRegistryHostname`, `airGapContainerRegistryRepository`
- If `airGapMode` is true, all of the images will be pulled from their airgapped repository location instead of `registry.redhat.io`, `docker.io`, etc.

We are thinking that this doesn't need a docs PR as this will mostly be covered in https://github.com/eclipse/che/issues/13886