### PR TITLE
Fix property name to avoid JGroups4 warnings

### DIFF
--- a/pkg/deploy/deployment_che.go
+++ b/pkg/deploy/deployment_che.go
@@ -149,7 +149,7 @@ func NewCheDeployment(cr *orgv1.CheCluster, cheImage string, cheTag string, cmRe
 									Value: cmRevision,
 								},
 								{
-									Name: "OPENSHIFT_KUBE_PING_NAMESPACE",
+									Name: "KUBERNETES_NAMESPACE",
 									ValueFrom: &corev1.EnvVarSource{
 										FieldRef: &corev1.ObjectFieldSelector{
 											FieldPath: "metadata.namespace"}},


### PR DESCRIPTION
Since we're swithing to JGroups 4,  need to update property name to avoid ugly warnings in logs.