### PR TITLE
Force valid namespace values for workspaces when Openshift OAuth is not enabled

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -99,6 +99,10 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 		if isOpenshift4 {
 			openShiftIdentityProviderId = "openshift-v4"
 		}
+	} else {
+		// This should probably be removed when PR https://github.com/eclipse/che-operator/pull/166 is merged
+		defaultTargetNamespace = cr.Namespace
+		namespaceAllowUserDefined = "false"	
 	}
 	tlsSupport := cr.Spec.Server.TlsSupport
 	protocol := "http"


### PR DESCRIPTION
... when Openshift OAuth is not enabled
... until PR #166 is merged (or updated)

Signed-off-by: David Festal <dfestal@redhat.com>