### PR TITLE
Correctly manage `che.properties`-located docker images for CRW (jira crw-468) 

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -183,6 +183,9 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 		WorkspaceNoProxy:                     cheWorkspaceNoProxy,
 		PluginRegistryUrl:                    pluginRegistryUrl,
 		DevfileRegistryUrl:                   devfileRegistryUrl,
+		CheWorkspacePluginBrokerInitImage:    DefaultCheWorkspacePluginBrokerInitImage(cr, cheFlavor),
+		CheWorkspacePluginBrokerUnifiedImage: DefaultCheWorkspacePluginBrokerUnifiedImage(cr, cheFlavor),
+		CheServerSecureExposerJwtProxyImage:  DefaultCheServerSecureExposerJwtProxyImage(cr, cheFlavor),
 	}
 
 	out, err := json.Marshal(data)
@@ -208,9 +211,6 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	}
 
 	addMap(cheEnv, cr.Spec.Server.CustomCheProperties)
-	if cr.IsAirGapMode() {
-		addMap(cheEnv, extraImagesConfig(cr))
-	}
 	return cheEnv
 }
 
@@ -228,13 +228,4 @@ func NewCheConfigMap(cr *orgv1.CheCluster, cheEnv map[string]string) *corev1.Con
 		},
 		Data: cheEnv,
 	}
-}
-
-func extraImagesConfig(cr *orgv1.CheCluster) map[string]string {
-	extraImages := map[string]string{
-		"CHE_WORKSPACE_PLUGIN__BROKER_INIT_IMAGE":    patchDefaultImageName(cr, cheWorkspacePluginBrokerInitImage),
-		"CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE": patchDefaultImageName(cr, cheWorkspacePluginBrokerUnifiedImage),
-		"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE":  patchDefaultImageName(cr, cheServerSecureExposerJwtProxyImage),
-	}
-	return extraImages
 }

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -63,6 +63,15 @@ const (
 	DefaultSecurityContextFsGroup   = "1724"
 	DefaultSecurityContextRunAsUser = "1724"
 
+	// CRW images for that are mentioned in the Che server che.properties
+	// For CRW these should be synced by hand with images stored in RH registries
+	// instead of being synced by script with the content of the upstream `che.properties` file
+	// NB:
+	// The upstream equivent are stored in the generated `extra_images.go` source file.
+	defaultCheWorkspacePluginBrokerInitImage    = "quay.io/crw/pluginbrokerinit-rhel8:2.0-6"
+	defaultCheWorkspacePluginBrokerUnifiedImage = "quay.io/crw/pluginbroker-rhel8:2.0-5"
+	defaultCheServerSecureExposerJwtProxyImage  = "quay.io/crw/jwtproxy-rhel8:2.0-4"
+
 	// This is only to correctly  manage defaults during the transition
 	// from Upstream 7.0.0 GA to the next version
 	// That fixed bug https://github.com/eclipse/che/issues/13714
@@ -136,6 +145,51 @@ func DefaultDevfileRegistryImage(cr *orgv1.CheCluster, cheFlavor string) string 
 		return patchDefaultImageName(cr, defaultDevfileRegistryImage)
 	} else {
 		return patchDefaultImageName(cr, defaultDevfileRegistryUpstreamImage)
+	}
+}
+
+func DefaultCheWorkspacePluginBrokerInitImage(cr *orgv1.CheCluster, cheFlavor string) string {
+	if cheFlavor == "codeready" {
+		// In the CRW case, we should always set the plugin broker image in the Che config map
+		return patchDefaultImageName(cr, defaultCheWorkspacePluginBrokerInitImage)
+	} else {
+		// In the Upstream Che case, the default will be provided by the Che server `che.properties` file
+		// if we return an empty string here.
+		// We only need to override it in case of AirGap mode
+		if cr.IsAirGapMode() {
+			return patchDefaultImageName(cr, defaultCheWorkspacePluginBrokerInitUpstreamImage)
+		}
+		return ""
+	}
+}
+
+func DefaultCheWorkspacePluginBrokerUnifiedImage(cr *orgv1.CheCluster, cheFlavor string) string {
+	if cheFlavor == "codeready" {
+		// In the CRW case, we should always set the plugin broker image in the Che config map
+		return patchDefaultImageName(cr, defaultCheWorkspacePluginBrokerUnifiedImage)
+	} else {
+		// In the Upstream Che case, the default will be provided by the Che server `che.properties` file
+		// if we return an empty string here.
+		// We only need to override it in case of AirGap mode
+		if cr.IsAirGapMode() {
+			return patchDefaultImageName(cr, defaultCheWorkspacePluginBrokerUnifiedUpstreamImage)
+		}
+		return ""
+	}
+}
+
+func DefaultCheServerSecureExposerJwtProxyImage(cr *orgv1.CheCluster, cheFlavor string) string {
+	if cheFlavor == "codeready" {
+		// In the CRW case, we should always set the jwt-proxy image in the Che config map
+		return patchDefaultImageName(cr, defaultCheServerSecureExposerJwtProxyImage)
+	} else {
+		// In the Upstream Che case, the default will be provided by the Che server `che.properties` file
+		// if we return an empty string here.
+		// We only need to override it in case of AirGap mode
+		if cr.IsAirGapMode() {
+			return patchDefaultImageName(cr, defaultCheServerSecureExposerJwtProxyUpstreamImage)
+		}
+		return ""
 	}
 }
 

--- a/pkg/deploy/extra_images.go
+++ b/pkg/deploy/extra_images.go
@@ -2,7 +2,7 @@
 package deploy
 
 const (
-	cheWorkspacePluginBrokerInitImage    = "eclipse/che-init-plugin-broker:v0.22"
-	cheWorkspacePluginBrokerUnifiedImage = "eclipse/che-unified-plugin-broker:v0.22"
-	cheServerSecureExposerJwtProxyImage  = "quay.io/eclipse/che-jwtproxy:dbd0578"
+	defaultCheWorkspacePluginBrokerInitUpstreamImage    = "eclipse/che-init-plugin-broker:v0.22"
+	defaultCheWorkspacePluginBrokerUnifiedUpstreamImage = "eclipse/che-unified-plugin-broker:v0.22"
+	defaultCheServerSecureExposerJwtProxyUpstreamImage  = "quay.io/eclipse/che-jwtproxy:dbd0578"
 )

--- a/release-operator-code.sh
+++ b/release-operator-code.sh
@@ -76,9 +76,9 @@ cat << EOF > pkg/deploy/extra_images.go
 package deploy
 
 const (
-	cheWorkspacePluginBrokerInitImage    = "${latestCheWorkspacePluginBrokerInitImage}"
-	cheWorkspacePluginBrokerUnifiedImage = "${latestCheWorkspacePluginBrokerUnifiedImage}"
-	cheServerSecureExposerJwtProxyImage  = "${latestCheServerSecureExposerJwtProxyImage}"
+	defaultCheWorkspacePluginBrokerInitUpstreamImage    = "${latestCheWorkspacePluginBrokerInitImage}"
+	defaultCheWorkspacePluginBrokerUnifiedUpstreamImage = "${latestCheWorkspacePluginBrokerUnifiedImage}"
+	defaultCheServerSecureExposerJwtProxyUpstreamImage  = "${latestCheServerSecureExposerJwtProxyImage}"
 )
 EOF
 


### PR DESCRIPTION
This PR is a fix in the operator for the issue https://issues.jboss.org/browse/CRW-468

It enables correctly getting CRW-specific images for the 3 containers whose docker images is specified in the upstream Che server `che.properties` file.