### PR TITLE
Set default Che secret name in Che server config map if tlsSecretName is not specified in CR

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -128,6 +128,9 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 
 	ingressDomain := cr.Spec.K8s.IngressDomain
 	tlsSecretName := cr.Spec.K8s.TlsSecretName
+	if tlsSupport && tlsSecretName == "" {
+		tlsSecretName = "che-tls"
+	}
 	securityContextFsGroup := util.GetValue(cr.Spec.K8s.SecurityContextFsGroup, DefaultSecurityContextFsGroup)
 	securityContextRunAsUser := util.GetValue(cr.Spec.K8s.SecurityContextRunAsUser, DefaultSecurityContextRunAsUser)
 	pvcStrategy := util.GetValue(cr.Spec.Storage.PvcStrategy, DefaultPvcStrategy)


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Sets default Che TLS secret name in Che config map if Che CR doesn't specify it when TLS is turned on.

### Referenced issues
https://github.com/eclipse/che/issues/16280
