### PR TITLE
check script parameter

### DIFF
--- a/build_deploy_local.sh
+++ b/build_deploy_local.sh
@@ -14,15 +14,21 @@
 
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 
+if [ -z "${1}" ]; then
+  echo "missing namespace parameter './build_deploy_local.sh <che-namespace>'"
+  exit 1
+fi
+NAMESPACE=${1}
+
 docker build -t che/operator .
-kubectl apply -f ${BASE_DIR}/deploy/service_account.yaml -n=$1
-kubectl apply -f ${BASE_DIR}/deploy/role.yaml -n=$1
-kubectl apply -f ${BASE_DIR}/deploy/role_binding.yaml -n=$1
-kubectl apply -f ${BASE_DIR}/deploy/crds/org_v1_che_crd.yaml -n=$1
+kubectl apply -f ${BASE_DIR}/deploy/service_account.yaml -n="${NAMESPACE}"
+kubectl apply -f ${BASE_DIR}/deploy/role.yaml -n="${NAMESPACE}"
+kubectl apply -f ${BASE_DIR}/deploy/role_binding.yaml -n="${NAMESPACE}"
+kubectl apply -f ${BASE_DIR}/deploy/crds/org_v1_che_crd.yaml -n="${NAMESPACE}"
 # sometimes the operator cannot get CRD right away
 sleep 2
 # uncomment when on OpenShift if you need login with OpenShift in Che
-#oc new-app -f ${BASE_DIR}/deploy/role_binding_oauth.yaml -p NAMESPACE=$1 -n=$1
-#oc apply -f ${BASE_DIR}/deploy/cluster_role.yaml -n=$1
-kubectl apply -f ${BASE_DIR}/deploy/operator-local.yaml -n=$1
-kubectl apply -f ${BASE_DIR}/deploy/crds/org_v1_che_cr.yaml -n=$1
+#oc new-app -f ${BASE_DIR}/deploy/role_binding_oauth.yaml -p NAMESPACE="${NAMESPACE}" -n="${NAMESPACE}"
+#oc apply -f ${BASE_DIR}/deploy/cluster_role.yaml -n="${NAMESPACE}"
+kubectl apply -f ${BASE_DIR}/deploy/operator-local.yaml -n="${NAMESPACE}"
+kubectl apply -f ${BASE_DIR}/deploy/crds/org_v1_che_cr.yaml -n="${NAMESPACE}"


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

It doesn't make sense to run `build_deploy_local.sh` without namespace parameter. This PR checks the parameter and `exit 1` with meaningful message if it's missing.