### PR TITLE
Remove deprecated BootstrapperBinaryUrl from configmaps

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -38,7 +38,6 @@ type CheConfigMap struct {
 	CheDebugServer                       string `json:"CHE_DEBUG_SERVER"`
 	CheInfrastructureActive              string `json:"CHE_INFRASTRUCTURE_ACTIVE"`
 	CheInfraKubernetesServiceAccountName string `json:"CHE_INFRA_KUBERNETES_SERVICE__ACCOUNT__NAME"`
-	BootstrapperBinaryUrl                string `json:"CHE_INFRA_KUBERNETES_BOOTSTRAPPER_BINARY__URL"`
 	WorkspacesNamespace                  string `json:"CHE_INFRA_OPENSHIFT_PROJECT"`
 	PvcStrategy                          string `json:"CHE_INFRA_KUBERNETES_PVC_STRATEGY"`
 	PvcClaimSize                         string `json:"CHE_INFRA_KUBERNETES_PVC_QUANTITY"`
@@ -159,7 +158,6 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 		CheDebugServer:                       cheDebug,
 		CheInfrastructureActive:              infra,
 		CheInfraKubernetesServiceAccountName: "che-workspace",
-		BootstrapperBinaryUrl:                protocol + "://" + cheHost + "/agent-binaries/linux_amd64/bootstrapper/bootstrapper",
 		WorkspacesNamespace:                  workspacesNamespace,
 		PvcStrategy:                          pvcStrategy,
 		PvcClaimSize:                         pvcClaimSize,

--- a/pkg/deploy/che_configmap_test.go
+++ b/pkg/deploy/che_configmap_test.go
@@ -12,7 +12,6 @@
 package deploy
 
 import (
-	"strings"
 	"testing"
 
 	orgv1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
@@ -31,7 +30,6 @@ func TestNewCheConfigMap(t *testing.T) {
 	cheEnv := GetConfigMapData(cr)
 	testCm := NewCheConfigMap(cr, cheEnv)
 	identityProvider := testCm.Data["CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER"]
-	protocol := strings.Split(testCm.Data["CHE_INFRA_KUBERNETES_BOOTSTRAPPER_BINARY__URL"], "://")[0]
 	_, isOpenshiftv4, _ := util.DetectOpenShift()
 	expectedIdentityProvider := "openshift-v3"
 	if isOpenshiftv4 {


### PR DESCRIPTION
The env var `CHE_INFRA_KUBERNETES_BOOTSTRAPPER_BINARY__URL` is from Che 6 and no longer needed/useful.

See: https://github.com/eclipse/che/issues/14633