### PR TITLE
🚧 don't create che-workspace sa

### DIFF
--- a/pkg/controller/che/che_controller_test.go
+++ b/pkg/controller/che/che_controller_test.go
@@ -12,8 +12,8 @@
 package che
 
 import (
-	"github.com/eclipse/che-operator/pkg/deploy"
 	"context"
+	"github.com/eclipse/che-operator/pkg/deploy"
 	"time"
 
 	console "github.com/openshift/api/console/v1"
@@ -26,7 +26,6 @@ import (
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacapi "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -167,10 +166,8 @@ func TestCheController(t *testing.T) {
 		t.Errorf("Custom config map should be deleted and merged with Che ConfigMap")
 	}
 
-	// Get the custom role binding that should have been created for the role we passed in
-	rb := &rbacapi.RoleBinding{}
-	if err := cl.Get(context.TODO(), types.NamespacedName{Name: "che-workspace-custom", Namespace: cheCR.Namespace}, rb); err != nil {
-		t.Errorf("Custom role binding %s not found: %s", rb.Name, err)
+	if cm.Data["CHE_INFRA_KUBERNETES_CLUSTER__ROLE__NAME"] != "cluster-admin" {
+		t.Errorf("Custom cluter role not set in configmap")
 	}
 
 	// run a few checks to make sure the operator reconciled tls routes and updated configmap

--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -70,6 +70,7 @@ type CheConfigMap struct {
 	CheWorkspacePluginBrokerUnifiedImage string `json:"CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE,omitempty"`
 	CheServerSecureExposerJwtProxyImage  string `json:"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE,omitempty"`
 	CheJGroupsKubernetesLabels           string `json:"KUBERNETES_LABELS,omitempty"`
+	CheClusterRole                       string `json:"CHE_INFRA_KUBERNETES_CLUSTER__ROLE__NAME"`
 }
 
 // GetConfigMapData gets env values from CR spec and returns a map with key:value
@@ -153,6 +154,7 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	cheDebug := util.GetValue(cr.Spec.Server.CheDebug, DefaultCheDebug)
 	cheMetrics := strconv.FormatBool(cr.Spec.Metrics.Enable)
 	cheLabels := util.MapToKeyValuePairs(GetLabels(cr, util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor)))
+	cheWorkspaceClusterRole := util.GetValue(cr.Spec.Server.CheWorkspaceClusterRole, "")
 
 	data := &CheConfigMap{
 		CheMultiUser:                         "true",
@@ -195,6 +197,7 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 		CheServerSecureExposerJwtProxyImage:  DefaultCheServerSecureExposerJwtProxyImage(cr, cheFlavor),
 		CheJGroupsKubernetesLabels:           cheLabels,
 		CheMetricsEnabled:                    cheMetrics,
+		CheClusterRole:                       cheWorkspaceClusterRole,
 	}
 
 	out, err := json.Marshal(data)


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

che-server is responsible for `che-workspace` serviceaccount.

**This PR**
- don't create `che-workspace` sa
- pass `CheWorkspaceClusterRole` as `CHE_INFRA_KUBERNETES_CLUSTER__ROLE__NAME` to configmap for the server

TODO:
 - [x] fix che_controller test
```
--- FAIL: TestCheController (31.04s)
    che_controller_test.go:173: Custom role binding  not found: rolebindings.rbac.authorization.k8s.io "che-workspace-custom" not found
```

Issue: https://github.com/eclipse/che/issues/15300