### PR TITLE
Add minikube installation without vm-driver

### DIFF
--- a/.ci/cico_olm_prcheck.sh
+++ b/.ci/cico_olm_prcheck.sh
@@ -23,7 +23,8 @@ init() {
   if [[ ${WORKSPACE} ]] && [[ -d ${WORKSPACE} ]]; then OPERATOR_REPO=${WORKSPACE}; else OPERATOR_REPO=$(dirname "$SCRIPTPATH"); fi
   RAM_MEMORY=8192
   NAMESPACE="che-default"
-  CHANNEL="nightly"
+  #Temporal stable waiting to fix tls in nightly
+  CHANNEL="stable"
 }
 
 install_Dependencies() {

--- a/.ci/cico_olm_prcheck.sh
+++ b/.ci/cico_olm_prcheck.sh
@@ -48,7 +48,8 @@ run_olm_tests() {
     fi
     if [[ ${platform} == 'kubernetes' ]]; then
       printInfo "Starting minikube VM to test kubernetes olm files..."
-      minikube start --memory=${RAM_MEMORY}
+      source ${OPERATOR_REPO}/.ci/start-minikube.sh
+  
       sh "${OPERATOR_REPO}"/olm/testCatalogSource.sh ${platform} ${CHANNEL} ${NAMESPACE}
       printInfo "Successfully verified olm files on kubernetes platform."
       rm -rf ~/.kube && yes | minikube delete

--- a/.ci/start-minikube.sh
+++ b/.ci/start-minikube.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+# Minikube environments config
+export MINIKUBE_VERSION=v1.2.0
+export KUBERNETES_VERSION=v1.14.5
+export MINIKUBE_HOME=$HOME
+export CHANGE_MINIKUBE_NONE_USER=true
+export KUBECONFIG=$HOME/.kube/config
+export TEST_OUTPUT=1
+
+sudo mount --make-rshared /
+sudo mount --make-rshared /proc
+sudo mount --make-rshared /sys
+
+# Download minikube binary
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && \
+  chmod +x kubectl &&  \
+sudo mv kubectl /usr/local/bin/
+
+# Download minikube binary
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube-linux-amd64 && \
+  chmod +x minikube && \
+  sudo mv minikube /usr/local/bin/
+
+# Configure firewall rules for docker0 network
+firewall-cmd --permanent --zone=trusted --add-interface=docker0
+firewall-cmd --reload
+firewall-cmd --get-active-zones
+firewall-cmd --list-all --zone=trusted
+
+# Create kube folder
+mkdir "${HOME}"/.kube || true
+touch "${HOME}"/.kube/config
+
+# minikube config
+minikube config set WantUpdateNotification false
+minikube config set WantReportErrorPrompt false
+minikube config set WantNoneDriverWarning false
+minikube config set vm-driver none
+minikube version
+
+# minikube start
+minikube start --kubernetes-version=$KUBERNETES_VERSION --extra-config=apiserver.authorization-mode=RBAC
+
+# waiting for node(s) to be ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+
+# waiting for kube-addon-manager to be ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
+
+# waiting for kube-dns to be ready
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
+
+#Give god access to the k8s API
+kubectl apply -f - <<EOF
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: cluster-reader
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["*"]
+    verbs: ["*"]
+
+EOF


### PR DESCRIPTION
In order to install minikube in ci.centos.org needed to install with vm-driver=none flag.