### PR TITLE
Support for the new way of specifying the workspace namespace in Che.

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -69,7 +69,7 @@ spec:
   storage:
     # persistent volume claim strategy for Che server. Can be common (all workspaces PVCs in one volume),
     # per-workspace (one PVC per workspace for all declared volumes) and unique (one PVC per declared volume). Defaults to common
-    pvcStrategy: 'per-workspace'
+    pvcStrategy: 'common'
     # size of a persistent volume claim for workspaces. Defaults to 1Gi
     pvcClaimSize: '1Gi'
     # instruct Che server to launch a special pod to precreate a subpath in a PV

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -38,7 +38,7 @@ type CheConfigMap struct {
 	CheDebugServer                       string `json:"CHE_DEBUG_SERVER"`
 	CheInfrastructureActive              string `json:"CHE_INFRASTRUCTURE_ACTIVE"`
 	CheInfraKubernetesServiceAccountName string `json:"CHE_INFRA_KUBERNETES_SERVICE__ACCOUNT__NAME"`
-	WorkspacesNamespace                  string `json:"CHE_INFRA_OPENSHIFT_PROJECT"`
+	DefaultTargetNamespace               string `json:"CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT"`
 	PvcStrategy                          string `json:"CHE_INFRA_KUBERNETES_PVC_STRATEGY"`
 	PvcClaimSize                         string `json:"CHE_INFRA_KUBERNETES_PVC_QUANTITY"`
 	PvcJobsImage                         string `json:"CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE"`
@@ -84,12 +84,12 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	if isOpenShift {
 		infra = "openshift"
 	}
-	workspacesNamespace := cr.Namespace
+	defaultTargetNamespace := cr.Namespace
 	tls := "false"
 	openShiftIdentityProviderId := "NULL"
 	openshiftOAuth := cr.Spec.Auth.OpenShiftoAuth
 	if openshiftOAuth && isOpenShift {
-		workspacesNamespace = ""
+		defaultTargetNamespace = "<username>-" + cheFlavor
 		openShiftIdentityProviderId = "openshift-v3"
 		if isOpenshift4 {
 			openShiftIdentityProviderId = "openshift-v4"
@@ -158,7 +158,7 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 		CheDebugServer:                       cheDebug,
 		CheInfrastructureActive:              infra,
 		CheInfraKubernetesServiceAccountName: "che-workspace",
-		WorkspacesNamespace:                  workspacesNamespace,
+		DefaultTargetNamespace:               defaultTargetNamespace,
 		PvcStrategy:                          pvcStrategy,
 		PvcClaimSize:                         pvcClaimSize,
 		WorkspacePvcStorageClassName:         workspacePvcStorageClassName,
@@ -196,7 +196,6 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	k8sCheEnv := map[string]string{
 		"CHE_INFRA_KUBERNETES_POD_SECURITY__CONTEXT_FS__GROUP":     securityContextFsGroup,
 		"CHE_INFRA_KUBERNETES_POD_SECURITY__CONTEXT_RUN__AS__USER": securityContextRunAsUser,
-		"CHE_INFRA_KUBERNETES_NAMESPACE":                           workspacesNamespace,
 		"CHE_INFRA_KUBERNETES_INGRESS_DOMAIN":                      ingressDomain,
 		"CHE_INFRA_KUBERNETES_SERVER__STRATEGY":                    ingressStrategy,
 		"CHE_INFRA_KUBERNETES_TLS__SECRET":                         tlsSecretName,


### PR DESCRIPTION
The default is still the current namespace if there is no oauth in the infra

With Openshift OAuth, the namespace is now `<username>-che` or
`<username>-codeready` depending on the che flavor.

Note that this change amounts to no workspace breakage even in case of upgrade from previous versions because of the workspace namespace resolution logic implemented in the che server.

The new logic (implemented in https://github.com/eclipse/che/pull/14828) does the following when determining a workspace namespace during workspace **start** (not creation):

1. Take the legacy `che.infra.kubernetes.namespace` or `che.infra.openshift.project` property (defaulting to `<workspaceid>` placeholder)
1. See if a namespace with the above determined name exists, use it for deploying the workspace if it does
1. If not, take the value of the new property `che.infra.kubernetes.namespace.default` (which is common for both k8s and openshift) and use the namespace determined by that.
1. If the new property has no value, error out.
1. store the target namespace in the workspace config so that we don't have to do the dance the next time the workspace is started.

This change, together with https://github.com/eclipse/che/pull/14828 enables us to keep existing workspaces working in their original namespaces and use the new configuration for the new workspaces.

The only consequence is that users will see che workspaces potentially in multiple namespaces (but the workspaces will be able to access all their data, etc.).

For the pre-existing workspaces created using an older version of Che, this logic ensures correct namespace resolution after the upgrade to the latest version of operator and che in both the below cases:

#### No OAuth
Because there's no oauth, the workspaces will be still colocated in the operator's namespace and will be found during step 2. above.

#### OAuth
The existing workspaces will be in the namespaces called after their `<workspaceid>`. The above logic will find them in step 2. (previously, oauth meant namespace per workspace).

## Depends on
https://github.com/eclipse/che/pull/14828