### PR TITLE
Set tlsSupport to true by default

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -37,7 +37,7 @@ spec:
     ## will be propagated to the Che components and provide particular configuration for Git.
     gitSelfSignedCert: false
     # TLS mode for Che. Make sure you either have public cert, or set selfSignedCert to true
-    tlsSupport: false
+    tlsSupport: true
     # protocol+hostname of a proxy server. Automatically added as JAVA_OPTS and https(s)_proxy
     # to Che server and workspaces containers
     proxyURL: ''


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

Backports https://github.com/eclipse/che-operator/pull/186 to 7.9.x