### PR TITLE
Set CHE_DEVFILE_REGISTRY_URL to allow airgap operation

### DIFF
--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -827,17 +827,16 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 	devfileRegistryURL := instance.Spec.Server.DevfileRegistryUrl
 
-	guessedDevfileRegistryURL, err := addRegistryRoute("devfile")
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	if devfileRegistryURL == "" {
-		devfileRegistryURL = guessedDevfileRegistryURL
-	}
-
 	// Create devfile registry resources unless an external registry is used
 	externalDevfileRegistry := instance.Spec.Server.ExternalDevfileRegistry
 	if !externalDevfileRegistry {
+		guessedDevfileRegistryURL, err := addRegistryRoute("devfile")
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if devfileRegistryURL == "" {
+			devfileRegistryURL = guessedDevfileRegistryURL
+		}
 		if instance.IsAirGapMode() {
 			devFileRegistryConfigMap := &corev1.ConfigMap{}
 			err = r.client.Get(context.TODO(), types.NamespacedName{Name: "devfile-registry", Namespace: instance.Namespace}, devFileRegistryConfigMap)

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -826,6 +826,15 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 	}
 
 	devfileRegistryURL := instance.Spec.Server.DevfileRegistryUrl
+
+	guessedDevfileRegistryURL, err := addRegistryRoute("devfile")
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if devfileRegistryURL == "" {
+		devfileRegistryURL = guessedDevfileRegistryURL
+	}
+
 	// Create devfile registry resources unless an external registry is used
 	externalDevfileRegistry := instance.Spec.Server.ExternalDevfileRegistry
 	if !externalDevfileRegistry {
@@ -834,7 +843,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			err = r.client.Get(context.TODO(), types.NamespacedName{Name: "devfile-registry", Namespace: instance.Namespace}, devFileRegistryConfigMap)
 			if err != nil {
 				if errors.IsNotFound(err) {
-					devFileRegistryConfigMap = deploy.CreateDevfileRegistryConfigMap(instance)
+					devFileRegistryConfigMap = deploy.CreateDevfileRegistryConfigMap(instance, devfileRegistryURL)
 					err = controllerutil.SetControllerReference(instance, devFileRegistryConfigMap, r.scheme)
 					if err != nil {
 						logrus.Errorf("An error occurred: %v", err)
@@ -852,7 +861,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 					return reconcile.Result{}, err
 				}
 			} else {
-				devFileRegistryConfigMap = deploy.CreateDevfileRegistryConfigMap(instance)
+				devFileRegistryConfigMap = deploy.CreateDevfileRegistryConfigMap(instance, devfileRegistryURL)
 				err = controllerutil.SetControllerReference(instance, devFileRegistryConfigMap, r.scheme)
 				if err != nil {
 					logrus.Errorf("An error occurred: %v", err)
@@ -865,14 +874,6 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 					return reconcile.Result{}, err
 				}
 			}
-		}
-
-		guessedDevfileRegistryURL, err := addRegistryRoute("devfile")
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		if devfileRegistryURL == "" {
-			devfileRegistryURL = guessedDevfileRegistryURL
 		}
 
 		devfileRegistryImage := util.GetValue(instance.Spec.Server.DevfileRegistryImage, deploy.DefaultDevfileRegistryImage(instance, cheFlavor))

--- a/pkg/deploy/registry_configmap.go
+++ b/pkg/deploy/registry_configmap.go
@@ -13,6 +13,7 @@ import (
 type DevFileRegistryConfigMap struct {
 	CheDevfileImagesRegistryURL          string `json:"CHE_DEVFILE_IMAGES_REGISTRY_URL"`
 	CheDevfileImagesRegistryOrganization string `json:"CHE_DEVFILE_IMAGES_REGISTRY_ORGANIZATION"`
+	CheDevfileHttpsEndpoint              string `json:"CHE_DEVFILE_HTTPS_ENDPOINT"`
 }
 
 type PluginRegistryConfigMap struct {
@@ -20,7 +21,7 @@ type PluginRegistryConfigMap struct {
 	CheSidecarContainersRegistryOrganization string `json:"CHE_SIDECAR_CONTAINERS_REGISTRY_ORGANIZATION"`
 }
 
-func CreateDevfileRegistryConfigMap(cr *orgv1.CheCluster) *corev1.ConfigMap {
+func CreateDevfileRegistryConfigMap(cr *orgv1.CheCluster, endpoint string) *corev1.ConfigMap {
 	labels := GetLabels(cr, util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor))
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -32,7 +33,7 @@ func CreateDevfileRegistryConfigMap(cr *orgv1.CheCluster) *corev1.ConfigMap {
 			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
-		Data: GetDevfileRegistryConfigMapData(cr),
+		Data: GetDevfileRegistryConfigMapData(cr, endpoint),
 	}
 }
 
@@ -53,11 +54,12 @@ func CreatePluginRegistryConfigMap(cr *orgv1.CheCluster) *corev1.ConfigMap {
 	}
 }
 
-func GetDevfileRegistryConfigMapData(cr *orgv1.CheCluster) map[string]string {
+func GetDevfileRegistryConfigMapData(cr *orgv1.CheCluster, endpoint string) map[string]string {
 	devfileRegistryEnv := make(map[string]string)
 	data := &DevFileRegistryConfigMap{
 		CheDevfileImagesRegistryURL:          cr.Spec.Server.AirGapContainerRegistryHostname,
 		CheDevfileImagesRegistryOrganization: cr.Spec.Server.AirGapContainerRegistryOrganization,
+		CheDevfileHttpsEndpoint:              endpoint,
 	}
 
 	out, err := json.Marshal(data)

--- a/pkg/deploy/registry_configmap.go
+++ b/pkg/deploy/registry_configmap.go
@@ -13,7 +13,7 @@ import (
 type DevFileRegistryConfigMap struct {
 	CheDevfileImagesRegistryURL          string `json:"CHE_DEVFILE_IMAGES_REGISTRY_URL"`
 	CheDevfileImagesRegistryOrganization string `json:"CHE_DEVFILE_IMAGES_REGISTRY_ORGANIZATION"`
-	CheDevfileHttpsEndpoint              string `json:"CHE_DEVFILE_HTTPS_ENDPOINT"`
+	CheDevfileRegistryURL                string `json:"CHE_DEVFILE_REGISTRY_URL"`
 }
 
 type PluginRegistryConfigMap struct {
@@ -59,7 +59,7 @@ func GetDevfileRegistryConfigMapData(cr *orgv1.CheCluster, endpoint string) map[
 	data := &DevFileRegistryConfigMap{
 		CheDevfileImagesRegistryURL:          cr.Spec.Server.AirGapContainerRegistryHostname,
 		CheDevfileImagesRegistryOrganization: cr.Spec.Server.AirGapContainerRegistryOrganization,
-		CheDevfileHttpsEndpoint:              endpoint,
+		CheDevfileRegistryURL:                endpoint,
 	}
 
 	out, err := json.Marshal(data)


### PR DESCRIPTION
This PR adds the `CHE_DEVFILE_HTTPS_ENDPOINT` variable when configuring the registries in airgap mode.  It uses the public-facing route of the devfile registry, and places it in the `devfile-registry` config map, and redeploys a new version of the registry based on changes to the route.

Enables https://github.com/eclipse/che/issues/14880