### PR TITLE
Add the debug port to che-host svc to expose the debug port

### DIFF
--- a/pkg/deploy/che_service.go
+++ b/pkg/deploy/che_service.go
@@ -27,6 +27,12 @@ func NewCheService(instance *orgv1.CheCluster, cheLabels map[string]string, r Se
 		portNames = append(portNames, "metrics")
 		portPorts = append(portPorts, DefaultCheMetricsPort)
 	}
+
+	if instance.Spec.Server.CheDebug == "true" {
+		portNames = append(portNames, "debug")
+		portPorts = append(portPorts, DefaultCheDebugPort)
+	}
+
 	cheService := NewService(instance, "che-host", portNames, portPorts, cheLabels)
 	if err := r.CreateService(instance, cheService, true); err != nil {
 		return nil, err

--- a/pkg/deploy/che_service_test.go
+++ b/pkg/deploy/che_service_test.go
@@ -51,6 +51,28 @@ func TestCreateCheDefaultService(t *testing.T) {
 	checkPort(ports[0], "http", 8080, t)
 }
 
+func TestCreateCheServerDebug(t *testing.T) {
+	cheCluster := &orgv1.CheCluster{
+		Spec: orgv1.CheClusterSpec{
+			Server: orgv1.CheClusterSpecServer{
+				CheDebug: "true",
+			},
+		},
+	}
+
+	service, err := NewCheService(cheCluster, map[string]string{}, &DummyServiceCreator{})
+
+	if service == nil || err != nil {
+		t.Error("service should be created witn no error")
+	}
+	ports := service.Spec.Ports
+	if len(ports) != 2 {
+		t.Error("expected 1 default port")
+	}
+	checkPort(ports[0], "http", 8080, t)
+	checkPort(ports[1], "debug", 8000, t)
+}
+
 func TestCreateCheServiceEnableMetrics(t *testing.T) {
 	cheCluster := &orgv1.CheCluster{
 		Spec: orgv1.CheClusterSpec{
@@ -107,7 +129,6 @@ func TestFailWhenCantCreateService(t *testing.T) {
 		t.Errorf("expected error and service to be nil. Actual service:`%s` err:`%s`", service, err)
 	}
 }
-
 
 func checkPort(actualPort corev1.ServicePort, expectedName string, expectedPort int32, t *testing.T) {
 	if actualPort.Name != expectedName || actualPort.Port != expectedPort {

--- a/pkg/deploy/che_service_test.go
+++ b/pkg/deploy/che_service_test.go
@@ -63,11 +63,11 @@ func TestCreateCheServerDebug(t *testing.T) {
 	service, err := NewCheService(cheCluster, map[string]string{}, &DummyServiceCreator{})
 
 	if service == nil || err != nil {
-		t.Error("service should be created witn no error")
+		t.Error("service should be created without error")
 	}
 	ports := service.Spec.Ports
 	if len(ports) != 2 {
-		t.Error("expected 1 default port")
+		t.Error("expected 2 default port")
 	}
 	checkPort(ports[0], "http", 8080, t)
 	checkPort(ports[1], "debug", 8000, t)

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -45,6 +45,7 @@ const (
 	DefaultCheLogLevel                  = "INFO"
 	DefaultCheDebug                     = "false"
 	DefaultCheMetricsPort               = int32(8087)
+	DefaultCheDebugPort                 = int32(8000)
 	defaultPvcJobsImage                 = "registry.redhat.io/ubi8-minimal:8.0-213"
 	defaultPvcJobsUpstreamImage         = "registry.access.redhat.com/ubi8-minimal:8.0-213"
 	defaultPostgresImage                = "registry.redhat.io/rhscl/postgresql-96-rhel7:1-47"


### PR DESCRIPTION
Signed-off-by: Tom George <tg82490@gmail.com>

setting `Spec.Server.CheDebug` to `true` will make `che-server` listen on port 8000 for debugging purposes.  However, the `che-host` service does not currently expose port 8000.  This change adds a debug port at port 8000 for the `che-host` service, so you can `port-forward` it and attach a debugger from your laptop into a running che instance.  

If `Spec.Server.CheDebug` is set to `true` it will add a route to port 8000 inside the pod, and will remove it from the service when `CheDebug` is set to false.

I needed this as part of https://github.com/eclipse/che/issues/15709.  It may be that you don't want users to attach a debugger to the che-operator, but it is useful when you are working on che.