### PR TITLE
Fix the JIRA issue CRW-514 (constant Che server rollout) 

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,6 +12,7 @@
 package util
 
 import (
+	"sort"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -65,8 +66,16 @@ func GeneratePasswd(stringLength int) (passwd string) {
 
 func MapToKeyValuePairs(m map[string]string) string {
 	buff := new(bytes.Buffer)
-	for key, value := range m {
-		fmt.Fprintf(buff, "%s=%s,", key, value)
+	keys := make([]string, 0, len(m))
+
+	for key := range m {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys) //sort keys alphabetically
+
+	for _, key := range keys {
+		fmt.Fprintf(buff, "%s=%s,", key, m[key])
 	}
 	return strings.TrimSuffix(buff.String(), ",")
 }


### PR DESCRIPTION
This PR fixes the bug https://issues.jboss.org/browse/CRW-514 that was introduced by PR https://github.com/eclipse/che-operator/pull/126

In order to fix this bug, it mainly orders map keys in alphabetic order when converting a map to string

Signed-off-by: David Festal <dfestal@redhat.com>