### PR TITLE
Align JGroups labels property name with original one in KUBE_PING

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -67,7 +67,7 @@ type CheConfigMap struct {
 	CheWorkspacePluginBrokerInitImage    string `json:"CHE_WORKSPACE_PLUGIN__BROKER_INIT_IMAGE,omitempty"`
 	CheWorkspacePluginBrokerUnifiedImage string `json:"CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE,omitempty"`
 	CheServerSecureExposerJwtProxyImage  string `json:"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE,omitempty"`
-	CheJGroupsKubernetesLabels           string `json:"KUBERNETES_LABEL,omitempty"`
+	CheJGroupsKubernetesLabels           string `json:"KUBERNETES_LABELS,omitempty"`
 }
 
 // GetConfigMapData gets env values from CR spec and returns a map with key:value


### PR DESCRIPTION
Align JGroups labels property name with original one in `KUBE_PING`
(see https://github.com/jgroups-extras/jgroups-kubernetes/blob/master/src/main/java/org/jgroups/protocols/kubernetes/KUBE_PING.java#L81) 
So possible naming confusions may be avoided in future.
Issue to `KUBE_PING` upstream to align their documentation: https://github.com/jgroups-extras/jgroups-kubernetes/issues/79