### PR TITLE
che #15504 Release 7.6.0 version of the che-operator

### DIFF
--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.6.0/eclipse-che-preview-kubernetes.crd.yaml
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.6.0/eclipse-che-preview-kubernetes.crd.yaml
@@ -1,0 +1,507 @@
+#
+#  Copyright (c) 2012-2019 Red Hat, Inc.
+#    This program and the accompanying materials are made
+#    available under the terms of the Eclipse Public License 2.0
+#    which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#    Red Hat, Inc. - initial API and implementation
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: checlusters.org.eclipse.che
+spec:
+  group: org.eclipse.che
+  names:
+    kind: CheCluster
+    listKind: CheClusterList
+    plural: checlusters
+    singular: checluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: The `CheCluster` custom resource allows defining and managing a
+        Che server installation
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Desired configuration of the Che installation. Based on these
+            settings, the operator automatically creates and maintains several config
+            maps that will contain the appropriate environment variables the various
+            components of the Che installation. These generated config maps should
+            NOT be updated manually.
+          properties:
+            auth:
+              description: Configuration settings related to the Authentication used
+                by the Che installation.
+              properties:
+                externalIdentityProvider:
+                  description: 'Instructs the operator on whether or not to deploy
+                    a dedicated Identity Provider (Keycloak or RH SSO instance). By
+                    default a dedicated Identity Provider server is deployed as part
+                    of the Che installation. But if `externalIdentityProvider` is
+                    `true`, then no dedicated identity provider will be deployed by
+                    the operator and you might need to provide details about the external
+                    identity provider you want to use. See also all the other fields
+                    starting with: `identityProvider`.'
+                  type: boolean
+                identityProviderAdminUserName:
+                  description: Overrides the name of the Identity Provider admin user.
+                    Defaults to `admin`.
+                  type: string
+                identityProviderClientId:
+                  description: Name of a Identity provider (Keycloak / RH SSO) `client-id`
+                    that should be used for Che. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to the value
+                    of the `flavour` field suffixed with `-public`.
+                  type: string
+                identityProviderImage:
+                  description: Overrides the container image used in the Identity
+                    Provider (Keycloak / RH SSO) deployment. This includes the image
+                    tag. Omit it or leave it empty to use the defaut container image
+                    provided by the operator.
+                  type: string
+                identityProviderImagePullPolicy:
+                  description: Overrides the image pull policy used in the Identity
+                    Provider (Keycloak / RH SSO) deployment. Default value is `Always`
+                    for `nightly` or `latest` images, and `IfNotPresent` in other
+                    cases.
+                  type: string
+                identityProviderPassword:
+                  description: Overrides the password of Keycloak admin user. This
+                    is useful to override it ONLY if you use an external Identity
+                    Provider (see the `externalIdentityProvider` field). If omitted
+                    or left blank, it will be set to an auto-generated password.
+                  type: string
+                identityProviderPostgresPassword:
+                  description: Password for The Identity Provider (Keycloak / RH SSO)
+                    to connect to the database. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to an auto-generated
+                    password.
+                  type: string
+                identityProviderRealm:
+                  description: Name of a Identity provider (Keycloak / RH SSO) realm
+                    that should be used for Che. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to the value
+                    of the `flavour` field.
+                  type: string
+                identityProviderURL:
+                  description: Public URL of the Identity Provider server (Keycloak
+                    / RH SSO server). You should set it ONLY if you use an external
+                    Identity Provider (see the `externalIdentityProvider` field).
+                    By default this will be automatically calculated and set by the
+                    operator.
+                  type: string
+                oAuthClientName:
+                  description: Name of the OpenShift `OAuthClient` resource used to
+                    setup identity federation on the OpenShift side. Auto-generated
+                    if left blank. See also the `OpenShiftoAuth` field.
+                  type: string
+                oAuthSecret:
+                  description: Name of the secret set in the OpenShift `OAuthClient`
+                    resource used to setup identity federation on the OpenShift side.
+                    Auto-generated if left blank. See also the `OAuthClientName` field.
+                  type: string
+                openShiftoAuth:
+                  description: 'Enables the integration of the identity provider (Keycloak
+                    / RHSSO) with OpenShift OAuth. Enabled by defaumt on OpenShift.
+                    This will allow users to directly login with their Openshift user
+                    throug the Openshift login, and have their workspaces created
+                    under personnal OpenShift namespaces. WARNING: the `kuebadmin`
+                    user is NOT supported, and logging through it will NOT allow accessing
+                    the Che Dashboard.'
+                  type: boolean
+                updateAdminPassword:
+                  description: Forces the default `admin` Che user to update password
+                    on first login. Defaults to `false`.
+                  type: boolean
+              type: object
+            database:
+              description: Configuration settings related to the database used by
+                the Che installation.
+              properties:
+                chePostgresDb:
+                  description: Postgres database name that the Che server uses to
+                    connect to the DB. Defaults to `dbche`.
+                  type: string
+                chePostgresHostName:
+                  description: Postgres Database hostname that the Che server uses
+                    to connect to. Defaults to postgres. This value should be overridden
+                    ONLY when using an external database (see field `externalDb`).
+                    In the default case it will be automatically set by the operator.
+                  type: string
+                chePostgresPassword:
+                  description: Postgres password that the Che server should use to
+                    connect to the DB. If omitted or left blank, it will be set to
+                    an auto-generated value.
+                  type: string
+                chePostgresPort:
+                  description: Postgres Database port that the Che server uses to
+                    connect to. Defaults to 5432. This value should be overridden
+                    ONLY when using an external database (see field `externalDb`).
+                    In the default case it will be automatically set by the operator.
+                  type: string
+                chePostgresUser:
+                  description: Postgres user that the Che server should use to connect
+                    to the DB. Defaults to `pgche`.
+                  type: string
+                externalDb:
+                  description: 'Instructs the operator on whether or not to deploy
+                    a dedicated database. By default a dedicated Postgres database
+                    is deployed as part of the Che installation. But if `externalDb`
+                    is `true`, then no dedicated database will be deployed by the
+                    operator and you might need to provide connection details to the
+                    external DB you want to use. See also all the fields starting
+                    with: `chePostgres`.'
+                  type: boolean
+                postgresImage:
+                  description: Overrides the container image used in the Postgres
+                    database deployment. This includes the image tag. Omit it or leave
+                    it empty to use the defaut container image provided by the operator.
+                  type: string
+                postgresImagePullPolicy:
+                  description: Overrides the image pull policy used in the Postgres
+                    database deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+              type: object
+            k8s:
+              description: Configuration settings specific to Che installations made
+                on upstream Kubernetes.
+              properties:
+                ingressClass:
+                  description: 'Ingress class that will define the which controler
+                    will manage ingresses. Defaults to `nginx`. NB: This drives the
+                    `is kubernetes.io/ingress.class` annotation on Che-related ingresses.'
+                  type: string
+                ingressDomain:
+                  description: 'Global ingress domain for a K8S cluster. This MUST
+                    be explicitly specified: there are no defaults.'
+                  type: string
+                ingressStrategy:
+                  description: Strategy for ingress creation. This can be `multi-host`
+                    (host is explicitly provided in ingress), `single-host` (host
+                    is provided, path-based rules) and `default-host.*`(no host is
+                    provided, path-based rules). Defaults to `"multi-host`
+                  type: string
+                securityContextFsGroup:
+                  description: FSGroup the Che pod and Workspace pods containers should
+                    run in. Defaults to `1724`.
+                  type: string
+                securityContextRunAsUser:
+                  description: ID of the user the Che pod and Workspace pods containers
+                    should run as. Default to `1724`.
+                  type: string
+                tlsSecretName:
+                  description: Name of a secret that will be used to setup ingress
+                    TLS termination if TLS is enabled. See also the `tlsSupport` field.
+                  type: string
+              type: object
+            metrics:
+              description: Configuration settings related to the metrics collection
+                used by the Che installation.
+              properties:
+                enable:
+                  description: Enables `metrics` Che server endpoint. Default to `false`.
+                  type: boolean
+              type: object
+            server:
+              description: General configuration settings related to the Che server
+                and the plugin and devfile registries
+              properties:
+                airGapContainerRegistryHostname:
+                  description: Optional hostname (or url) to an alternate container
+                    registry to pull images from. This value overrides the container
+                    registry hostname defined in all the default container images
+                    involved in a Che deployment. This is particularly useful to install
+                    Che in an air-gapped environment.
+                  type: string
+                airGapContainerRegistryOrganization:
+                  description: Optional repository name of an alternate container
+                    registry to pull images from. This value overrides the container
+                    registry organization defined in all the default container images
+                    involved in a Che deployment. This is particularly useful to install
+                    Che in an air-gapped environment.
+                  type: string
+                allowUserDefinedWorkspaceNamespaces:
+                  description: Defines if a user is able to specify Kubernetes namespace
+                    (or OpenShift project) different from the default. It's NOT RECOMMENDED
+                    to configured true without OAuth configured. This property is
+                    also used by the OpenShift infra.
+                  type: boolean
+                cheDebug:
+                  description: Enables the debug mode for Che server. Defaults to
+                    `false`.
+                  type: string
+                cheFlavor:
+                  description: Flavor of the installation. This is either `che` for
+                    upstream Che installations, or `codeready` for CodeReady Workspaces
+                    installation. In most cases the default value should not be overriden.
+                  type: string
+                cheHost:
+                  description: Public hostname of the installed Che server. This will
+                    be automatically set by the operator. In most cases the default
+                    value set by the operator should not be overriden.
+                  type: string
+                cheImage:
+                  description: Overrides the container image used in Che deployment.
+                    This does NOT include the container image tag. Omit it or leave
+                    it empty to use the defaut container image provided by the operator.
+                  type: string
+                cheImagePullPolicy:
+                  description: Overrides the image pull policy used in Che deployment.
+                    Default value is `Always` for `nightly` or `latest` images, and
+                    `IfNotPresent` in other cases.
+                  type: string
+                cheImageTag:
+                  description: Overrides the tag of the container image used in Che
+                    deployment. Omit it or leave it empty to use the defaut image
+                    tag provided by the operator.
+                  type: string
+                cheLogLevel:
+                  description: 'Log level for the Che server: `INFO` or `DEBUG`. Defaults
+                    to `INFO`.'
+                  type: string
+                cheWorkspaceClusterRole:
+                  description: Custom cluster role bound to the user for the Che workspaces.
+                    The default roles are used if this is omitted or left blank.
+                  type: string
+                customCheProperties:
+                  additionalProperties:
+                    type: string
+                  description: Map of additional environment variables that will be
+                    applied in the generated `che` config map to be used by the Che
+                    server, in addition to the values already generated from other
+                    fields of the `CheCluster` custom resource (CR). If `customCheProperties`
+                    contains a property that would be normally generated in `che`
+                    config map from other CR fields, then the value defined in the
+                    `customCheProperties` will be used instead.
+                  type: object
+                devfileRegistryImage:
+                  description: Overrides the container image used in the Devfile registry
+                    deployment. This includes the image tag. Omit it or leave it empty
+                    to use the defaut container image provided by the operator.
+                  type: string
+                devfileRegistryMemoryLimit:
+                  description: Overrides the memory limit used in the Devfile registry
+                    deployment. Defaults to 256Mi.
+                  type: string
+                devfileRegistryMemoryRequest:
+                  description: Overrides the memory request used in the Devfile registry
+                    deployment. Defaults to 16Mi.
+                  type: string
+                devfileRegistryPullPolicy:
+                  description: Overrides the image pull policy used in the Devfile
+                    registry deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+                devfileRegistryUrl:
+                  description: Public URL of the Devfile registry, that serves sample,
+                    ready-to-use devfiles. You should set it ONLY if you use an external
+                    devfile registry (see the `externalDevfileRegistry` field). By
+                    default this will be automatically calculated by the operator.
+                  type: string
+                externalDevfileRegistry:
+                  description: Instructs the operator on whether or not to deploy
+                    a dedicated Devfile registry server. By default a dedicated devfile
+                    registry server is started. But if `externalDevfileRegistry` is
+                    `true`, then no such dedicated server will be started by the operator
+                    and you will have to manually set the `devfileRegistryUrl` field
+                  type: boolean
+                externalPluginRegistry:
+                  description: Instructs the operator on whether or not to deploy
+                    a dedicated Plugin registry server. By default a dedicated plugin
+                    registry server is started. But if `externalPluginRegistry` is
+                    `true`, then no such dedicated server will be started by the operator
+                    and you will have to manually set the `pluginRegistryUrl` field.
+                  type: boolean
+                nonProxyHosts:
+                  description: List of hosts that should not use the configured proxy.
+                    Use `|`` as delimiter, eg `localhost|my.host.com|123.42.12.32`
+                    Only use when configuring a proxy is required (see also the `proxyURL`
+                    field).
+                  type: string
+                pluginRegistryImage:
+                  description: Overrides the container image used in the Plugin registry
+                    deployment. This includes the image tag. Omit it or leave it empty
+                    to use the defaut container image provided by the operator.
+                  type: string
+                pluginRegistryMemoryLimit:
+                  description: Overrides the memory limit used in the Plugin registry
+                    deployment. Defaults to 256Mi.
+                  type: string
+                pluginRegistryMemoryRequest:
+                  description: Overrides the memory request used in the Plugin registry
+                    deployment. Defaults to 16Mi.
+                  type: string
+                pluginRegistryPullPolicy:
+                  description: Overrides the image pull policy used in the Plugin
+                    registry deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+                pluginRegistryUrl:
+                  description: Public URL of the Plugin registry, that serves sample
+                    ready-to-use devfiles. You should set it ONLY if you use an external
+                    devfile registry (see the `externalPluginRegistry` field). By
+                    default this will be automatically calculated by the operator.
+                  type: string
+                proxyPassword:
+                  description: "Password of the proxy server \n Only use when proxy
+                    configuration is required (see also the `proxyUser` field)."
+                  type: string
+                proxyPort:
+                  description: Port of the proxy server. Only use when configuring
+                    a proxy is required (see also the `proxyURL` field).
+                  type: string
+                proxyURL:
+                  description: URL (protocol+hostname) of the proxy server. This drives
+                    the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy`
+                    variables in the Che server and workspaces containers. Only use
+                    when configuring a proxy is required.
+                  type: string
+                proxyUser:
+                  description: User name of the proxy server. Only use when configuring
+                    a proxy is required (see also the `proxyURL` field).
+                  type: string
+                selfSignedCert:
+                  description: Enables the support of OpenShift clusters whose router
+                    uses self-signed certificates. When enabled, the operator retrieves
+                    the default self-signed certificate of OpenShift routes and adds
+                    it to the Java trust store of the Che server. This is usually
+                    required when activating the `tlsSupport` field on demo OpenShift
+                    clusters that have not been setup with a valid certificate for
+                    the routes. This is disabled by default.
+                  type: boolean
+                serverMemoryLimit:
+                  description: Overrides the memory limit used in the Che server deployment.
+                    Defaults to 1Gi.
+                  type: string
+                serverMemoryRequest:
+                  description: Overrides the memory request used in the Che server
+                    deployment. Defaults to 512Mi.
+                  type: string
+                tlsSupport:
+                  description: 'Instructs the operator to deploy Che in TLS mode,
+                    ie with TLS routes or ingresses. This is disabled by default.
+                    WARNING: Enabling TLS might require enabling the `selfSignedCert`
+                    field also in some cases.'
+                  type: boolean
+                workspaceNamespaceDefault:
+                  description: 'Defines Kubernetes default namespace in which user''s
+                    workspaces are created if user does not override it. It''s possible
+                    to use <username>, <userid> and <workspaceid> placeholders (e.g.:
+                    che-workspace-<username>). In that case, new namespace will be
+                    created for each user (or workspace). Is used by OpenShift infra
+                    as well to specify Project'
+                  type: string
+              type: object
+            storage:
+              description: Configuration settings related to the persistent storage
+                used by the Che installation.
+              properties:
+                postgresPVCStorageClassName:
+                  description: Storage class for the Persistent Volume Claim dedicated
+                    to the Postgres database. If omitted or left blank, default storage
+                    class is used.
+                  type: string
+                preCreateSubPaths:
+                  description: Instructs the Che server to launch a special pod to
+                    pre-create a subpath in the Persistent Volumes. Defaults to `false`,
+                    however it might need to enable it according to the configuration
+                    of your K8S cluster.
+                  type: boolean
+                pvcClaimSize:
+                  description: Size of the persistent volume claim for workspaces.
+                    Defaults to `1Gi`
+                  type: string
+                pvcJobsImage:
+                  description: Overrides the container image used to create sub-paths
+                    in the Persistent Volumes. This includes the image tag. Omit it
+                    or leave it empty to use the defaut container image provided by
+                    the operator. See also the `preCreateSubPaths` field.
+                  type: string
+                pvcStrategy:
+                  description: Persistent volume claim strategy for the Che server.
+                    This Can be:`common` (all workspaces PVCs in one volume), `per-workspace`
+                    (one PVC per workspace for all declared volumes) and `unique`
+                    (one PVC per declared volume). Defaults to `common`.
+                  type: string
+                workspacePVCStorageClassName:
+                  description: Storage class for the Persistent Volume Claims dedicated
+                    to the Che workspaces. If omitted or left blank, default storage
+                    class is used.
+                  type: string
+              type: object
+          type: object
+        status:
+          description: CheClusterStatus defines the observed state of Che installation
+          properties:
+            cheClusterRunning:
+              description: Status of a Che installation. Can be `Available`, `Unavailable`,
+                or `Available, Rolling Update in Progress`
+              type: string
+            cheURL:
+              description: Public URL to the Che server
+              type: string
+            cheVersion:
+              description: Current installed Che version
+              type: string
+            dbProvisioned:
+              description: Indicates if or not a Postgres instance has been correctly
+                provisioned
+              type: boolean
+            devfileRegistryURL:
+              description: Public URL to the Devfile registry
+              type: string
+            helpLink:
+              description: A URL that can point to some URL where to find help related
+                to the current Operator status.
+              type: string
+            keycloakProvisioned:
+              description: Indicates whether an Identity Provider instance (Keycloak
+                / RH SSO) has been provisioned with realm, client and user
+              type: boolean
+            keycloakURL:
+              description: Public URL to the Identity Provider server (Keycloak /
+                RH SSO).
+              type: string
+            message:
+              description: A human readable message indicating details about why the
+                pod is in this condition.
+              type: string
+            openShiftoAuthProvisioned:
+              description: Indicates whether an Identity Provider instance (Keycloak
+                / RH SSO) has been configured to integrate with the OpenShift OAuth.
+              type: boolean
+            pluginRegistryURL:
+              description: Public URL to the Plugin registry
+              type: string
+            reason:
+              description: A brief CamelCase message indicating details about why
+                the pod is in this state.
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.6.0/eclipse-che-preview-kubernetes.v7.6.0.clusterserviceversion.yaml
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.6.0/eclipse-che-preview-kubernetes.v7.6.0.clusterserviceversion.yaml
@@ -1,0 +1,354 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "org.eclipse.che/v1",
+          "kind": "CheCluster",
+          "metadata": {
+             "name": "eclipse-che"
+          },
+          "spec": {
+            "k8s": {
+                "ingressDomain": "",
+                "tlsSecretName": ""
+              },
+             "server": {
+                "cheImageTag": "",
+                "devfileRegistryImage": "",
+                "pluginRegistryImage": "",
+                "tlsSupport": false,
+                "selfSignedCert": false
+             },
+             "database": {
+                "externalDb": false,
+                "chePostgresHostName": "",
+                "chePostgresPort": "",
+                "chePostgresUser": "",
+                "chePostgresPassword": "",
+                "chePostgresDb": ""
+             },
+             "auth": {
+                "identityProviderImage": "",
+                "externalIdentityProvider": false,
+                "identityProviderURL": "",
+                "identityProviderRealm": "",
+                "identityProviderClientId": ""
+             },
+             "storage": {
+                "pvcStrategy": "per-workspace",
+                "pvcClaimSize": "1Gi",
+                "preCreateSubPaths": true
+             }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Developer Tools
+    certified: "false"
+    containerImage: quay.io/eclipse/che-operator:7.6.0
+    createdAt: "2019-12-20T14:28:21Z"
+    description: A Kube-native development solution that delivers portable and collaborative
+      developer workspaces.
+    repository: https://github.com/eclipse/che-operator
+    support: Eclipse Foundation
+  name: eclipse-che-preview-kubernetes.v7.6.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Eclipse Che cluster with DB and Auth Server
+      displayName: Eclipse Che Cluster
+      kind: CheCluster
+      name: checlusters.org.eclipse.che
+      specDescriptors:
+      - description: TLS routes
+        displayName: TLS Mode
+        path: server.tlsSupport
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      statusDescriptors:
+      - description: Ingress to access Eclipse Che
+        displayName: Eclipse Che URL
+        path: cheURL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      - description: Ingress to access Keycloak Admin Console
+        displayName: Keycloak Admin Console URL
+        path: keycloakURL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      - description: Eclipse Che server version
+        displayName: Eclipse Che version
+        path: cheVersion
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:label
+      - description: The current status of the application
+        displayName: Status
+        path: cheClusterRunning
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Reason of the current status
+        displayName: Reason
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Message explaining the current status
+        displayName: Message
+        path: message
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Link providing help related to the current status
+        displayName: Help link
+        path: helpLink
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      version: v1
+  description: |
+    A collaborative Kubernetes-native development solution that delivers Kubernetes workspaces and in-browser IDE for rapid cloud application development.
+    This operator installs PostgreSQL, Keycloak, Registries and the Eclipse Che server, as well as configures all these services.
+    ## Prerequisites
+    - Operator Lifecycle Manager (OLM) needs to be installed.
+    - Kubernetes Platform. For OpenShift, the installation is directly made from OperatorHub UI in the admin console.
+
+    OLM installation can be checked by running the command:
+    ```
+    $ kubectl get pods --all-namespaces | grep olm
+    olm             catalog-operator-7b8cd7f8bf-2v7zj                       1/1     Running   0          10m
+    olm             olm-operator-5c5c798cd5-s6ll5                           1/1     Running   0          10m
+    olm             olm-operators-fm5wc                                     1/1     Running   0          10m
+    olm             operatorhubio-catalog-d78km                             1/1     Running   0          10m
+    olm             packageserver-5c5f64947b-trghp                          1/1     Running   0          9m56s
+    olm             packageserver-5c5f64947b-zqvxg                          1/1     Running   0          9m56s
+    ```
+
+    ## How to Install
+    Install `Eclipse Che Operator` by following instructions in top right button `Install`.
+
+    A new pod che-operator is created in `my-eclipse-che` namespace
+
+    ```
+    $ kubectl get pods --all-namespaces | grep my-eclipse-che
+    my-eclipse-che   che-operator-554c564476-fl98z                           1/1     Running   0          13s
+    ```
+
+    The operator is now providing new Custom Resources Definitions: `checluster.org.eclipse.che`
+
+    Create a new Eclipse Che instance by creating a new CheCluster resource:
+
+    On the bottom of this page, there is a section `Custom Resource Definitions` with `Eclipse Che Cluster` name.
+
+    Click on `View YAML Example` *Link* and copy the content to a new file named `my-eclipse-che.yaml`
+    **Important!** Make sure you provide **K8s.ingressDomain** which is a global ingress domain of your k8s cluster, for example, `gcp.my-ide.cloud`
+    Create the new CheCluster by creating the resource in the `my-eclipse-che` namespace :
+    ```
+    $ kubectl create -f my-eclipse-che.yaml -n my-eclipse-che
+    ```
+    ***important:*** The operator is only tracking resources in its own namespace. If CheCluster is not created in this namespace it's ignored.
+    The operator will now create pods for Eclipse Che. The deployment status can be tracked by looking at the Operator logs by using the command:
+    ```
+    $ kubectl logs -n my-eclipse-che che-operator-554c564476-fl98z
+    ```
+    ***important:*** pod name is different on each installation
+
+    When all Eclipse Che containers are running, the Eclipse Che URL is printed
+
+
+    Eclipse Che URL can be tracked by searching for available trace:
+    ```
+    $ kubectl logs -f -n my-eclipse-che che-operator-7b6b4bcb9c-m4m2m | grep "Eclipse Che is now available"
+    time="2019-08-01T13:31:05Z" level=info msg="Eclipse Che is now available at: http://che-my-eclipse-che.gcp.my-ide.cloud"
+    ```
+    When Eclipse Che is ready, the Eclipse Che URL is displayed in CheCluster resource in `status` section
+    ```
+    $ kubectl describe checluster/eclipse-che -n my-eclipse-che
+    ```
+
+    ```
+    Status:
+      Che Cluster Running:           Available
+      Che URL:                       http://che-my-eclipse-che.gcp.my-ide.cloud
+      Che Version:                   7.0.0
+      ...
+    ```
+
+    By opening this URL in a web browser, Eclipse Che is ready to use.
+    ## Defaults
+    By default, the operator deploys Eclipse Che with:
+    * Bundled PostgreSQL and Keycloak
+    * Per-Workspace PVC strategy
+    * Auto-generated passwords
+    * HTTP mode (non-secure ingresses)
+    ## Installation Options
+    Eclipse Che operator installation options include:
+    * Connection to external database and Keycloak
+    * Configuration of default passwords and object names
+    * TLS mode
+    * PVC strategy (once shared PVC for all workspaces, PVC per workspace, or PVC per volume)
+    * Authentication options
+    ### External Database and Keycloak
+    To instruct the operator to skip deploying PostgreSQL and Keycloak and connect to an existing DB and Keycloak instead:
+    * set respective fields to `true` in a custom resource spec
+    * provide the operator with connection and authentication details:
+      ```
+      externalDb: true
+      chePostgresHostname: 'yourPostgresHost'
+      chePostgresPort: '5432'
+      chePostgresUser: 'myuser'
+      chePostgresPassword: 'mypass'
+      chePostgresDb: 'mydb'
+      externalIdentityProvider: true
+      identityProviderURL: 'https://my-keycloak.com'
+      identityProviderRealm: 'myrealm'
+      identityProviderClientId: 'myClient'
+      ```
+    ### TLS Mode
+    To activate TLS mode, set the respective field in the CR spec to `true` (in the `server` block):
+    ```
+    tlsSupport: true
+    ```
+    You will also need to provide name of tls secret that will be used for Eclipse Che and workspaces ingresses:
+    ```
+    tlsSecretName: 'my-ingress-tls-secret'
+    ```
+  displayName: Eclipse Che
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAANMAAAD0CAYAAAABrhNXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAaNklEQVR42u3de3QU9dkH8O/zm91EQK0U77dqVdTW++1V20KigUSQahLjsSSbtp4eeqqVLHILCcoiyQZEIbF61B6PVQJ6XiOkr6TlYiABr603wHotar1bBUWUYDY787x/JIGoSchmZ+c3M/t8/iS7M8+M5+vs7szz/IiZIYRIntJdgBB+IWESwiYSJiFsImESwiYSJiFsImESwiaBvv5ARLprEwB4ddaJTBQF8w/JsKbQmI0v665JAL3dUqK+7jNJmPTiNWOHWYhNB1AOILPrn+MA369MazaNe+Iz3TWmMwmTB3AEyrwwu4SIbwVwWB+v+hxEt6gg7qLs1rjumtORhMnlePUlF5hk1RFw4QDf8rrFmBLMa12tu/Z0I2FyKV53yVGWyTVgLgGQ8IknoImMQBnlNL+t+1jShYTJZXjlhKFW8KsbQJgNYP8ktxYDcI8yh95E41bt1H1sfidhcpH4mtETCHQHgONs3vTHAEXUMy33UQSW7uP0KwmTC/DqS84xyaol4Bcp3tULiqiMxrY8pfuY/UjCpBG3ZB1sxfgmgK4HYDi1WwI9SnGaTuPXv6v7HPiJhEkDfv7coPX5AdeB+RaADtRURRtAC9UB7Qvo4md26z4nfiBhcljH6qwcRbgDwKm6a+nyATNVGrkt9USQrtAkSJgcwquyT2ZlLWLQON219FofsMEghGls6ybdtXiVhCnFuOnnw62gEQHoOvTz3KM7sAVSy5RS0yln3X91V+M1EqYU4ZasgBWjawGuAnCI7noStAOM+coaUkvjVrXrLsYrJEwp0LHmkksUrFoAp+uuJSnMbzLR1EBua5PuUrxAwmSj7tYIBhfprsVOBDQTU5jyWl7RXYubSZhs0KM1YiaA/XTXkyIdAN+tMmgOZbfu0F2MG0mYksAMMtdkh4h4AYDDddfj0FF3tnrsOOROurrB1F2Nm0iYBolXjT7fVFRHwEW6a9FkkyIK09iWDboLcQsJU4KSbY3wGwKaCNZkyt34ju5adJMwDRA/fdEQa2fmZBAqARygux536Wr1+CY+m6546ivd1Wg7CxKmfUtha4TP8EeAmpuurR4Spn7w46PONi2qJdAo3bV4CROeM1iFKXf907prcfS4JUzfx82XjrDM+M0Ot0b4TWerB8yplLvxfd3FOHLAEqYeJ2NPawTmAviB7np8YheA21QG5lN26ze6i0klCVOXjtVZOUpxHZh+orsWn3qfmWYH8lqW6C4kVdI+TLwq+2Q2+HZmjNddSzogoIUsI0yXrduiuxa7pW2YuOnnw62MwEwwTwEoQ3c96aWr1SMen+qnKbRpF6a901GthQAdqrueNPcFGAvUzkMW09UNMd3FJCutwtSxenS2ItQCdIbuWsS3vMFENwbGtvxddyHJSIsw8ZpRx1hkVIM5pLsW0TcCmsk0ymjculd11zIYvg5TmrRG+E1nq4cK3kxjmr/UXUwifBkmZpD5+OiriHEbQMfqrkcMynYQ5nmp1cN3YepsjUAtgS7WXYuwA7+oGGHK2/CE7kr2WalfwsRrxxxpcWwOgN8BJEuJ+gwBTWThBrqs9T+6a+mL58PEjxRlWAd99gcw5kFaI3yO20D0JxVEFWW3fq27mu9V5+UwdbVG1AE4XnctwlEfMlOF26bQejJMvDbrLJNRS8Bo3bUIfRj8T0NRGY1pfVZ3LYDHwsSrc39o0TdzpDVC7OWeKbSeCFOP1ogIgIO0FCHcrrPVwxxSo2sKrevD1LVqRC2Anzq+c+FFW5m4IjB2Q4PTO3ZtmLj50pFsmrczcLnTJ0V4HzHWESFMua3/cmqfrgsTt2QdZHWgHIwwgEynToTwpTjA96sMqqTs1m2p3plrwiStESJ1uqbQBnEXZbfGU7YXN4SpY1VWllKoBXBmqg5UCACvW4wpwbzW1anYuNYw8d+zjrYCFJXpqMJJBDSRESijnOa37dyuljDxyglDrYyvZkBaI4Q2XVNozaE30bhVO23ZopNhktYI4UIfAxSxYwqtY2HitVnndT0C9DOHT5YQA/GCIiqjsS1PDXYDKQ8Tr/7FERapCKQ1Qrhf5xTaOE2n8evfTfjNqQrT3tYIvgWgA3WfJSEGjtsAWpjoFNqUhKmzNQK1AP1Y92kRIgkfMFPlQFs9bA0TPz7qVLbUIgbydJ8FIezChFbDojDltWzu93V2hElaI4T/dbV6cHAa5a79tNdXJBMmbskKWDG6FszVIBys+3CFcMAOMOYra0jtd1s9Bh2mjrXZlyrmWgCn6T46IRzH/CYTTQ3ktjbt/acEw8RrR53EbFQzuEj38QihGwHNxBSmvJZXEgqT9Xj2bWC+QVaNEKInjoFQpca0zvvuXwJ9vwdT5XlUIXpiC6T+Vyn1597+Gkh0c0KkIwb+YUCV0diWfwBAbx/oJExC9G/AN3MlTEL0qudE2ZYBTZSVMAnxHQQ0Udz4Y6IPwEqYhNiDX1SdU2OfHMy7pU1CCMY2EMLqy0MvGGyQALkyifTWuXKhNfQmyku+nV3CJNISAc2krMk0ZuNrdm1TwiTSzRtMdKORgtXeJUwiXXwBwtzO4ZQtKRlOKWESftc5Ntm0ZtO4Jz5L5Y4kTMK3CLyerMAUumzdFif2J2HyBu58GkwmPg3QW8w01chr/T8ndyr/cVyPX1QKoxTUBcwY9D2QNLELwFyVgdMCeS2OBgmQK5N7MbZBoUrtOPROurrBBABmjDIfH30VgRaC8SPdJboIg2ip6uAZNL71E11F9N0cuDbbNStbp5nOG4n9zMXuMb99BoAhugvWiQnPGSaX0WUbnnF0vwl12kqYHEdAE5kqTOPWvzWQ16f5yiIfMlPFQOfc2U3C5F5vMHhKIHfDqsG8mddmj7Y6B96cpftAHLAbhDvU7o5quuKpr3QVIWFynx43EpNb5W7vaox8K4DDdB9YKhDQRLAmU+7Gd3TXImFyj5TdSOSWrP2tGKYBKIdf1glmvKRIhSl3/UbdpewpScKkH4HXk+Iwjdn4cir345MxbdtBmKd2HLLnF023kDDptZWJKwJjNzQ4udOO1Vk5ilAL4Ke6T0AiZQN8t1LBm2lM85e6i+mNhEmPXQBuS3TJEjvx8+cGre0H/tYLo617DnrUXUt/JEzOcsWNxG8V5OZFF3oZQexmEiaHMPifhoWw0zcSB1zf46NOZVMtZkKu7lrQPRx/5yGL6eqGmO5iBkrClHpabyQmqnOhOqoDcLzze9/3si1u1ltu5EFXe+wGYYHKwCmBvJYlXggSAARyN6xUXx5yCghhAI7dAGVCq2J1jjG2pdSLQeqLXJmSREATWbiBLmv9j+5aksFrxxxpcWwOUru49/vMNNsrV+7+yMc8OzFeUuAyytvwhO5SbD2stVnnmcx1BLrYxq0OahFmN5Mw2cO1NxLtwgwyHx99FTFuA+jYZDZFoEdJGdNoTPN7uo/LThKm5Lj+RqLdeM3YYRZi0wHMBLBfQu8FnjeIwjS25Sndx5GScyNhGhwCmsk0ymjculd116IDrxl1jEVGNZhDA3j5xwBF1DMt91EElu7aU3ZOJEwJe4OJbgykYMaaF3WsHp3d+WgSnfH9v3IMwD39NTX6iYRp4L4AY4HXbiQ6YW+rh7UQoEOBrl80jUAZ5TS/rbs+x86DhGmf4gD/WRmBmyln3XbdxbhZ56NJ7dMtqMeDuevX667H8eOXMPWNgBayjLBTM9aEt/WWG5lO1H0jMa9lie5ChLelc5h6tEa0+OJGotArHcPUeSMR5lTK3fi+7mKEf6RVmJjwnMEqTLnrn9Zdi/CfNHlqnD8C6PfG060XSpBEqvj9ytQ1Yy2udcaaSA++DdOeGWtj9c9YE/4RiUTUlreCpQAe+O7f/BimTQqqzE0z1oQ/FBTXnL9lK2oBvhg+D5PvWyOEHr+8ZsGRgUB8DsC/Qz+/M/ghTGnXGiGcUVS0aEg8s30ywawE6IB9vd7TYdo7Y63V1TPWhPcUhqommPxNHSUwbMabYeqasWZ4ZMaa8I4rJ1afpRTqmGlUou/1Wpg6Z6xZQ2tp3Kp23cUI/ygqivzQysiYw4RBD+j0SJh6zFjL889oKKHfpEn3Bre3bbvOBEUAHJTMtlwfJia0GpYKU27LZt21CH8pLK3J2bZrey2IbFnUwM1hep+ZZgdypTVC2Cu/NDpSMW5niy+3c/FSF4ap54w1aY0Q9rnyN5GDjHiwnC2EOQULwbkpTF0z1gK+m7Em9IpEImrz1mAJxelWTuESpa4Ik99nrAl98kPR0Vu2oo6AM1O9L81h4o8ANdfw+Yw14byC4gVHA2YUjBLAzm9GfdMSprhF2PThwZvf3Tli/NU33vOhjhqEP02YFBkabAvOAMwZAIY4uW/Hw/TCB4fgL8+fgv9+NeRMAM8Vhmoip5/Qfl8kEpErk0gCU35o/lXUxgsB/EhHBY6N+vrgy/3xwPMnY/NHI3r78/NghFcsq5DvTCJhV06sOVcprgPwM6f2ubx+1vc+Oqb8yvR1ewANL5+I1a8fA4v7/Oh6HghPFJZEH1VKTWtYUi6/5ol9KiipPgJAZF+tEU5J2ZXJtAgtbx2FhzediJ3fZCTy1jaAFx4Y6Jj/wAMRuc8kvqeoKJJhZQb/YIFuIeBAHTX0dmVKSZpf/mQEZvztItz77E8SDRIADAVozs54xr/zS6pLAXbklxjhDYWhqglmZsZrDKrVFaS+2Hpl+njnUDy86UQ88+7hthXIQCugwo1Ly+XZvDRW+KvoKWxgMYA83bUAKfzO9E2HgZWvHYfGl49Hh2XvxY6ALMB6saA4uoxVcFpj/XR5ajyN9GiNuA7a74v2L6krEwN44p0jUf/CSOzYnfDHucHYwaD53wwfVrvqT5Oln8nHsrIigRHHZF7LbFUDdLDuer7L1u9M/972A1Su+h/86cnTnAoSABxE4PlDvvh6S35x9HKndiqcdVVx9aUjjs54kZnvdWOQ+pLwZXN72354+KWTsPGdw8H6fhsYSYSVBcXRZgqo8PIHy2UGhA8UldScaIGjFlCku5bBGHCY2k2Fx145Hn995TjE4oPq6rUfIYdN66XC4ujdZjA2568PRHboLkkkLhRaOGwXx6ab4HKkoDXCKfv8zsRMePa9w1D/wkh8tiuhBbcdPhJ8Tsy3qPaT7mxouFrm5nkCU35JNESgBQDs+wnYAb19Z+o3TG9tPxAPPn8yXvt0uO7aE8CvEWHK8vrKNborEX27cmLVBUoZdQBfqLuWwUjop/G7nj4NG946AuzM0+s2olOZsbowFG1SMCc31N8ks8ZdpKi06ijTVDUglPjthnyfYWp960jdtSWFGZebMMYWFkfv6cg0Zj92/0xZBUOj7umopsWzQdhfdz2poP3hwBTLYMLkQMx8vTBUMykSifj9eF2pMFQ1wcz45lUCzwf8GSTA/2HqdiQz37tla8azV5VUXay7mHRRUFJ9Tn5JdCOzegyE43TXk2qufjwjBc63oJ6UVo/Uyi+NjlAmbmbgehrkdFQvSrcwAQAxUGRa1riCkurbpNXDPt3TUdnCXCb8QHc9TkuXj3m9GQbQnJ1mxpudrR4iGYWlNTmftW3fxKBaIP2CBKTnlenbGMcQ6MGCUPQ3RBxevqRyi+6SvKSoZN7JJoxFbPE4X/3OPQgSpm6MbGZ6SVo9Bmb8xJrh+ylrpgmaAsCxJ53dTML0bQqEkOKOy/NLahYE2tsXNzREYrqLcpM901HBCxl0qO563CSdvzP1iYHhBJ5vZma8XFBSPV53PW5RMLE6e8vWjJcI9CAACdJ3yJWpfyMBaioojjYbQFnDsopXdRekwxXXVB1jGKoahJDuWtxMwjQQhBwT2FRYHL1bxdTNDQ3labEQdXdrBEAzAbi4ZcAd5GPewAWZMNnMtN4qLKkuKyp6xMc3I5nyQzVFu7jjVYDmQII0IBKmxI1gUK2ZufW5gonzE15E2O0KimvOLyiZ/yQxPwLgWN31eIl8zBu8s6GsDX5p9fjlNQuODATic9wyHdWLJExJ6mr1uLSwpPqOjoxAtddaPbqnozLMeQAdoLseL5P/A9ljCINmBmLma16aQts1HfX1rkeAJEhJkiuTvY4i0IMFJTV/ZBUta1xS8YzugnqTH1pwKlnmYmbk6q7FTyRMqXE+WXiqoDi61AgGZjQ8MOMT3QUBPaajsnk9KH1aI5wiYUodAiFkxuMFuls9Jk26N7h99+e/NdmqBuCZoY5eI9+ZUm9Y16oeL+eHahwfrlhYWpOzbdf2l7w2HdWL5MrknBOJ+ZGCkuh6Ujwl1a0ehRPnnQTDWMQWX+65AVMeJWFy3iVs0QsFJdX3G0Ga3fCXis/s3PiVv4kcZMSD5QwKg707HdWLJEx6BACaZHWgyK5Wjz2tEXG6lYHDdB9gOpLvTBp1t3rEMzO3FIai4wa7nfxQdPTLWzNe6GqNkCBpIlcmFyDwycz4W0FxtJmVMbmxfuZrA3lfQfGCowEzCkYJQ74Z6SZhchNCDrG5ubA4encbYjetWhbZ2dvLJkyKDA22BWcA5gwAQ3SXLTrJxzz3CTJh8hAK9tLq0dkaEWzL6G6NkCC5SJ+rYBSGahJeIFqkxIsKCMctalOK6wD8THdBIoULRIuUOscCNijFDPkk4WoSJm8gyA8Mrif/pxPCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWzSd5iIbgcgS1AK8W2xrmx8T59hWlE/axpZ5mkENOiuXghXYDSToc5ZUT9rWm9/7rM5kGjvE/9XFVdfahHVAjhN9/EIocGbAN+4Ymnl37r/obfcDChMAJCVFQmMOCbzWmarWiaDijSxg0HzexvFllSYuu0Z/k64DtJcKPzJAmMZq+C0xvrpn/b2AlvC1K3wV9FT2MBiAHm6j1wIuzDQCqhw49Lyzf2+zs4wdSsMVU1gVrUAfqz7RAgxaIT3mXl249LKJQN5eW+5Sfo+0/L62SuN9tipBA4zsDPZ7QnhsDaA5x5oxEYONEh9SfrK1FNBSfURACIAySLDwu2YgEeVUtMalpS/l/CbU/ExrzdXTqw5V2a8CRd7HozwimUVTw12A46FqWt3lB+afxUxLwTwIyfPlBB9+JiIIqef0H5fJBKxktmQw2HqtHcuNslcbKFLjBj39De/PVFawtRtz4oNhBLIQEXhECI0waSy5Q/NetvO7WoNU7f8UHQ0MeoAnJmSHQgBAITXmWlK49JZq1Ox+ZT8NJ6oxvqKDWecGDuHwb8G8F+n9y98jvA5gcOfvx87PVVB6nPXTl+ZevrW+quQ9VdFUuIA399hZlaufHjatlTvzBUf83qTXxodqRi3M+Nyx3YqfIOBdSAON9ZX/suxfbo1TN0KS2ty2ORaEH7q+M6FB9G/mVDZWD/L8Z47V3xn6s/yJbOaDx424mwi+j3AKb9UC8/6GuC5u4cPO11HkPriqitTTz1aPa4HYCS9QeEHFhjL4hZPf+zhSq0/Xrn+Y15v8kMLTiXLXAxCru5ahEaEf8KyylYsm/2s7lIAj4apW1erRx2A43XXIhz1IYMrGpdW1APkmnWWXf+dqT9drR6nEDgM4Cvd9YiUayPwAqM9dkpna4R7gtQXz1yZevrlNQuODATic6TVw5+I0GQadMNfH5j1H9219MXTH/N6UxiqOo/ZqAP4Yt21CFu8qIDwo0srntBdyL74Lkxdh9Xd6nEbgGN1VyMGg7cRUKXaT7qzoeFqU3c1A6rYn2HqFAotHLaLY9MBmglgP931iAHpIMbddrZGOMXXYep2xTVVxxiGqgYhpLsW0Q9GMytjcmP9zNd0lzKo8tMhTN0KJlZnQ1EtgDN01yL2YtAbivjG5fUVf9ddS1LH4eWfxhO14qHKljNOjJ3d1erxadIbFEkh4AsGlQfa28/wepD6PEa/Xpl66tHqMQVAhu560owFxjIjA1Mb/lLxme5i7JJWH/N6k18aHUkWLQJ4vO5a0gKhhYjDy5dUbtFdit3SPkzdCktrciyL6wj4ie5afOo9Bt+U7FBHN0ur70z9Wb5kVvMhQ0ec1fVo0pe66/GRXQDPPTAQO9nPQepLWl6ZesovjY5QJm6WVo+kMBhLjWBgRsMDMz7RXYwjBywf8/pWWFpzNltWLUCjdNfiMc+xQlnjkopndBfiJAnTAEirx4B9xOBZbmuNcIqEaYCKihYNiWe2TyZwJYADdNfjMrsJfEdHRqD6sftnpm0rjIQpQUWlVUeZpqqRKbSdiNCkYE5uqL/pHd216CZhGqSC4przAa4D4SLdtWjyEiwVXvFQ+UbdhbiFhCkpTPkl0RCBFgA4XHc1DtlO4Hleao1wioTJBmnS6tFBjLtVTN3c0FAu9+F6IWGy0ZW/nneCYRo1DBTprsVWjGYKqPDyB8tf0V2Km0mYUiA/VHMJMS+G91s93mTG1MZlFU26C/ECeZwoBRrrZ63v0erhxaeidzCofPfw/c+QICVHrkw2Gj+xZvh+yprpkVYPC4xlrILTGuunS79XguRjnkOKSuadbMJYBGCc7lp6w0AroMKNS8s3667FqyRMDissrclhy7oDoFN119LlAwZXpusjQHaS70wOW75kVvPBQw8+0wWtHm1drREneWU6qhfJlckhmlo9mIBH2bKmr3ho9ru6z4GfyMc8FygoqT6HQbUE/CKV+yHCC2yhbMWyiqd0H7MfSZhcpDBUNYEtdQcIx9m86Y+JKHL6Ce33RSIRS/dx+pWEyWUmTIoMDbRl3kDg2QD2T3JzMWLc48XpqF4kYXKpZFs9iNAEk8qWPzTrbd3Hki4kTC535cSqC5Qy6gC+cEBvILzOTFMal85arbv2dCNh8oQBtHoQPifmW7Z/0HFXa2skrrvidCRh8pAerR7lADK7/jkO8P0dZmblyoenyWr0GkmYPKhw4ryTYBiL2EKQlTHFq6tG+E1CYRJCJEYeJxLCJhImIWwiYRLCJhImIWwiYRLCJv8P9sXhC7xE4kIAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDQtMTNUMDg6MTY6MDgrMDI6MDCcYZVaAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA0LTEzVDA4OjE2OjA4KzAyOjAw7Twt5gAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      deployments:
+      - name: che-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: che-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: che-operator
+            spec:
+              containers:
+              - command:
+                - /usr/local/bin/che-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: che-operator
+                image: quay.io/eclipse/che-operator:7.6.0
+                imagePullPolicy: IfNotPresent
+                name: che-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              restartPolicy: Always
+              serviceAccountName: che-operator
+              terminationGracePeriodSeconds: 5
+      permissions:
+      - rules:
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - serviceaccounts
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - pods/exec
+          - pods/log
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - org.eclipse.che
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: che-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - eclipse che
+  - workspaces
+  - devtools
+  - developer
+  - ide
+  - java
+  links:
+  - name: Product Page
+    url: http://www.eclipse.org/che
+  - name: Documentation
+    url: https://www.eclipse.org/che/docs
+  - name: Operator GitHub Repo
+    url: https://github.com/eclipse/che-operator
+  maintainers:
+  - email: dfestal@redhat.com
+    name: David Festal
+  maturity: stable
+  provider:
+    name: Eclipse Foundation
+  replaces: eclipse-che-preview-kubernetes.v7.5.1
+  version: 7.6.0

--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.6.0/eclipse-che-preview-kubernetes.v7.6.0.clusterserviceversion.yaml.diff
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.6.0/eclipse-che-preview-kubernetes.v7.6.0.clusterserviceversion.yaml.diff
@@ -1,0 +1,36 @@
+--- /home/ibuziuk/git/che-operator/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.5.1/eclipse-che-preview-kubernetes.v7.5.1.clusterserviceversion.yaml	2019-12-20 15:05:05.603179298 +0100
++++ /home/ibuziuk/git/che-operator/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.6.0/eclipse-che-preview-kubernetes.v7.6.0.clusterserviceversion.yaml	2019-12-20 15:28:21.069992264 +0100
+@@ -48,13 +48,13 @@
+     capabilities: Seamless Upgrades
+     categories: Developer Tools
+     certified: "false"
+-    containerImage: quay.io/eclipse/che-operator:7.5.1
+-    createdAt: "2019-12-10T13:31:32Z"
++    containerImage: quay.io/eclipse/che-operator:7.6.0
++    createdAt: "2019-12-20T14:28:21Z"
+     description: A Kube-native development solution that delivers portable and collaborative
+       developer workspaces.
+     repository: https://github.com/eclipse/che-operator
+     support: Eclipse Foundation
+-  name: eclipse-che-preview-kubernetes.v7.5.1
++  name: eclipse-che-preview-kubernetes.v7.6.0
+   namespace: placeholder
+ spec:
+   apiservicedefinitions: {}
+@@ -247,7 +247,7 @@
+                       fieldPath: metadata.name
+                 - name: OPERATOR_NAME
+                   value: che-operator
+-                image: quay.io/eclipse/che-operator:7.5.1
++                image: quay.io/eclipse/che-operator:7.6.0
+                 imagePullPolicy: IfNotPresent
+                 name: che-operator
+                 ports:
+@@ -350,5 +350,5 @@
+   maturity: stable
+   provider:
+     name: Eclipse Foundation
+-  replaces: eclipse-che-preview-kubernetes.v7.4.0
+-  version: 7.5.1
++  replaces: eclipse-che-preview-kubernetes.v7.5.1
++  version: 7.6.0

--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/eclipse-che-preview-kubernetes.package.yaml
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/eclipse-che-preview-kubernetes.package.yaml
@@ -1,7 +1,7 @@
 channels:
 - currentCSV: eclipse-che-preview-kubernetes.v9.9.9-nightly.1575355471
   name: nightly
-- currentCSV: eclipse-che-preview-kubernetes.v7.5.1
+- currentCSV: eclipse-che-preview-kubernetes.v7.6.0
   name: stable
 defaultChannel: stable
 packageName: eclipse-che-preview-kubernetes

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.6.0/eclipse-che-preview-openshift.crd.yaml
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.6.0/eclipse-che-preview-openshift.crd.yaml
@@ -1,0 +1,504 @@
+#
+#  Copyright (c) 2012-2019 Red Hat, Inc.
+#    This program and the accompanying materials are made
+#    available under the terms of the Eclipse Public License 2.0
+#    which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#    Red Hat, Inc. - initial API and implementation
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: checlusters.org.eclipse.che
+spec:
+  group: org.eclipse.che
+  names:
+    kind: CheCluster
+    listKind: CheClusterList
+    plural: checlusters
+    singular: checluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Desired configuration of the Che installation. Based on these
+            settings, the operator automatically creates and maintains several config
+            maps that will contain the appropriate environment variables the various
+            components of the Che installation. These generated config maps should
+            NOT be updated manually.
+          properties:
+            auth:
+              description: Configuration settings related to the Authentication used
+                by the Che installation.
+              properties:
+                externalIdentityProvider:
+                  description: 'Instructs the operator on whether or not to deploy
+                    a dedicated Identity Provider (Keycloak or RH SSO instance). By
+                    default a dedicated Identity Provider server is deployed as part
+                    of the Che installation. But if `externalIdentityProvider` is
+                    `true`, then no dedicated identity provider will be deployed by
+                    the operator and you might need to provide details about the external
+                    identity provider you want to use. See also all the other fields
+                    starting with: `identityProvider`.'
+                  type: boolean
+                identityProviderAdminUserName:
+                  description: Overrides the name of the Identity Provider admin user.
+                    Defaults to `admin`.
+                  type: string
+                identityProviderClientId:
+                  description: Name of a Identity provider (Keycloak / RH SSO) `client-id`
+                    that should be used for Che. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to the value
+                    of the `flavour` field suffixed with `-public`.
+                  type: string
+                identityProviderImage:
+                  description: Overrides the container image used in the Identity
+                    Provider (Keycloak / RH SSO) deployment. This includes the image
+                    tag. Omit it or leave it empty to use the defaut container image
+                    provided by the operator.
+                  type: string
+                identityProviderImagePullPolicy:
+                  description: Overrides the image pull policy used in the Identity
+                    Provider (Keycloak / RH SSO) deployment. Default value is `Always`
+                    for `nightly` or `latest` images, and `IfNotPresent` in other
+                    cases.
+                  type: string
+                identityProviderPassword:
+                  description: Overrides the password of Keycloak admin user. This
+                    is useful to override it ONLY if you use an external Identity
+                    Provider (see the `externalIdentityProvider` field). If omitted
+                    or left blank, it will be set to an auto-generated password.
+                  type: string
+                identityProviderPostgresPassword:
+                  description: Password for The Identity Provider (Keycloak / RH SSO)
+                    to connect to the database. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to an auto-generated
+                    password.
+                  type: string
+                identityProviderRealm:
+                  description: Name of a Identity provider (Keycloak / RH SSO) realm
+                    that should be used for Che. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to the value
+                    of the `flavour` field.
+                  type: string
+                identityProviderURL:
+                  description: Public URL of the Identity Provider server (Keycloak
+                    / RH SSO server). You should set it ONLY if you use an external
+                    Identity Provider (see the `externalIdentityProvider` field).
+                    By default this will be automatically calculated and set by the
+                    operator.
+                  type: string
+                oAuthClientName:
+                  description: Name of the OpenShift `OAuthClient` resource used to
+                    setup identity federation on the OpenShift side. Auto-generated
+                    if left blank. See also the `OpenShiftoAuth` field.
+                  type: string
+                oAuthSecret:
+                  description: Name of the secret set in the OpenShift `OAuthClient`
+                    resource used to setup identity federation on the OpenShift side.
+                    Auto-generated if left blank. See also the `OAuthClientName` field.
+                  type: string
+                openShiftoAuth:
+                  description: 'Enables the integration of the identity provider (Keycloak
+                    / RHSSO) with OpenShift OAuth. Enabled by defaumt on OpenShift.
+                    This will allow users to directly login with their Openshift user
+                    throug the Openshift login, and have their workspaces created
+                    under personnal OpenShift namespaces. WARNING: the `kuebadmin`
+                    user is NOT supported, and logging through it will NOT allow accessing
+                    the Che Dashboard.'
+                  type: boolean
+                updateAdminPassword:
+                  description: Forces the default `admin` Che user to update password
+                    on first login. Defaults to `false`.
+                  type: boolean
+              type: object
+            database:
+              description: Configuration settings related to the database used by
+                the Che installation.
+              properties:
+                chePostgresDb:
+                  description: Postgres database name that the Che server uses to
+                    connect to the DB. Defaults to `dbche`.
+                  type: string
+                chePostgresHostName:
+                  description: Postgres Database hostname that the Che server uses
+                    to connect to. Defaults to postgres. This value should be overridden
+                    ONLY when using an external database (see field `externalDb`).
+                    In the default case it will be automatically set by the operator.
+                  type: string
+                chePostgresPassword:
+                  description: Postgres password that the Che server should use to
+                    connect to the DB. If omitted or left blank, it will be set to
+                    an auto-generated value.
+                  type: string
+                chePostgresPort:
+                  description: Postgres Database port that the Che server uses to
+                    connect to. Defaults to 5432. This value should be overridden
+                    ONLY when using an external database (see field `externalDb`).
+                    In the default case it will be automatically set by the operator.
+                  type: string
+                chePostgresUser:
+                  description: Postgres user that the Che server should use to connect
+                    to the DB. Defaults to `pgche`.
+                  type: string
+                externalDb:
+                  description: 'Instructs the operator on whether or not to deploy
+                    a dedicated database. By default a dedicated Postgres database
+                    is deployed as part of the Che installation. But if `externalDb`
+                    is `true`, then no dedicated database will be deployed by the
+                    operator and you might need to provide connection details to the
+                    external DB you want to use. See also all the fields starting
+                    with: `chePostgres`.'
+                  type: boolean
+                postgresImage:
+                  description: Overrides the container image used in the Postgres
+                    database deployment. This includes the image tag. Omit it or leave
+                    it empty to use the defaut container image provided by the operator.
+                  type: string
+                postgresImagePullPolicy:
+                  description: Overrides the image pull policy used in the Postgres
+                    database deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+              type: object
+            k8s:
+              description: Configuration settings specific to Che installations made
+                on upstream Kubernetes.
+              properties:
+                ingressClass:
+                  description: 'Ingress class that will define the which controler
+                    will manage ingresses. Defaults to `nginx`. NB: This drives the
+                    `is kubernetes.io/ingress.class` annotation on Che-related ingresses.'
+                  type: string
+                ingressDomain:
+                  description: 'Global ingress domain for a K8S cluster. This MUST
+                    be explicitly specified: there are no defaults.'
+                  type: string
+                ingressStrategy:
+                  description: Strategy for ingress creation. This can be `multi-host`
+                    (host is explicitly provided in ingress), `single-host` (host
+                    is provided, path-based rules) and `default-host.*`(no host is
+                    provided, path-based rules). Defaults to `"multi-host`
+                  type: string
+                securityContextFsGroup:
+                  description: FSGroup the Che pod and Workspace pods containers should
+                    run in. Defaults to `1724`.
+                  type: string
+                securityContextRunAsUser:
+                  description: ID of the user the Che pod and Workspace pods containers
+                    should run as. Default to `1724`.
+                  type: string
+                tlsSecretName:
+                  description: Name of a secret that will be used to setup ingress
+                    TLS termination if TLS is enabled. See also the `tlsSupport` field.
+                  type: string
+              type: object
+            metrics:
+              description: Configuration settings related to the metrics collection
+                used by the Che installation.
+              properties:
+                enable:
+                  description: Enables `metrics` Che server endpoint. Default to `false`.
+                  type: boolean
+              type: object
+            server:
+              description: General configuration settings related to the Che server
+                and the plugin and devfile registries
+              properties:
+                airGapContainerRegistryHostname:
+                  description: Optional hostname (or url) to an alternate container
+                    registry to pull images from. This value overrides the container
+                    registry hostname defined in all the default container images
+                    involved in a Che deployment. This is particularly useful to install
+                    Che in an air-gapped environment.
+                  type: string
+                airGapContainerRegistryOrganization:
+                  description: Optional repository name of an alternate container
+                    registry to pull images from. This value overrides the container
+                    registry organization defined in all the default container images
+                    involved in a Che deployment. This is particularly useful to install
+                    Che in an air-gapped environment.
+                  type: string
+                allowUserDefinedWorkspaceNamespaces:
+                  description: Defines if a user is able to specify Kubernetes namespace
+                    (or OpenShift project) different from the default. It's NOT RECOMMENDED
+                    to configured true without OAuth configured. This property is
+                    also used by the OpenShift infra.
+                  type: boolean
+                cheDebug:
+                  description: Enables the debug mode for Che server. Defaults to
+                    `false`.
+                  type: string
+                cheFlavor:
+                  description: Flavor of the installation. This is either `che` for
+                    upstream Che installations, or `codeready` for CodeReady Workspaces
+                    installation. In most cases the default value should not be overriden.
+                  type: string
+                cheHost:
+                  description: Public hostname of the installed Che server. This will
+                    be automatically set by the operator. In most cases the default
+                    value set by the operator should not be overriden.
+                  type: string
+                cheImage:
+                  description: Overrides the container image used in Che deployment.
+                    This does NOT include the container image tag. Omit it or leave
+                    it empty to use the defaut container image provided by the operator.
+                  type: string
+                cheImagePullPolicy:
+                  description: Overrides the image pull policy used in Che deployment.
+                    Default value is `Always` for `nightly` or `latest` images, and
+                    `IfNotPresent` in other cases.
+                  type: string
+                cheImageTag:
+                  description: Overrides the tag of the container image used in Che
+                    deployment. Omit it or leave it empty to use the defaut image
+                    tag provided by the operator.
+                  type: string
+                cheLogLevel:
+                  description: 'Log level for the Che server: `INFO` or `DEBUG`. Defaults
+                    to `INFO`.'
+                  type: string
+                cheWorkspaceClusterRole:
+                  description: Custom cluster role bound to the user for the Che workspaces.
+                    The default roles are used if this is omitted or left blank.
+                  type: string
+                customCheProperties:
+                  additionalProperties:
+                    type: string
+                  description: Map of additional environment variables that will be
+                    applied in the generated `che` config map to be used by the Che
+                    server, in addition to the values already generated from other
+                    fields of the `CheCluster` custom resource (CR). If `customCheProperties`
+                    contains a property that would be normally generated in `che`
+                    config map from other CR fields, then the value defined in the
+                    `customCheProperties` will be used instead.
+                  type: object
+                devfileRegistryImage:
+                  description: Overrides the container image used in the Devfile registry
+                    deployment. This includes the image tag. Omit it or leave it empty
+                    to use the defaut container image provided by the operator.
+                  type: string
+                devfileRegistryMemoryLimit:
+                  description: Overrides the memory limit used in the Devfile registry
+                    deployment. Defaults to 256Mi.
+                  type: string
+                devfileRegistryMemoryRequest:
+                  description: Overrides the memory request used in the Devfile registry
+                    deployment. Defaults to 16Mi.
+                  type: string
+                devfileRegistryPullPolicy:
+                  description: Overrides the image pull policy used in the Devfile
+                    registry deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+                devfileRegistryUrl:
+                  description: Public URL of the Devfile registry, that serves sample,
+                    ready-to-use devfiles. You should set it ONLY if you use an external
+                    devfile registry (see the `externalDevfileRegistry` field). By
+                    default this will be automatically calculated by the operator.
+                  type: string
+                externalDevfileRegistry:
+                  description: Instructs the operator on whether or not to deploy
+                    a dedicated Devfile registry server. By default a dedicated devfile
+                    registry server is started. But if `externalDevfileRegistry` is
+                    `true`, then no such dedicated server will be started by the operator
+                    and you will have to manually set the `devfileRegistryUrl` field
+                  type: boolean
+                externalPluginRegistry:
+                  description: Instructs the operator on whether or not to deploy
+                    a dedicated Plugin registry server. By default a dedicated plugin
+                    registry server is started. But if `externalPluginRegistry` is
+                    `true`, then no such dedicated server will be started by the operator
+                    and you will have to manually set the `pluginRegistryUrl` field.
+                  type: boolean
+                nonProxyHosts:
+                  description: List of hosts that should not use the configured proxy.
+                    Use `|`` as delimiter, eg `localhost|my.host.com|123.42.12.32`
+                    Only use when configuring a proxy is required (see also the `proxyURL`
+                    field).
+                  type: string
+                pluginRegistryImage:
+                  description: Overrides the container image used in the Plugin registry
+                    deployment. This includes the image tag. Omit it or leave it empty
+                    to use the defaut container image provided by the operator.
+                  type: string
+                pluginRegistryMemoryLimit:
+                  description: Overrides the memory limit used in the Plugin registry
+                    deployment. Defaults to 256Mi.
+                  type: string
+                pluginRegistryMemoryRequest:
+                  description: Overrides the memory request used in the Plugin registry
+                    deployment. Defaults to 16Mi.
+                  type: string
+                pluginRegistryPullPolicy:
+                  description: Overrides the image pull policy used in the Plugin
+                    registry deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+                pluginRegistryUrl:
+                  description: Public URL of the Plugin registry, that serves sample
+                    ready-to-use devfiles. You should set it ONLY if you use an external
+                    devfile registry (see the `externalPluginRegistry` field). By
+                    default this will be automatically calculated by the operator.
+                  type: string
+                proxyPassword:
+                  description: "Password of the proxy server \n Only use when proxy
+                    configuration is required (see also the `proxyUser` field)."
+                  type: string
+                proxyPort:
+                  description: Port of the proxy server. Only use when configuring
+                    a proxy is required (see also the `proxyURL` field).
+                  type: string
+                proxyURL:
+                  description: URL (protocol+hostname) of the proxy server. This drives
+                    the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy`
+                    variables in the Che server and workspaces containers. Only use
+                    when configuring a proxy is required.
+                  type: string
+                proxyUser:
+                  description: User name of the proxy server. Only use when configuring
+                    a proxy is required (see also the `proxyURL` field).
+                  type: string
+                selfSignedCert:
+                  description: Enables the support of OpenShift clusters whose router
+                    uses self-signed certificates. When enabled, the operator retrieves
+                    the default self-signed certificate of OpenShift routes and adds
+                    it to the Java trust store of the Che server. This is usually
+                    required when activating the `tlsSupport` field on demo OpenShift
+                    clusters that have not been setup with a valid certificate for
+                    the routes. This is disabled by default.
+                  type: boolean
+                serverMemoryLimit:
+                  description: Overrides the memory limit used in the Che server deployment.
+                    Defaults to 1Gi.
+                  type: string
+                serverMemoryRequest:
+                  description: Overrides the memory request used in the Che server
+                    deployment. Defaults to 512Mi.
+                  type: string
+                tlsSupport:
+                  description: 'Instructs the operator to deploy Che in TLS mode,
+                    ie with TLS routes or ingresses. This is disabled by default.
+                    WARNING: Enabling TLS might require enabling the `selfSignedCert`
+                    field also in some cases.'
+                  type: boolean
+                workspaceNamespaceDefault:
+                  description: 'Defines Kubernetes default namespace in which user''s
+                    workspaces are created if user does not override it. It''s possible
+                    to use <username>, <userid> and <workspaceid> placeholders (e.g.:
+                    che-workspace-<username>). In that case, new namespace will be
+                    created for each user (or workspace). Is used by OpenShift infra
+                    as well to specify Project'
+                  type: string
+              type: object
+            storage:
+              description: Configuration settings related to the persistent storage
+                used by the Che installation.
+              properties:
+                postgresPVCStorageClassName:
+                  description: Storage class for the Persistent Volume Claim dedicated
+                    to the Postgres database. If omitted or left blank, default storage
+                    class is used.
+                  type: string
+                preCreateSubPaths:
+                  description: Instructs the Che server to launch a special pod to
+                    pre-create a subpath in the Persistent Volumes. Defaults to `false`,
+                    however it might need to enable it according to the configuration
+                    of your K8S cluster.
+                  type: boolean
+                pvcClaimSize:
+                  description: Size of the persistent volume claim for workspaces.
+                    Defaults to `1Gi`
+                  type: string
+                pvcJobsImage:
+                  description: Overrides the container image used to create sub-paths
+                    in the Persistent Volumes. This includes the image tag. Omit it
+                    or leave it empty to use the defaut container image provided by
+                    the operator. See also the `preCreateSubPaths` field.
+                  type: string
+                pvcStrategy:
+                  description: Persistent volume claim strategy for the Che server.
+                    This Can be:`common` (all workspaces PVCs in one volume), `per-workspace`
+                    (one PVC per workspace for all declared volumes) and `unique`
+                    (one PVC per declared volume). Defaults to `common`.
+                  type: string
+                workspacePVCStorageClassName:
+                  description: Storage class for the Persistent Volume Claims dedicated
+                    to the Che workspaces. If omitted or left blank, default storage
+                    class is used.
+                  type: string
+              type: object
+          type: object
+        status:
+          description: CheClusterStatus defines the observed state of Che installation
+          properties:
+            cheClusterRunning:
+              description: Status of a Che installation. Can be `Available`, `Unavailable`,
+                or `Available, Rolling Update in Progress`
+              type: string
+            cheURL:
+              description: Public URL to the Che server
+              type: string
+            cheVersion:
+              description: Current installed Che version
+              type: string
+            dbProvisioned:
+              description: Indicates if or not a Postgres instance has been correctly
+                provisioned
+              type: boolean
+            devfileRegistryURL:
+              description: Public URL to the Devfile registry
+              type: string
+            helpLink:
+              description: A URL that can point to some URL where to find help related
+                to the current Operator status.
+              type: string
+            keycloakProvisioned:
+              description: Indicates whether an Identity Provider instance (Keycloak
+                / RH SSO) has been provisioned with realm, client and user
+              type: boolean
+            keycloakURL:
+              description: Public URL to the Identity Provider server (Keycloak /
+                RH SSO).
+              type: string
+            message:
+              description: A human readable message indicating details about why the
+                pod is in this condition.
+              type: string
+            openShiftoAuthProvisioned:
+              description: Indicates whether an Identity Provider instance (Keycloak
+                / RH SSO) has been configured to integrate with the OpenShift OAuth.
+              type: boolean
+            pluginRegistryURL:
+              description: Public URL to the Plugin registry
+              type: string
+            reason:
+              description: A brief CamelCase message indicating details about why
+                the pod is in this state.
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.6.0/eclipse-che-preview-openshift.v7.6.0.clusterserviceversion.yaml
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.6.0/eclipse-che-preview-openshift.v7.6.0.clusterserviceversion.yaml
@@ -1,0 +1,399 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "org.eclipse.che/v1",
+          "kind": "CheCluster",
+          "metadata": {
+             "name": "eclipse-che"
+          },
+          "spec": {
+             "server": {
+                "cheImageTag": "",
+                "devfileRegistryImage": "",
+                "pluginRegistryImage": "",
+                "tlsSupport": false,
+                "selfSignedCert": false
+             },
+             "database": {
+                "externalDb": false,
+                "chePostgresHostName": "",
+                "chePostgresPort": "",
+                "chePostgresUser": "",
+                "chePostgresPassword": "",
+                "chePostgresDb": ""
+             },
+             "auth": {
+                "openShiftoAuth": true,
+                "identityProviderImage": "",
+                "externalIdentityProvider": false,
+                "identityProviderURL": "",
+                "identityProviderRealm": "",
+                "identityProviderClientId": ""
+             },
+             "storage": {
+                "pvcStrategy": "per-workspace",
+                "pvcClaimSize": "1Gi",
+                "preCreateSubPaths": true
+             }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Developer Tools, OpenShift Optional
+    certified: "false"
+    containerImage: quay.io/eclipse/che-operator:7.6.0
+    createdAt: "2019-12-20T14:28:21Z"
+    description: A Kube-native development solution that delivers portable and collaborative
+      developer workspaces in OpenShift.
+    repository: https://github.com/eclipse/che-operator
+    support: Eclipse Foundation
+  name: eclipse-che-preview-openshift.v7.6.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Eclipse Che cluster with DB and Auth Server
+      displayName: Eclipse Che Cluster
+      kind: CheCluster
+      name: checlusters.org.eclipse.che
+      specDescriptors:
+      - description: Log in to Eclipse Che with OpenShift credentials
+        displayName: OpenShift oAuth
+        path: auth.openShiftoAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: TLS routes
+        displayName: TLS Mode
+        path: server.tlsSupport
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      statusDescriptors:
+      - description: Route to access Eclipse Che
+        displayName: Eclipse Che URL
+        path: cheURL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      - description: Route to access Keycloak Admin Console
+        displayName: Keycloak Admin Console URL
+        path: keycloakURL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      - description: Eclipse Che server version
+        displayName: Eclipse Che version
+        path: cheVersion
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:label
+      - description: The current status of the application
+        displayName: Status
+        path: cheClusterRunning
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Reason of the current status
+        displayName: Reason
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Message explaining the current status
+        displayName: Message
+        path: message
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Link providing help related to the current status
+        displayName: Help link
+        path: helpLink
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      version: v1
+  description: |
+    A collaborative Kubernetes-native development solution that delivers OpenShift workspaces and in-browser IDE for rapid cloud application development.
+    This operator installs PostgreSQL, Keycloak, and the Eclipse Che server, as well as configures all three services.
+
+    ## How to Install
+
+    Press the **Install** button, choose the upgrade strategy, and wait for the **Installed** Operator status.
+
+    When the operator is installed, create a new CR of Kind CheCluster (click the **Create New** button).
+    The CR spec contains all defaults (see below).
+
+    You can start using Eclipse Che when the CR status is set to **Available**, and you see a URL to Eclipse Che.
+
+    ## Defaults
+
+    By default, the operator deploys Eclipse Che with:
+
+    * Bundled PostgreSQL and Keycloak
+
+    * Per-Workspace PVC strategy
+
+    * Auto-generated passwords
+
+    * HTTP mode (non-secure routes)
+
+    * Regular login extended with OpenShift OAuth authentication
+
+    ## Installation Options
+
+    Eclipse Che operator installation options include:
+
+    * Connection to external database and Keycloak
+
+    * Configuration of default passwords and object names
+
+    * TLS mode
+
+    * PVC strategy (once shared PVC for all workspaces, PVC per workspace, or PVC per volume)
+
+    * Authentication options
+
+    ### External Database and Keycloak
+
+    To instruct the operator to skip deploying PostgreSQL and Keycloak and connect to an existing DB and Keycloak instead:
+
+    * set respective fields to `true` in a custom resource spec
+
+    * provide the operator with connection and authentication details:
+
+
+
+      `externalDb: true`
+
+
+      `chePostgresHostname: 'yourPostgresHost'`
+
+
+      `chePostgresPort: '5432'`
+
+
+      `chePostgresUser: 'myuser'`
+
+
+      `chePostgresPassword: 'mypass'`
+
+
+      `chePostgresDb: 'mydb'`
+
+
+      `externalIdentityProvider: true`
+
+
+      `identityProviderURL: 'https://my-keycloak.com'`
+
+
+      `identityProviderRealm: 'myrealm'`
+
+
+      `identityProviderClientId: 'myClient'`
+
+
+    ### TLS Mode
+
+    To activate TLS mode, set the respective field in the CR spec to `true` (in the `server` block):
+
+
+    ```
+    tlsSupport: true
+    ```
+
+    #### Self-signed Certificates
+
+    To use Eclipse Che with TLS enabled, but the OpenShift router does not use certificates signed by a public authority, you can use self-signed certificates, which the operator can fetch for you:
+
+
+    ```
+    selfSignedCert: true
+    ```
+
+
+    You can also manually create a secret:
+
+
+
+    ```
+    oc create secret self-signed-certificate generic --from-file=/path/to/certificate/ca.crt -n=$codeReadyNamespace
+    ```
+  displayName: Eclipse Che
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAANMAAAD0CAYAAAABrhNXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAaNklEQVR42u3de3QU9dkH8O/zm91EQK0U77dqVdTW++1V20KigUSQahLjsSSbtp4eeqqVLHILCcoiyQZEIbF61B6PVQJ6XiOkr6TlYiABr603wHotar1bBUWUYDY787x/JIGoSchmZ+c3M/t8/iS7M8+M5+vs7szz/IiZIYRIntJdgBB+IWESwiYSJiFsImESwiYSJiFsImESwiaBvv5ARLprEwB4ddaJTBQF8w/JsKbQmI0v665JAL3dUqK+7jNJmPTiNWOHWYhNB1AOILPrn+MA369MazaNe+Iz3TWmMwmTB3AEyrwwu4SIbwVwWB+v+hxEt6gg7qLs1rjumtORhMnlePUlF5hk1RFw4QDf8rrFmBLMa12tu/Z0I2FyKV53yVGWyTVgLgGQ8IknoImMQBnlNL+t+1jShYTJZXjlhKFW8KsbQJgNYP8ktxYDcI8yh95E41bt1H1sfidhcpH4mtETCHQHgONs3vTHAEXUMy33UQSW7uP0KwmTC/DqS84xyaol4Bcp3tULiqiMxrY8pfuY/UjCpBG3ZB1sxfgmgK4HYDi1WwI9SnGaTuPXv6v7HPiJhEkDfv7coPX5AdeB+RaADtRURRtAC9UB7Qvo4md26z4nfiBhcljH6qwcRbgDwKm6a+nyATNVGrkt9USQrtAkSJgcwquyT2ZlLWLQON219FofsMEghGls6ybdtXiVhCnFuOnnw62gEQHoOvTz3KM7sAVSy5RS0yln3X91V+M1EqYU4ZasgBWjawGuAnCI7noStAOM+coaUkvjVrXrLsYrJEwp0LHmkksUrFoAp+uuJSnMbzLR1EBua5PuUrxAwmSj7tYIBhfprsVOBDQTU5jyWl7RXYubSZhs0KM1YiaA/XTXkyIdAN+tMmgOZbfu0F2MG0mYksAMMtdkh4h4AYDDddfj0FF3tnrsOOROurrB1F2Nm0iYBolXjT7fVFRHwEW6a9FkkyIK09iWDboLcQsJU4KSbY3wGwKaCNZkyt34ju5adJMwDRA/fdEQa2fmZBAqARygux536Wr1+CY+m6546ivd1Wg7CxKmfUtha4TP8EeAmpuurR4Spn7w46PONi2qJdAo3bV4CROeM1iFKXf907prcfS4JUzfx82XjrDM+M0Ot0b4TWerB8yplLvxfd3FOHLAEqYeJ2NPawTmAviB7np8YheA21QG5lN26ze6i0klCVOXjtVZOUpxHZh+orsWn3qfmWYH8lqW6C4kVdI+TLwq+2Q2+HZmjNddSzogoIUsI0yXrduiuxa7pW2YuOnnw62MwEwwTwEoQ3c96aWr1SMen+qnKbRpF6a901GthQAdqrueNPcFGAvUzkMW09UNMd3FJCutwtSxenS2ItQCdIbuWsS3vMFENwbGtvxddyHJSIsw8ZpRx1hkVIM5pLsW0TcCmsk0ymjculd11zIYvg5TmrRG+E1nq4cK3kxjmr/UXUwifBkmZpD5+OiriHEbQMfqrkcMynYQ5nmp1cN3YepsjUAtgS7WXYuwA7+oGGHK2/CE7kr2WalfwsRrxxxpcWwOgN8BJEuJ+gwBTWThBrqs9T+6a+mL58PEjxRlWAd99gcw5kFaI3yO20D0JxVEFWW3fq27mu9V5+UwdbVG1AE4XnctwlEfMlOF26bQejJMvDbrLJNRS8Bo3bUIfRj8T0NRGY1pfVZ3LYDHwsSrc39o0TdzpDVC7OWeKbSeCFOP1ogIgIO0FCHcrrPVwxxSo2sKrevD1LVqRC2Anzq+c+FFW5m4IjB2Q4PTO3ZtmLj50pFsmrczcLnTJ0V4HzHWESFMua3/cmqfrgsTt2QdZHWgHIwwgEynToTwpTjA96sMqqTs1m2p3plrwiStESJ1uqbQBnEXZbfGU7YXN4SpY1VWllKoBXBmqg5UCACvW4wpwbzW1anYuNYw8d+zjrYCFJXpqMJJBDSRESijnOa37dyuljDxyglDrYyvZkBaI4Q2XVNozaE30bhVO23ZopNhktYI4UIfAxSxYwqtY2HitVnndT0C9DOHT5YQA/GCIiqjsS1PDXYDKQ8Tr/7FERapCKQ1Qrhf5xTaOE2n8evfTfjNqQrT3tYIvgWgA3WfJSEGjtsAWpjoFNqUhKmzNQK1AP1Y92kRIgkfMFPlQFs9bA0TPz7qVLbUIgbydJ8FIezChFbDojDltWzu93V2hElaI4T/dbV6cHAa5a79tNdXJBMmbskKWDG6FszVIBys+3CFcMAOMOYra0jtd1s9Bh2mjrXZlyrmWgCn6T46IRzH/CYTTQ3ktjbt/acEw8RrR53EbFQzuEj38QihGwHNxBSmvJZXEgqT9Xj2bWC+QVaNEKInjoFQpca0zvvuXwJ9vwdT5XlUIXpiC6T+Vyn1597+Gkh0c0KkIwb+YUCV0diWfwBAbx/oJExC9G/AN3MlTEL0qudE2ZYBTZSVMAnxHQQ0Udz4Y6IPwEqYhNiDX1SdU2OfHMy7pU1CCMY2EMLqy0MvGGyQALkyifTWuXKhNfQmyku+nV3CJNISAc2krMk0ZuNrdm1TwiTSzRtMdKORgtXeJUwiXXwBwtzO4ZQtKRlOKWESftc5Ntm0ZtO4Jz5L5Y4kTMK3CLyerMAUumzdFif2J2HyBu58GkwmPg3QW8w01chr/T8ndyr/cVyPX1QKoxTUBcwY9D2QNLELwFyVgdMCeS2OBgmQK5N7MbZBoUrtOPROurrBBABmjDIfH30VgRaC8SPdJboIg2ip6uAZNL71E11F9N0cuDbbNStbp5nOG4n9zMXuMb99BoAhugvWiQnPGSaX0WUbnnF0vwl12kqYHEdAE5kqTOPWvzWQ16f5yiIfMlPFQOfc2U3C5F5vMHhKIHfDqsG8mddmj7Y6B96cpftAHLAbhDvU7o5quuKpr3QVIWFynx43EpNb5W7vaox8K4DDdB9YKhDQRLAmU+7Gd3TXImFyj5TdSOSWrP2tGKYBKIdf1glmvKRIhSl3/UbdpewpScKkH4HXk+Iwjdn4cir345MxbdtBmKd2HLLnF023kDDptZWJKwJjNzQ4udOO1Vk5ilAL4Ke6T0AiZQN8t1LBm2lM85e6i+mNhEmPXQBuS3TJEjvx8+cGre0H/tYLo617DnrUXUt/JEzOcsWNxG8V5OZFF3oZQexmEiaHMPifhoWw0zcSB1zf46NOZVMtZkKu7lrQPRx/5yGL6eqGmO5iBkrClHpabyQmqnOhOqoDcLzze9/3si1u1ltu5EFXe+wGYYHKwCmBvJYlXggSAARyN6xUXx5yCghhAI7dAGVCq2J1jjG2pdSLQeqLXJmSREATWbiBLmv9j+5aksFrxxxpcWwOUru49/vMNNsrV+7+yMc8OzFeUuAyytvwhO5SbD2stVnnmcx1BLrYxq0OahFmN5Mw2cO1NxLtwgwyHx99FTFuA+jYZDZFoEdJGdNoTPN7uo/LThKm5Lj+RqLdeM3YYRZi0wHMBLBfQu8FnjeIwjS25Sndx5GScyNhGhwCmsk0ymjculd116IDrxl1jEVGNZhDA3j5xwBF1DMt91EElu7aU3ZOJEwJe4OJbgykYMaaF3WsHp3d+WgSnfH9v3IMwD39NTX6iYRp4L4AY4HXbiQ6YW+rh7UQoEOBrl80jUAZ5TS/rbs+x86DhGmf4gD/WRmBmyln3XbdxbhZ56NJ7dMtqMeDuevX667H8eOXMPWNgBayjLBTM9aEt/WWG5lO1H0jMa9lie5ChLelc5h6tEa0+OJGotArHcPUeSMR5lTK3fi+7mKEf6RVmJjwnMEqTLnrn9Zdi/CfNHlqnD8C6PfG060XSpBEqvj9ytQ1Yy2udcaaSA++DdOeGWtj9c9YE/4RiUTUlreCpQAe+O7f/BimTQqqzE0z1oQ/FBTXnL9lK2oBvhg+D5PvWyOEHr+8ZsGRgUB8DsC/Qz+/M/ghTGnXGiGcUVS0aEg8s30ywawE6IB9vd7TYdo7Y63V1TPWhPcUhqommPxNHSUwbMabYeqasWZ4ZMaa8I4rJ1afpRTqmGlUou/1Wpg6Z6xZQ2tp3Kp23cUI/ygqivzQysiYw4RBD+j0SJh6zFjL889oKKHfpEn3Bre3bbvOBEUAHJTMtlwfJia0GpYKU27LZt21CH8pLK3J2bZrey2IbFnUwM1hep+ZZgdypTVC2Cu/NDpSMW5niy+3c/FSF4ap54w1aY0Q9rnyN5GDjHiwnC2EOQULwbkpTF0z1gK+m7Em9IpEImrz1mAJxelWTuESpa4Ik99nrAl98kPR0Vu2oo6AM1O9L81h4o8ANdfw+Yw14byC4gVHA2YUjBLAzm9GfdMSprhF2PThwZvf3Tli/NU33vOhjhqEP02YFBkabAvOAMwZAIY4uW/Hw/TCB4fgL8+fgv9+NeRMAM8Vhmoip5/Qfl8kEpErk0gCU35o/lXUxgsB/EhHBY6N+vrgy/3xwPMnY/NHI3r78/NghFcsq5DvTCJhV06sOVcprgPwM6f2ubx+1vc+Oqb8yvR1ewANL5+I1a8fA4v7/Oh6HghPFJZEH1VKTWtYUi6/5ol9KiipPgJAZF+tEU5J2ZXJtAgtbx2FhzediJ3fZCTy1jaAFx4Y6Jj/wAMRuc8kvqeoKJJhZQb/YIFuIeBAHTX0dmVKSZpf/mQEZvztItz77E8SDRIADAVozs54xr/zS6pLAXbklxjhDYWhqglmZsZrDKrVFaS+2Hpl+njnUDy86UQ88+7hthXIQCugwo1Ly+XZvDRW+KvoKWxgMYA83bUAKfzO9E2HgZWvHYfGl49Hh2XvxY6ALMB6saA4uoxVcFpj/XR5ajyN9GiNuA7a74v2L6krEwN44p0jUf/CSOzYnfDHucHYwaD53wwfVrvqT5Oln8nHsrIigRHHZF7LbFUDdLDuer7L1u9M/972A1Su+h/86cnTnAoSABxE4PlDvvh6S35x9HKndiqcdVVx9aUjjs54kZnvdWOQ+pLwZXN72354+KWTsPGdw8H6fhsYSYSVBcXRZgqo8PIHy2UGhA8UldScaIGjFlCku5bBGHCY2k2Fx145Hn995TjE4oPq6rUfIYdN66XC4ujdZjA2568PRHboLkkkLhRaOGwXx6ab4HKkoDXCKfv8zsRMePa9w1D/wkh8tiuhBbcdPhJ8Tsy3qPaT7mxouFrm5nkCU35JNESgBQDs+wnYAb19Z+o3TG9tPxAPPn8yXvt0uO7aE8CvEWHK8vrKNborEX27cmLVBUoZdQBfqLuWwUjop/G7nj4NG946AuzM0+s2olOZsbowFG1SMCc31N8ks8ZdpKi06ijTVDUglPjthnyfYWp960jdtSWFGZebMMYWFkfv6cg0Zj92/0xZBUOj7umopsWzQdhfdz2poP3hwBTLYMLkQMx8vTBUMykSifj9eF2pMFQ1wcz45lUCzwf8GSTA/2HqdiQz37tla8azV5VUXay7mHRRUFJ9Tn5JdCOzegyE43TXk2qufjwjBc63oJ6UVo/Uyi+NjlAmbmbgehrkdFQvSrcwAQAxUGRa1riCkurbpNXDPt3TUdnCXCb8QHc9TkuXj3m9GQbQnJ1mxpudrR4iGYWlNTmftW3fxKBaIP2CBKTnlenbGMcQ6MGCUPQ3RBxevqRyi+6SvKSoZN7JJoxFbPE4X/3OPQgSpm6MbGZ6SVo9Bmb8xJrh+ylrpgmaAsCxJ53dTML0bQqEkOKOy/NLahYE2tsXNzREYrqLcpM901HBCxl0qO563CSdvzP1iYHhBJ5vZma8XFBSPV53PW5RMLE6e8vWjJcI9CAACdJ3yJWpfyMBaioojjYbQFnDsopXdRekwxXXVB1jGKoahJDuWtxMwjQQhBwT2FRYHL1bxdTNDQ3labEQdXdrBEAzAbi4ZcAd5GPewAWZMNnMtN4qLKkuKyp6xMc3I5nyQzVFu7jjVYDmQII0IBKmxI1gUK2ZufW5gonzE15E2O0KimvOLyiZ/yQxPwLgWN31eIl8zBu8s6GsDX5p9fjlNQuODATic9wyHdWLJExJ6mr1uLSwpPqOjoxAtddaPbqnozLMeQAdoLseL5P/A9ljCINmBmLma16aQts1HfX1rkeAJEhJkiuTvY4i0IMFJTV/ZBUta1xS8YzugnqTH1pwKlnmYmbk6q7FTyRMqXE+WXiqoDi61AgGZjQ8MOMT3QUBPaajsnk9KH1aI5wiYUodAiFkxuMFuls9Jk26N7h99+e/NdmqBuCZoY5eI9+ZUm9Y16oeL+eHahwfrlhYWpOzbdf2l7w2HdWL5MrknBOJ+ZGCkuh6Ujwl1a0ehRPnnQTDWMQWX+65AVMeJWFy3iVs0QsFJdX3G0Ga3fCXis/s3PiVv4kcZMSD5QwKg707HdWLJEx6BACaZHWgyK5Wjz2tEXG6lYHDdB9gOpLvTBp1t3rEMzO3FIai4wa7nfxQdPTLWzNe6GqNkCBpIlcmFyDwycz4W0FxtJmVMbmxfuZrA3lfQfGCowEzCkYJQ74Z6SZhchNCDrG5ubA4encbYjetWhbZ2dvLJkyKDA22BWcA5gwAQ3SXLTrJxzz3CTJh8hAK9tLq0dkaEWzL6G6NkCC5SJ+rYBSGahJeIFqkxIsKCMctalOK6wD8THdBIoULRIuUOscCNijFDPkk4WoSJm8gyA8Mrif/pxPCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWzSd5iIbgcgS1AK8W2xrmx8T59hWlE/axpZ5mkENOiuXghXYDSToc5ZUT9rWm9/7rM5kGjvE/9XFVdfahHVAjhN9/EIocGbAN+4Ymnl37r/obfcDChMAJCVFQmMOCbzWmarWiaDijSxg0HzexvFllSYuu0Z/k64DtJcKPzJAmMZq+C0xvrpn/b2AlvC1K3wV9FT2MBiAHm6j1wIuzDQCqhw49Lyzf2+zs4wdSsMVU1gVrUAfqz7RAgxaIT3mXl249LKJQN5eW+5Sfo+0/L62SuN9tipBA4zsDPZ7QnhsDaA5x5oxEYONEh9SfrK1FNBSfURACIAySLDwu2YgEeVUtMalpS/l/CbU/ExrzdXTqw5V2a8CRd7HozwimUVTw12A46FqWt3lB+afxUxLwTwIyfPlBB9+JiIIqef0H5fJBKxktmQw2HqtHcuNslcbKFLjBj39De/PVFawtRtz4oNhBLIQEXhECI0waSy5Q/NetvO7WoNU7f8UHQ0MeoAnJmSHQgBAITXmWlK49JZq1Ox+ZT8NJ6oxvqKDWecGDuHwb8G8F+n9y98jvA5gcOfvx87PVVB6nPXTl+ZevrW+quQ9VdFUuIA399hZlaufHjatlTvzBUf83qTXxodqRi3M+Nyx3YqfIOBdSAON9ZX/suxfbo1TN0KS2ty2ORaEH7q+M6FB9G/mVDZWD/L8Z47V3xn6s/yJbOaDx424mwi+j3AKb9UC8/6GuC5u4cPO11HkPriqitTTz1aPa4HYCS9QeEHFhjL4hZPf+zhSq0/Xrn+Y15v8kMLTiXLXAxCru5ahEaEf8KyylYsm/2s7lIAj4apW1erRx2A43XXIhz1IYMrGpdW1APkmnWWXf+dqT9drR6nEDgM4Cvd9YiUayPwAqM9dkpna4R7gtQXz1yZevrlNQuODATic6TVw5+I0GQadMNfH5j1H9219MXTH/N6UxiqOo/ZqAP4Yt21CFu8qIDwo0srntBdyL74Lkxdh9Xd6nEbgGN1VyMGg7cRUKXaT7qzoeFqU3c1A6rYn2HqFAotHLaLY9MBmglgP931iAHpIMbddrZGOMXXYep2xTVVxxiGqgYhpLsW0Q9GMytjcmP9zNd0lzKo8tMhTN0KJlZnQ1EtgDN01yL2YtAbivjG5fUVf9ddS1LH4eWfxhO14qHKljNOjJ3d1erxadIbFEkh4AsGlQfa28/wepD6PEa/Xpl66tHqMQVAhu560owFxjIjA1Mb/lLxme5i7JJWH/N6k18aHUkWLQJ4vO5a0gKhhYjDy5dUbtFdit3SPkzdCktrciyL6wj4ie5afOo9Bt+U7FBHN0ur70z9Wb5kVvMhQ0ec1fVo0pe66/GRXQDPPTAQO9nPQepLWl6ZesovjY5QJm6WVo+kMBhLjWBgRsMDMz7RXYwjBywf8/pWWFpzNltWLUCjdNfiMc+xQlnjkopndBfiJAnTAEirx4B9xOBZbmuNcIqEaYCKihYNiWe2TyZwJYADdNfjMrsJfEdHRqD6sftnpm0rjIQpQUWlVUeZpqqRKbSdiNCkYE5uqL/pHd216CZhGqSC4przAa4D4SLdtWjyEiwVXvFQ+UbdhbiFhCkpTPkl0RCBFgA4XHc1DtlO4Hleao1wioTJBmnS6tFBjLtVTN3c0FAu9+F6IWGy0ZW/nneCYRo1DBTprsVWjGYKqPDyB8tf0V2Km0mYUiA/VHMJMS+G91s93mTG1MZlFU26C/ECeZwoBRrrZ63v0erhxaeidzCofPfw/c+QICVHrkw2Gj+xZvh+yprpkVYPC4xlrILTGuunS79XguRjnkOKSuadbMJYBGCc7lp6w0AroMKNS8s3667FqyRMDissrclhy7oDoFN119LlAwZXpusjQHaS70wOW75kVvPBQw8+0wWtHm1drREneWU6qhfJlckhmlo9mIBH2bKmr3ho9ru6z4GfyMc8FygoqT6HQbUE/CKV+yHCC2yhbMWyiqd0H7MfSZhcpDBUNYEtdQcIx9m86Y+JKHL6Ce33RSIRS/dx+pWEyWUmTIoMDbRl3kDg2QD2T3JzMWLc48XpqF4kYXKpZFs9iNAEk8qWPzTrbd3Hki4kTC535cSqC5Qy6gC+cEBvILzOTFMal85arbv2dCNh8oQBtHoQPifmW7Z/0HFXa2skrrvidCRh8pAerR7lADK7/jkO8P0dZmblyoenyWr0GkmYPKhw4ryTYBiL2EKQlTHFq6tG+E1CYRJCJEYeJxLCJhImIWwiYRLCJhImIWwiYRLCJv8P9sXhC7xE4kIAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDQtMTNUMDg6MTY6MDgrMDI6MDCcYZVaAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA0LTEzVDA4OjE2OjA4KzAyOjAw7Twt5gAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - get
+          - delete
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          verbs:
+          - get
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - users
+          verbs:
+          - list
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consolelinks
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - patch
+          - delete
+        serviceAccountName: che-operator
+      deployments:
+      - name: che-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: che-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: che-operator
+            spec:
+              containers:
+              - command:
+                - /usr/local/bin/che-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: che-operator
+                image: quay.io/eclipse/che-operator:7.6.0
+                imagePullPolicy: IfNotPresent
+                name: che-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              restartPolicy: Always
+              serviceAccountName: che-operator
+              terminationGracePeriodSeconds: 5
+      permissions:
+      - rules:
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - serviceaccounts
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - pods/exec
+          - pods/log
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - org.eclipse.che
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: che-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - workspaces
+  - devtools
+  - developer
+  - ide
+  - java
+  links:
+  - name: Product Page
+    url: http://www.eclipse.org/che
+  - name: Documentation
+    url: https://www.eclipse.org/che/docs
+  - name: Operator GitHub Repo
+    url: https://github.com/eclipse/che-operator
+  maintainers:
+  - email: dfestal@redhat.com
+    name: David Festal
+  maturity: stable
+  provider:
+    name: Eclipse Foundation
+  replaces: eclipse-che-preview-openshift.v7.5.1
+  version: 7.6.0

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.6.0/eclipse-che-preview-openshift.v7.6.0.clusterserviceversion.yaml.diff
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.6.0/eclipse-che-preview-openshift.v7.6.0.clusterserviceversion.yaml.diff
@@ -1,0 +1,36 @@
+--- /home/ibuziuk/git/che-operator/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.5.1/eclipse-che-preview-openshift.v7.5.1.clusterserviceversion.yaml	2019-12-20 15:05:05.609179322 +0100
++++ /home/ibuziuk/git/che-operator/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/7.6.0/eclipse-che-preview-openshift.v7.6.0.clusterserviceversion.yaml	2019-12-20 15:28:21.334993393 +0100
+@@ -45,13 +45,13 @@
+     capabilities: Seamless Upgrades
+     categories: Developer Tools, OpenShift Optional
+     certified: "false"
+-    containerImage: quay.io/eclipse/che-operator:7.5.1
+-    createdAt: "2019-12-10T13:31:32Z"
++    containerImage: quay.io/eclipse/che-operator:7.6.0
++    createdAt: "2019-12-20T14:28:21Z"
+     description: A Kube-native development solution that delivers portable and collaborative
+       developer workspaces in OpenShift.
+     repository: https://github.com/eclipse/che-operator
+     support: Eclipse Foundation
+-  name: eclipse-che-preview-openshift.v7.5.1
++  name: eclipse-che-preview-openshift.v7.6.0
+   namespace: placeholder
+ spec:
+   apiservicedefinitions: {}
+@@ -287,7 +287,7 @@
+                       fieldPath: metadata.name
+                 - name: OPERATOR_NAME
+                   value: che-operator
+-                image: quay.io/eclipse/che-operator:7.5.1
++                image: quay.io/eclipse/che-operator:7.6.0
+                 imagePullPolicy: IfNotPresent
+                 name: che-operator
+                 ports:
+@@ -395,5 +395,5 @@
+   maturity: stable
+   provider:
+     name: Eclipse Foundation
+-  replaces: eclipse-che-preview-openshift.v7.4.0
+-  version: 7.5.1
++  replaces: eclipse-che-preview-openshift.v7.5.1
++  version: 7.6.0

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/eclipse-che-preview-openshift.package.yaml
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/eclipse-che-preview-openshift.package.yaml
@@ -1,7 +1,7 @@
 channels:
 - currentCSV: eclipse-che-preview-openshift.v9.9.9-nightly.1575355471
   name: nightly
-- currentCSV: eclipse-che-preview-openshift.v7.5.1
+- currentCSV: eclipse-che-preview-openshift.v7.6.0
   name: stable
 defaultChannel: stable
 packageName: eclipse-che-preview-openshift

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -22,7 +22,7 @@ import (
 const (
 	defaultCheServerImageRepo           = "eclipse/che-server"
 	defaultCodeReadyServerImageRepo     = "registry.redhat.io/codeready-workspaces/server-rhel8"
-	defaultCheServerImageTag            = "7.5.1"
+	defaultCheServerImageTag            = "7.6.0"
 	defaultCodeReadyServerImageTag      = "2.0"
 	DefaultCheFlavor                    = "che"
 	DefaultChePostgresUser              = "pgche"
@@ -34,11 +34,11 @@ const (
 	DefaultIngressStrategy              = "multi-host"
 	DefaultIngressClass                 = "nginx"
 	defaultPluginRegistryImage          = "registry.redhat.io/codeready-workspaces/pluginregistry-rhel8:2.0"
-	defaultPluginRegistryUpstreamImage  = "quay.io/eclipse/che-plugin-registry:7.5.1"
+	defaultPluginRegistryUpstreamImage  = "quay.io/eclipse/che-plugin-registry:7.6.0"
 	DefaultPluginRegistryMemoryLimit    = "256Mi"
 	DefaultPluginRegistryMemoryRequest  = "16Mi"
 	defaultDevfileRegistryImage         = "registry.redhat.io/codeready-workspaces/devfileregistry-rhel8:2.0"
-	defaultDevfileRegistryUpstreamImage = "quay.io/eclipse/che-devfile-registry:7.5.1"
+	defaultDevfileRegistryUpstreamImage = "quay.io/eclipse/che-devfile-registry:7.6.0"
 	DefaultDevfileRegistryMemoryLimit   = "256Mi"
 	DefaultDevfileRegistryMemoryRequest = "16Mi"
 	DefaultKeycloakAdminUserName        = "admin"
@@ -50,7 +50,7 @@ const (
 	defaultPostgresImage                = "registry.redhat.io/rhscl/postgresql-96-rhel7:1-47"
 	defaultPostgresUpstreamImage        = "centos/postgresql-96-centos7:9.6"
 	defaultKeycloakImage                = "registry.redhat.io/redhat-sso-7/sso73-openshift:1.0-15"
-	defaultKeycloakUpstreamImage        = "eclipse/che-keycloak:7.5.1"
+	defaultKeycloakUpstreamImage        = "eclipse/che-keycloak:7.6.0"
 	DefaultJavaOpts                     = "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 " +
 		"-XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 " +
 		"-XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap " +


### PR DESCRIPTION
Issue #15504

Release 7.6.0 version of the che-operator
 - update defaults.go files 
 - release 7.6.0 OLM files

OLM packages on the Quay.io preview applications:
- https://quay.io/application/eclipse-che-operator-kubernetes/eclipse-che-preview-kubernetes
- https://quay.io/application/eclipse-che-operator-openshift/eclipse-che-preview-openshift


  
