### PR TITLE
fix: This is a fixup of PR #119 (Provide easier migration from 1.2 to 2.0)

### DIFF
--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -79,10 +79,10 @@ const (
 	OldDefaultPvcJobsUpstreamImageToDetect  = "registry.access.redhat.com/ubi8-minimal:8.0-127"
 	OldDefaultPostgresUpstreamImageToDetect = "centos/postgresql-96-centos7:9.6"
 
-	OldDefaultCodeReadyServerImageRepo="registry.redhat.io/codeready-workspaces/server-operator-rhel8"
-	OldDefaultCodeReadyServerImageTag="1.2"
-	OldCrwPluginRegistryUrl="https://che-plugin-registry.openshift.io"
-	
+	OldDefaultCodeReadyServerImageRepo = "registry.redhat.io/codeready-workspaces/server-rhel8"
+	OldDefaultCodeReadyServerImageTag  = "1.2"
+	OldCrwPluginRegistryUrl            = "https://che-plugin-registry.openshift.io"
+
 	// ConsoleLink default
 	DefaultConsoleLinkName                = "che"
 	DefaultConsoleLinkSection             = "Red Hat Applications"
@@ -90,7 +90,6 @@ const (
 	defaultConsoleLinkUpstreamDisplayName = "Eclipse Che"
 	defaultConsoleLinkDisplayName         = "CodeReady Workspaces"
 )
-
 
 func MigratingToCRW2_0(cr *orgv1.CheCluster) bool {
 	if cr.Spec.Server.CheFlavor == "codeready" &&


### PR DESCRIPTION
This is a fixup of PR #119 (Provide easier migration from 1.2 to 2.0).
There was a wrong docker image references, that finally prevented the 1.2 Che server docker to e automatically updated to the 2.0 one.