### PR TITLE
che #14809 Enable CodeReady branding on the ConsoleLink elements created by the che operator with 'codeready' flavor

### DIFF
--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -1044,6 +1044,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 	// we can now try to create consolelink, after che instance is available
 	if err := createConsoleLink(isOpenShift4, protocol, instance, r); err != nil {
+		logrus.Errorf("An error occurred during console link provisioning: %s", err)
 		return reconcile.Result{}, err
 	}
 
@@ -1200,7 +1201,7 @@ func createConsoleLink(isOpenShift4 bool, protocol string, instance *orgv1.CheCl
 		// console link is supported only with https
 		return nil
 	}
-
+	cheFlavor := instance.Spec.Server.CheFlavor
 	cheHost := instance.Spec.Server.CheHost
 	preparedConsoleLink := &consolev1.ConsoleLink{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1209,7 +1210,7 @@ func createConsoleLink(isOpenShift4 bool, protocol string, instance *orgv1.CheCl
 		Spec: consolev1.ConsoleLinkSpec{
 			Link: consolev1.Link{
 				Href: protocol + "://" + cheHost,
-				Text: deploy.DefaultConsoleLinkDisplayName},
+				Text: deploy.DefaultConsoleLinkDisplayName(cheFlavor)},
 			Location: consolev1.ApplicationMenu,
 			ApplicationMenu: &consolev1.ApplicationMenuSpec{
 				Section:  deploy.DefaultConsoleLinkSection,

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -71,11 +71,19 @@ const (
 	OldDefaultPostgresUpstreamImageToDetect = "centos/postgresql-96-centos7:9.6"
 
 	// ConsoleLink default
-	DefaultConsoleLinkName        = "che"
-	DefaultConsoleLinkImage       = "/dashboard/assets/branding/loader.svg"
-	DefaultConsoleLinkDisplayName = "Eclipse Che"
-	DefaultConsoleLinkSection     = "Red Hat Applications"
+	DefaultConsoleLinkName                = "che"
+	DefaultConsoleLinkSection             = "Red Hat Applications"
+	DefaultConsoleLinkImage               = "/dashboard/assets/branding/loader.svg"
+	defaultConsoleLinkUpstreamDisplayName = "Eclipse Che"
+	defaultConsoleLinkDisplayName         = "CodeReady Workspaces"
 )
+
+func DefaultConsoleLinkDisplayName(cheFlavor string) string {
+	if cheFlavor == "codeready" {
+		return defaultConsoleLinkDisplayName
+	}
+	return defaultConsoleLinkUpstreamDisplayName
+}
 
 func DefaultCheServerImageTag(cheFlavor string) string {
 	if cheFlavor == "codeready" {


### PR DESCRIPTION
Che issue - https://github.com/eclipse/che/issues/14809

ConsoleLink functionality works just fine


![image](https://user-images.githubusercontent.com/1461122/67565353-83499900-f725-11e9-85ad-4aef7efda7fe.png)

Verified against crc:

`./run server:start -a operator -p crc -b console-openshift-console.apps-crc.testing -n crw-link --che-operator-image=quay.io/ibuziuk/che-operator:che-14809-new --che-operator-cr-yaml=crw.yaml`

crw.yaml:

```
apiVersion: org.eclipse.che/v1
kind: CheCluster 
metadata:
  name: eclipse-che
spec:
  server:
    # server image used in Che deployment
    cheImage: 'quay.io/crw/server-rhel8'
    # tag of an image used in Che deployment
    cheImageTag: '2.0-377'
    # image:tag used in Devfile registry deployment
    devfileRegistryImage: 'quay.io/crw/devfileregistry-rhel8:2.0-159'
    # image:tag used in plugin registry deployment
    pluginRegistryImage: 'quay.io/crw/pluginregistry-rhel8:2.0-203'
    # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
    # the difference is in images, labels, exec commands
    cheFlavor: 'codeready'
    # when set to true the operator will attempt to get a secret in OpenShift router namespace
    # to add it to Java trust store of Che server. Requires cluster-admin privileges for operator service account
    selfSignedCert: true
    # TLS mode for Che. Make sure you either have public cert, or set selfSignedCert to true
    tlsSupport: true
    # protocol+hostname of a proxy server. Automatically added as JAVA_OPTS and https(s)_proxy
    # to Che server and workspaces containers
    # proxyURL: ''
    # port of a proxy server
    # proxyPort: ''
    # username for a proxy server
    # proxyUser: ''
    # password for a proxy user
    # proxyPassword: ''
    # a list of non-proxy hosts. Use | as delimiter, eg localhost|my.host.com|123.42.12.32
    # nonProxyHosts: ''
    # overrides for https://github.com/eclipse/che/blob/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
    customCheProperties:
      CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY: 'Always'
      CHE_DOCKER_ALWAYS__PULL__IMAGE: 'true'
      # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
      # CHE_INFRA_KUBERNETES_PVC_JOBS_IMAGE: 'registry.access.redhat.com/ubi8-minimal:8.0-213'
      CHE_WORKSPACE_PLUGIN__BROKER_INIT_IMAGE: 'quay.io/crw/pluginbrokerinit-rhel8:2.0-6'
      CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE: 'quay.io/crw/pluginbroker-rhel8:2.0-5'
      CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:2.0-4'
      CHE_FACTORY_DEFAULT__EDITOR: 'eclipse/che-theia/7.3.0'
      CHE_FACTORY_DEFAULT__PLUGINS: 'eclipse/che-machine-exec-plugin/7.3.0'
      CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR: 'eclipse/che-theia/7.3.0'
      CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR_PLUGINS: 'eclipse/che-machine-exec-plugin/7.3.0'
    # when set to true, the operator skips deploying Postgres, and passes connection details of existing DB to Che server
    # otherwise a Postgres deployment is created
    # externalDb: false
    # Postgres deployment in format image:tag. Defaults to registry.redhat.io/rhscl/postgresql-96-rhel7 (see pkg/deploy/defaults.go for latest tag)
    # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
    # postgresImage: 'registry.redhat.io/rhscl/postgresql-96-rhel7:1-47'
  # storage:
    # persistent volume claim strategy for Che server. Can be common (all workspaces PVCs in one volume),
    # per-workspace (one PVC per workspace for all declared volumes) and unique (one PVC per declared volume). Defaults to common
    # pvcStrategy: 'per-workspace'
    # size of a persistent volume claim for workspaces. Defaults to 1Gi
    # pvcClaimSize: '1Gi'
    # instruct Che server to launch a special pod to precreate a subpath in a PV
    # preCreateSubPaths: true
    # image:tag for preCreateSubPaths jobs
    # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
    # pvcJobsImage: 'registry.access.redhat.com/ubi8-minimal:8.0-213'
  # auth:
    # instructs operator on whether or not to deploy Keycloak/RH SSO instance. When set to true provision connection details
    # externalIdentityProvider: false
    # retrieved from respective route/ingress unless explicitly specified in CR (when ExternalKeycloak is true)
    # instructs an Operator to enable OpenShift v3 identity provider in Keycloak,
    # as well as create respective oAuthClient and configure Che configMap accordingly
    # openShiftoAuth: false
    # image:tag used in Keycloak deployment
    # set by operator, probably don't need to override. Latest in https://github.com/eclipse/che-operator/blob/master/pkg/deploy/defaults.go#L47-L51
    # identityProviderImage: 'registry.redhat.io/redhat-sso-7/sso73-openshift:1.0-15'
```
