### PR TITLE
Refactor setting of tlsSecretName in NewIngress

### DIFF
--- a/pkg/deploy/ingress.go
+++ b/pkg/deploy/ingress.go
@@ -12,8 +12,6 @@
 package deploy
 
 import (
-	"strconv"
-
 	orgv1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
 	"github.com/eclipse/che-operator/pkg/util"
 	"k8s.io/api/extensions/v1beta1"
@@ -31,15 +29,14 @@ func NewIngress(cr *orgv1.CheCluster, name string, serviceName string, port int)
 	ingressClass := util.GetValue(cr.Spec.K8s.IngressClass, DefaultIngressClass)
 	labels := GetLabels(cr, name)
 
+	tlsSecretName := cr.Spec.K8s.TlsSecretName
 	tls := "false"
 	if tlsSupport {
 		tls = "true"
-	}
-	tlsSecretName := cr.Spec.K8s.TlsSecretName
-	// If TLS is turned on but the secret is not set, try to use Che default value as k8s cluster defaults will not work.
-	tlsFlag, _ := strconv.ParseBool(tls)
-	if tlsFlag && tlsSecretName == "" {
-		tlsSecretName = "che-tls"
+		// If TLS is turned on but the secret name is not set, try to use Che default value as k8s cluster defaults will not work.
+		if tlsSecretName == "" {
+			tlsSecretName = "che-tls"
+		}
 	}
 
 	host := ""


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

Remove redundant parsing of string to boolean and second tls flag.
Follow up to: https://github.com/eclipse/che-operator/pull/191