### PR TITLE
Cherry-pick PR #126 (Add environment variable for JGroups labels)

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -67,6 +67,7 @@ type CheConfigMap struct {
 	CheWorkspacePluginBrokerInitImage    string `json:"CHE_WORKSPACE_PLUGIN__BROKER_INIT_IMAGE,omitempty"`
 	CheWorkspacePluginBrokerUnifiedImage string `json:"CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE,omitempty"`
 	CheServerSecureExposerJwtProxyImage  string `json:"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE,omitempty"`
+	CheJGroupsKubernetesLabels           string `json:"KUBERNETES_LABEL,omitempty"`
 }
 
 // GetConfigMapData gets env values from CR spec and returns a map with key:value
@@ -147,6 +148,7 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	pluginRegistryUrl := cr.Status.PluginRegistryURL
 	cheLogLevel := util.GetValue(cr.Spec.Server.CheLogLevel, DefaultCheLogLevel)
 	cheDebug := util.GetValue(cr.Spec.Server.CheDebug, DefaultCheDebug)
+	cheLabels := util.MapToKeyValuePairs(GetLabels(cr, util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor)))
 
 	data := &CheConfigMap{
 		CheMultiUser:                         "true",
@@ -186,6 +188,7 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 		CheWorkspacePluginBrokerInitImage:    DefaultCheWorkspacePluginBrokerInitImage(cr, cheFlavor),
 		CheWorkspacePluginBrokerUnifiedImage: DefaultCheWorkspacePluginBrokerUnifiedImage(cr, cheFlavor),
 		CheServerSecureExposerJwtProxyImage:  DefaultCheServerSecureExposerJwtProxyImage(cr, cheFlavor),
+		CheJGroupsKubernetesLabels:           cheLabels,
 	}
 
 	out, err := json.Marshal(data)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -25,6 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"strings"
 	"time"
+	"bytes"
+	"fmt"
 )
 
 
@@ -59,6 +61,14 @@ func GeneratePasswd(stringLength int) (passwd string) {
 	}
 	passwd = string(buf)
 	return passwd
+}
+
+func MapToKeyValuePairs(m map[string]string) string {
+	buff := new(bytes.Buffer)
+	for key, value := range m {
+		fmt.Fprintf(buff, "%s=%s,", key, value)
+	}
+	return strings.TrimSuffix(buff.String(), ",")
 }
 
 func DetectOpenShift() (isOpenshift bool, isOpenshift4 bool, anError error) {


### PR DESCRIPTION
This PR cherry-picks the PR #126: Add environment variable for JGroups labels

This is import to allow JGroups labels to correctly reference the CRW Che server PODS. in the case of CRW, the labels for Che server pods use the `codeready` flavor, instead of `che`, and it has to be propagated to the Che server through this new environment variable.
If it is not the case, restarting the CRW Che server with running workspaces may lead to inconsistencies.