### PR TITLE
Apply git self-signed SSL certs

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -33,6 +33,9 @@ spec:
     # when set to true the operator will attempt to get a secret in OpenShift router namespace
     # to add it to Java trust store of Che server. Requires cluster-admin privileges for operator service account
     selfSignedCert: false
+    ## If enabled then the certificate from `che-git-self-signed-cert` config map
+    ## will be propagated to the Che components and provide particular configuration for Git.
+    gitSelfSignedCert: false
     # TLS mode for Che. Make sure you either have public cert, or set selfSignedCert to true
     tlsSupport: false
     # protocol+hostname of a proxy server. Automatically added as JAVA_OPTS and https(s)_proxy

--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -390,6 +390,11 @@ spec:
                     clusters that have not been setup with a valid certificate for
                     the routes. This is disabled by default.
                   type: boolean
+                gitSelfSignedCert:
+                  description: If enabled, then the certificate from `che-git-self-signed-cert`
+                  config map will be propagated to the Che components and provide particular
+                  configuration for Git.
+                  type: boolean
                 serverMemoryLimit:
                   description: Overrides the memory limit used in the Che server deployment.
                     Defaults to 1Gi.

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -117,6 +117,7 @@ type CheClusterSpecServer struct {
 	// This is disabled by default.
 	// +optional
 	SelfSignedCert bool `json:"selfSignedCert"`
+	GitSelfSignedCert bool `json:"gitSelfSignedCert"`
 	// Instructs the operator to deploy Che in TLS mode, ie with TLS routes or ingresses.
 	// This is disabled by default.
 	// WARNING: Enabling TLS might require enabling the `selfSignedCert` field also in some cases.

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -1157,11 +1157,14 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 	desiredImagePullPolicy := util.GetValue(string(instance.Spec.Server.CheImagePullPolicy), deploy.DefaultPullPolicyFromDockerImage(cheImageRepo+":"+cheImageTag))
 	effectiveImagePullPolicy := string(effectiveCheDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 	desiredSelfSignedCert := instance.Spec.Server.SelfSignedCert
+	desiredGitSelfSignedCert := instance.Spec.Server.GitSelfSignedCert
 	effectiveSelfSignedCert := r.GetDeploymentEnvVarSource(effectiveCheDeployment, "CHE_SELF__SIGNED__CERT") != nil
+	effectiveGitSelfSignedCert := r.GetDeploymentEnvVarSource(effectiveCheDeployment, "CHE_GIT_SELF__SIGNED__CERT") != nil
 	if desiredMemRequest.Cmp(effectiveMemRequest) != 0 ||
 		desiredMemLimit.Cmp(effectiveMemLimit) != 0 ||
 		effectiveImagePullPolicy != desiredImagePullPolicy ||
-		effectiveSelfSignedCert != desiredSelfSignedCert {
+		effectiveSelfSignedCert != desiredSelfSignedCert ||
+		effectiveGitSelfSignedCert != desiredGitSelfSignedCert {
 		cheDeployment, err := deploy.NewCheDeployment(instance, cheImageRepo, cheImageTag, cmResourceVersion, isOpenShift)
 		if err != nil {
 			logrus.Errorf("An error occurred: %s", err)


### PR DESCRIPTION
Add new boolean property `gitSelfSignedCert`that applies environment variables that contain SSL certificate and git host written from `che-git-self-signed-cert` config map.
The same logic is applied for the helm deployment: https://github.com/eclipse/che/pull/15218

fixes https://github.com/eclipse/che/issues/15285

Docs PR: https://github.com/eclipse/che-docs/pull/1001