### PR TITLE
Append `/v3` to pluginRegistryURL in all cases.

### DIFF
--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -941,9 +941,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		if cheFlavor != "codeready" {
-			guessedPluginRegistryURL += "/v3"
-		}
+		guessedPluginRegistryURL += "/v3"
 		if pluginRegistryURL == "" {
 			pluginRegistryURL = guessedPluginRegistryURL
 		}


### PR DESCRIPTION
In history it was not appended, when flavor was codeready (backwards compatibility). I think this is not needed anymore.

Should fix https://issues.jboss.org/browse/CRW-430

Signed-off-by: Radim Hopp <rhopp@redhat.com>