### PR TITLE
Add missing separating spaces to che_crd.yaml

### DIFF
--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -390,8 +390,8 @@ spec:
                   type: boolean
                 gitSelfSignedCert:
                   description: If enabled, then the certificate from `che-git-self-signed-cert`
-                  config map will be propagated to the Che components and provide particular
-                  configuration for Git.
+                    config map will be propagated to the Che components and provide particular
+                    configuration for Git.
                   type: boolean
                 serverMemoryLimit:
                   description: Overrides the memory limit used in the Che server deployment.


### PR DESCRIPTION
The `gitSelfSignedCert` item has incorrect description format. This fixes the formatting and prevents an error: 
```
✖ Create CRD checlusters.org.eclipse.che
      →                           ^
      Waiting 5 seconds for the new Kubernetes resources to get flushed
      Create deployment che-operator in namespace che
      Create Che Cluster eclipse-che in namespace che
Eclipse Che logs will be available in '/home/tolusha/projects/chectl/bin/logs'
YAMLException: can not read a block mapping entry; a multiline key may not be an implicit key at line 395, column 23:
                      type: boolean
                          ^
    at generateError (~/projects/chectl/node_modules/js-yaml/lib/js-yaml/loader.js:167:10)
    at throwError (~/projects/chectl/node_modules/js-yaml/lib/js-yaml/loader.js:173:9)
    at readBlockMapping (~/projects/chectl/node_modules/js-yaml/lib/js-yaml/loader.js:1073:9)
    at composeNode (~/projects/chectl/node_modules/js-yaml/lib/js-yaml/loader.js:1359:12)
``` 