### PR TITLE
[base] Update from devtools/go-toolset-rhel7:1.11.13-11.1571302666 to devtools/go-toolset-rhel7:1.12.8-20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # NOTE: using registry.redhat.io/rhel8/go-toolset requires login, which complicates automation
 # NOTE: since updateBaseImages.sh does not support other registries than RHCC, update to RHEL8
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/devtools/go-toolset-rhel7
-FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.11.13-11.1571302666  as builder
+FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.12.8-20  as builder
 ENV PATH=/opt/rh/go-toolset-1.11/root/usr/bin:$PATH \
     GOPATH=/go/
 


### PR DESCRIPTION
Change-Id: I849cd3be474222565a1208386917217ce35ad373
Signed-off-by: nickboldt <nboldt@redhat.com>

[base] Update from devtools/go-toolset-rhel7:1.11.13-11.1571302666 to devtools/go-toolset-rhel7:1.12.8-20

Change-Id: I849cd3be474222565a1208386917217ce35ad373
Signed-off-by: nickboldt <nboldt@redhat.com>