### PR TITLE
Provide easier migration from 1.2 to 2.0

### DIFF
--- a/pkg/controller/che/create.go
+++ b/pkg/controller/che/create.go
@@ -477,23 +477,35 @@ func (r *ReconcileChe) GenerateAndSaveFields(instance *orgv1.CheCluster, request
 	// from Upstream 7.0.0 GA to the next
 	// version that should fixed bug https://github.com/eclipse/che/issues/13714
 
-	if instance.Spec.Storage.PvcJobsImage == deploy.OldDefaultPvcJobsUpstreamImageToDetect {
+	if instance.Spec.Storage.PvcJobsImage == deploy.OldDefaultPvcJobsUpstreamImageToDetect ||
+		deploy.MigratingToCRW2_0(instance) {
 		instance.Spec.Storage.PvcJobsImage = ""
 		if err := r.UpdateCheCRSpec(instance, "pvc jobs image", instance.Spec.Storage.PvcJobsImage); err != nil {
 			return err
 		}
 	}
 
-	if instance.Spec.Database.PostgresImage == deploy.OldDefaultPostgresUpstreamImageToDetect {
+	if instance.Spec.Database.PostgresImage == deploy.OldDefaultPostgresUpstreamImageToDetect ||
+		deploy.MigratingToCRW2_0(instance) {
 		instance.Spec.Database.PostgresImage = ""
 		if err := r.UpdateCheCRSpec(instance, "postgres image", instance.Spec.Database.PostgresImage); err != nil {
 			return err
 		}
 	}
 
-	if instance.Spec.Auth.IdentityProviderImage == deploy.OldDefaultKeycloakUpstreamImageToDetect {
+	if instance.Spec.Auth.IdentityProviderImage == deploy.OldDefaultKeycloakUpstreamImageToDetect ||
+		deploy.MigratingToCRW2_0(instance) {
 		instance.Spec.Auth.IdentityProviderImage = ""
 		if err := r.UpdateCheCRSpec(instance, "keycloak image", instance.Spec.Auth.IdentityProviderImage); err != nil {
+			return err
+		}
+	}
+
+	if deploy.MigratingToCRW2_0(instance) &&
+		! instance.Spec.Server.ExternalPluginRegistry &&
+		instance.Spec.Server.PluginRegistryUrl == "https://che-plugin-registry.openshift.io" {
+		instance.Spec.Server.PluginRegistryUrl = ""
+		if err := r.UpdateCheCRSpec(instance, "plugin registry url", instance.Spec.Server.PluginRegistryUrl); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/che/create.go
+++ b/pkg/controller/che/create.go
@@ -476,9 +476,10 @@ func (r *ReconcileChe) GenerateAndSaveFields(instance *orgv1.CheCluster, request
 	// This is only to correctly  manage defaults during the transition
 	// from Upstream 7.0.0 GA to the next
 	// version that should fixed bug https://github.com/eclipse/che/issues/13714
+	// Or for the transition from CRW 1.2 to 2.0
 
 	if instance.Spec.Storage.PvcJobsImage == deploy.OldDefaultPvcJobsUpstreamImageToDetect ||
-		deploy.MigratingToCRW2_0(instance) {
+		(deploy.MigratingToCRW2_0(instance) && instance.Spec.Storage.PvcJobsImage != "") {
 		instance.Spec.Storage.PvcJobsImage = ""
 		if err := r.UpdateCheCRSpec(instance, "pvc jobs image", instance.Spec.Storage.PvcJobsImage); err != nil {
 			return err
@@ -486,7 +487,7 @@ func (r *ReconcileChe) GenerateAndSaveFields(instance *orgv1.CheCluster, request
 	}
 
 	if instance.Spec.Database.PostgresImage == deploy.OldDefaultPostgresUpstreamImageToDetect ||
-		deploy.MigratingToCRW2_0(instance) {
+		(deploy.MigratingToCRW2_0(instance) && instance.Spec.Database.PostgresImage != "") {
 		instance.Spec.Database.PostgresImage = ""
 		if err := r.UpdateCheCRSpec(instance, "postgres image", instance.Spec.Database.PostgresImage); err != nil {
 			return err
@@ -494,7 +495,7 @@ func (r *ReconcileChe) GenerateAndSaveFields(instance *orgv1.CheCluster, request
 	}
 
 	if instance.Spec.Auth.IdentityProviderImage == deploy.OldDefaultKeycloakUpstreamImageToDetect ||
-		deploy.MigratingToCRW2_0(instance) {
+		(deploy.MigratingToCRW2_0(instance) && instance.Spec.Auth.IdentityProviderImage != "") {
 		instance.Spec.Auth.IdentityProviderImage = ""
 		if err := r.UpdateCheCRSpec(instance, "keycloak image", instance.Spec.Auth.IdentityProviderImage); err != nil {
 			return err
@@ -503,9 +504,25 @@ func (r *ReconcileChe) GenerateAndSaveFields(instance *orgv1.CheCluster, request
 
 	if deploy.MigratingToCRW2_0(instance) &&
 		! instance.Spec.Server.ExternalPluginRegistry &&
-		instance.Spec.Server.PluginRegistryUrl == "https://che-plugin-registry.openshift.io" {
+		instance.Spec.Server.PluginRegistryUrl == deploy.OldCrwPluginRegistryUrl {
 		instance.Spec.Server.PluginRegistryUrl = ""
 		if err := r.UpdateCheCRSpec(instance, "plugin registry url", instance.Spec.Server.PluginRegistryUrl); err != nil {
+			return err
+		}
+	}
+
+	if deploy.MigratingToCRW2_0(instance) &&
+		instance.Spec.Server.CheImage == deploy.OldDefaultCodeReadyServerImageRepo {
+		instance.Spec.Server.CheImage = ""
+		if err := r.UpdateCheCRSpec(instance, "che image repo", instance.Spec.Server.CheImage); err != nil {
+			return err
+		}
+	}
+
+	if deploy.MigratingToCRW2_0(instance) &&
+		instance.Spec.Server.CheImageTag == deploy.OldDefaultCodeReadyServerImageTag {
+		instance.Spec.Server.CheImageTag = ""
+		if err := r.UpdateCheCRSpec(instance, "che image tag", instance.Spec.Server.CheImageTag); err != nil {
 			return err
 		}
 	}

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -79,6 +79,10 @@ const (
 	OldDefaultPvcJobsUpstreamImageToDetect  = "registry.access.redhat.com/ubi8-minimal:8.0-127"
 	OldDefaultPostgresUpstreamImageToDetect = "centos/postgresql-96-centos7:9.6"
 
+	OldDefaultCodeReadyServerImageRepo="registry.redhat.io/codeready-workspaces/server-operator-rhel8"
+	OldDefaultCodeReadyServerImageTag="1.2"
+	OldCrwPluginRegistryUrl="https://che-plugin-registry.openshift.io"
+	
 	// ConsoleLink default
 	DefaultConsoleLinkName                = "che"
 	DefaultConsoleLinkSection             = "Red Hat Applications"
@@ -86,6 +90,7 @@ const (
 	defaultConsoleLinkUpstreamDisplayName = "Eclipse Che"
 	defaultConsoleLinkDisplayName         = "CodeReady Workspaces"
 )
+
 
 func MigratingToCRW2_0(cr *orgv1.CheCluster) bool {
 	if cr.Spec.Server.CheFlavor == "codeready" &&

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -24,7 +24,7 @@ const (
 	defaultCodeReadyServerImageRepo     = "quay.io/crw/server-rhel8"
 	defaultCheServerImageTag            = "7.3.1"
 	defaultCodeReadyServerImageTag      = "2.0-384"
-	DefaultCheFlavor                    = "codeready"
+	DefaultCheFlavor                    = "che"
 	DefaultChePostgresUser              = "pgche"
 	DefaultChePostgresHostName          = "postgres"
 	DefaultChePostgresPort              = "5432"

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -87,6 +87,15 @@ const (
 	defaultConsoleLinkDisplayName         = "CodeReady Workspaces"
 )
 
+func MigratingToCRW2_0(cr *orgv1.CheCluster) bool {
+	if cr.Spec.Server.CheFlavor == "codeready" &&
+		strings.HasPrefix(cr.Status.CheVersion, "1.2") &&
+		strings.HasPrefix(defaultCodeReadyServerImageTag, "2.0") {
+		return true
+	}
+	return false
+}
+
 func DefaultConsoleLinkDisplayName(cheFlavor string) string {
 	if cheFlavor == "codeready" {
 		return defaultConsoleLinkDisplayName


### PR DESCRIPTION
This PR is a fix for https://issues.jboss.org/browse/CRW-455.

It should avoid the requirement of manually cleaning the CustomResource when upgrading CRW from 1.2 to 2.0 