### PR TITLE
Fix a CRD change that is incompatible with OS 3.11

### DIFF
--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -24,8 +24,6 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: The `CheCluster` custom resource allows defining and managing a
-        Che server installation
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -499,7 +497,6 @@ spec:
                 the pod is in this state.
               type: string
           type: object
-      type: object
   version: v1
   versions:
   - name: v1

--- a/olm/README.md
+++ b/olm/README.md
@@ -5,6 +5,8 @@ OLM packages scripts are using some required dependencies that need to be instal
  - [https://github.com/kislyuk/yq](https://github.com/kislyuk/yq) and not [http://mikefarah.github.io/yq/](http://mikefarah.github.io/yq/)
  - [Operator SDK v0.10.0](https://github.com/operator-framework/operator-sdk/blob/v0.10.0/doc/user/install-operator-sdk.md)
 
+WARNING: Please make sure to use the precise `v0.10.0` version of the `operator-sdk`. If you use a more recent version, you might generate a CRD that is not compatible with Kubernetes 1.11 and Openshift 3.11 (see issue https://github.com/eclipse/che/issues/15396).
+
 If these dependencies are not installed, `docker-run.sh` can be used as a container bootstrap to run a given script with the appropriate dependencies.
 
 Example : `$ docker-run.sh update-nightly-olm-files.sh`


### PR DESCRIPTION
This PR fixes issue https://github.com/eclipse/che/issues/15396 :
*Invalid CRD openAPIV3Schema on OpenShift 3.11*

It seems that the last CRD generation that was applied on this repository was probably done with an `operator-sdk` > 0.10.0.
It added a `type: object` field  (and description) at the root of the `spec.validation.openAPIV3Schema` field.

This makes the CRD invalid for Kubernetes 1.11 (on which Openshift 3.11 is based), since this version of Kubernetes had the following bug: https://github.com/kubernetes/kubernetes/issues/65293.

This PR removes the added optional fields that made the CRD invalid for OS 3.11