### PR TITLE
Improve debug configuration. Add debug binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ anaconda-mode/
 *.dll
 *.so
 *.dylib
+cmd/manager/__debug_bin
 
 # Test binary, build with 'go test -c'
 *.test

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,14 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "useApiV1": false,
+      "dlvLoadConfig": {
+          "followPointers": true,
+          "maxVariableRecurse": 1,
+          "maxStringLen": 3000,
+          "maxArrayValues": 100,
+          "maxStructFields": -1
+      },
       "name": "Che Operator",
       "type": "go",
       "request": "launch",


### PR DESCRIPTION
Improve debug configuration. Add debug binary to .gitignore. In the latest vscode-go extension we have an issue with cutting strings to 64 characters, and cut array by length. `maxStructFields` - means evaluate all nested fields in the structure. `followPointers` - usefull when we have an structure with nested structures in the fields.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>