### PR TITLE
Store credentials into secrets instead of plain text of CheCluster CR fields

### DIFF
--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2012-2019 Red Hat, Inc.
+#  Copyright (c) 2012-2020 Red Hat, Inc.
 #    This program and the accompanying materials are made
 #    available under the terms of the Eclipse Public License 2.0
 #    which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -94,12 +94,33 @@ spec:
                     field). If omitted or left blank, it will be set to an auto-generated
                     password.
                   type: string
+                identityProviderPostgresSecret:
+                  description: 'The secret that contains `password` for The Identity
+                    Provider (Keycloak / RH SSO) to connect to the database. If the
+                    secret is defined then `identityProviderPostgresPassword` will
+                    be ignored. If the value is omitted or left blank then there are
+                    two scenarios: 1. `identityProviderPostgresPassword` is defined,
+                    then it will be used to connect to the database. 2. `identityProviderPostgresPassword`
+                    is not defined, then a new secret with the name `che-identity-postgres-secret`
+                    will be created with an auto-generated value for `password`.'
+                  type: string
                 identityProviderRealm:
                   description: Name of a Identity provider (Keycloak / RH SSO) realm
                     that should be used for Che. This is useful to override it ONLY
                     if you use an external Identity Provider (see the `externalIdentityProvider`
                     field). If omitted or left blank, it will be set to the value
                     of the `flavour` field.
+                  type: string
+                identityProviderSecret:
+                  description: 'The secret that contains `user` and `password` for
+                    Identity Provider. If the secret is defined then `identityProviderAdminUserName`
+                    and `identityProviderPassword` are ignored. If the value is omitted
+                    or left blank then there are two scenarios: 1. `identityProviderAdminUserName`
+                    and `identityProviderPassword` are defined, then they will be
+                    used. 2. `identityProviderAdminUserName` or `identityProviderPassword`
+                    are not defined, then a new secret with the name `che-identity-secret`
+                    will be created with default value `admin` for `user` and with
+                    an auto-generated value for `password`.'
                   type: string
                 identityProviderURL:
                   description: Public URL of the Identity Provider server (Keycloak
@@ -120,10 +141,10 @@ spec:
                   type: string
                 openShiftoAuth:
                   description: 'Enables the integration of the identity provider (Keycloak
-                    / RHSSO) with OpenShift OAuth. Enabled by defaumt on OpenShift.
+                    / RHSSO) with OpenShift OAuth. Enabled by default on OpenShift.
                     This will allow users to directly login with their Openshift user
-                    throug the Openshift login, and have their workspaces created
-                    under personnal OpenShift namespaces. WARNING: the `kuebadmin`
+                    through the Openshift login, and have their workspaces created
+                    under personal OpenShift namespaces. WARNING: the `kubeadmin`
                     user is NOT supported, and logging through it will NOT allow accessing
                     the Che Dashboard.'
                   type: boolean
@@ -156,6 +177,17 @@ spec:
                     connect to. Defaults to 5432. This value should be overridden
                     ONLY when using an external database (see field `externalDb`).
                     In the default case it will be automatically set by the operator.
+                  type: string
+                chePostgresSecret:
+                  description: 'The secret that contains Postgres `user` and `password`
+                    that the Che server should use to connect to the DB. If the secret
+                    is defined then `chePostgresUser` and `chePostgresPassword` are
+                    ignored. If the value is omitted or left blank then there are
+                    two scenarios: 1. `chePostgresUser` and `chePostgresPassword`
+                    are defined, then they will be used to connect to the DB. 2. `chePostgresUser`
+                    or `chePostgresPassword` are not defined, then a new secret with
+                    the name `che-postgres-secret` will be created with default value
+                    of `pgche` for `user` and with an auto-generated value for `password`.'
                   type: string
                 chePostgresUser:
                   description: Postgres user that the Che server should use to connect
@@ -293,13 +325,6 @@ spec:
                     config map from other CR fields, then the value defined in the
                     `customCheProperties` will be used instead.
                   type: object
-                serverTrustStoreConfigMapName:
-                  description: Name of the config-map with public certificates to
-                    add to Java trust store of the Che server. This is usually required
-                    when adding the OpenShift OAuth provider which has https endpoint
-                    signed with self-signed cert. So, Che server must be aware of
-                    its CA cert to be able to request it. This is disabled by default.
-                  type: string
                 devfileRegistryImage:
                   description: Overrides the container image used in the Devfile registry
                     deployment. This includes the image tag. Omit it or leave it empty
@@ -374,12 +399,17 @@ spec:
                     default this will be automatically calculated by the operator.
                   type: string
                 proxyPassword:
-                  description: Password of the proxy server  Only use when proxy configuration
-                    is required (see also the `proxyUser` field).
+                  description: Password of the proxy server Only use when proxy configuration
+                    is required (see also the `proxyUser` and `proxySecret` fields).
                   type: string
                 proxyPort:
                   description: Port of the proxy server. Only use when configuring
                     a proxy is required (see also the `proxyURL` field).
+                  type: string
+                proxySecret:
+                  description: The secret that contains `user` and `password` for
+                    a proxy server. If the secret is defined then `proxyUser` and
+                    `proxyPassword` are ignored
                   type: string
                 proxyURL:
                   description: URL (protocol+hostname) of the proxy server. This drives
@@ -389,7 +419,7 @@ spec:
                   type: string
                 proxyUser:
                   description: User name of the proxy server. Only use when configuring
-                    a proxy is required (see also the `proxyURL` field).
+                    a proxy is required (see also the `proxyURL` `proxySecret` fields).
                   type: string
                 selfSignedCert:
                   description: Enables the support of OpenShift clusters whose router
@@ -407,6 +437,13 @@ spec:
                 serverMemoryRequest:
                   description: Overrides the memory request used in the Che server
                     deployment. Defaults to 512Mi.
+                  type: string
+                serverTrustStoreConfigMapName:
+                  description: Name of the config-map with public certificates to
+                    add to Java trust store of the Che server. This is usually required
+                    when adding the OpenShift OAuth provider which has https endpoint
+                    signed with self-signed cert. So, Che server must be aware of
+                    its CA cert to be able to request it. This is disabled by default.
                   type: string
                 tlsSupport:
                   description: 'Instructs the operator to deploy Che in TLS mode,

--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584615281/eclipse-che-preview-kubernetes.crd.yaml
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584615281/eclipse-che-preview-kubernetes.crd.yaml
@@ -1,0 +1,553 @@
+#
+#  Copyright (c) 2012-2020 Red Hat, Inc.
+#    This program and the accompanying materials are made
+#    available under the terms of the Eclipse Public License 2.0
+#    which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#    Red Hat, Inc. - initial API and implementation
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: checlusters.org.eclipse.che
+spec:
+  group: org.eclipse.che
+  names:
+    kind: CheCluster
+    listKind: CheClusterList
+    plural: checlusters
+    singular: checluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Desired configuration of the Che installation. Based on these
+            settings, the operator automatically creates and maintains several config
+            maps that will contain the appropriate environment variables the various
+            components of the Che installation. These generated config maps should
+            NOT be updated manually.
+          properties:
+            auth:
+              description: Configuration settings related to the Authentication used
+                by the Che installation.
+              properties:
+                externalIdentityProvider:
+                  description: 'Instructs the operator on whether or not to deploy
+                    a dedicated Identity Provider (Keycloak or RH SSO instance). By
+                    default a dedicated Identity Provider server is deployed as part
+                    of the Che installation. But if `externalIdentityProvider` is
+                    `true`, then no dedicated identity provider will be deployed by
+                    the operator and you might need to provide details about the external
+                    identity provider you want to use. See also all the other fields
+                    starting with: `identityProvider`.'
+                  type: boolean
+                identityProviderAdminUserName:
+                  description: Overrides the name of the Identity Provider admin user.
+                    Defaults to `admin`.
+                  type: string
+                identityProviderClientId:
+                  description: Name of a Identity provider (Keycloak / RH SSO) `client-id`
+                    that should be used for Che. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to the value
+                    of the `flavour` field suffixed with `-public`.
+                  type: string
+                identityProviderImage:
+                  description: Overrides the container image used in the Identity
+                    Provider (Keycloak / RH SSO) deployment. This includes the image
+                    tag. Omit it or leave it empty to use the defaut container image
+                    provided by the operator.
+                  type: string
+                identityProviderImagePullPolicy:
+                  description: Overrides the image pull policy used in the Identity
+                    Provider (Keycloak / RH SSO) deployment. Default value is `Always`
+                    for `nightly` or `latest` images, and `IfNotPresent` in other
+                    cases.
+                  type: string
+                identityProviderPassword:
+                  description: Overrides the password of Keycloak admin user. This
+                    is useful to override it ONLY if you use an external Identity
+                    Provider (see the `externalIdentityProvider` field). If omitted
+                    or left blank, it will be set to an auto-generated password.
+                  type: string
+                identityProviderPostgresPassword:
+                  description: Password for The Identity Provider (Keycloak / RH SSO)
+                    to connect to the database. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to an auto-generated
+                    password.
+                  type: string
+                identityProviderPostgresSecret:
+                  description: 'The secret that contains `password` for The Identity
+                    Provider (Keycloak / RH SSO) to connect to the database. If the
+                    secret is defined then `identityProviderPostgresPassword` will
+                    be ignored. If the value is omitted or left blank then there are
+                    two scenarios: 1. `identityProviderPostgresPassword` is defined,
+                    then it will be used to connect to the database. 2. `identityProviderPostgresPassword`
+                    is not defined, then a new secret with the name `che-identity-postgres-secret`
+                    will be created with an auto-generated value for `password`.'
+                  type: string
+                identityProviderRealm:
+                  description: Name of a Identity provider (Keycloak / RH SSO) realm
+                    that should be used for Che. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to the value
+                    of the `flavour` field.
+                  type: string
+                identityProviderSecret:
+                  description: 'The secret that contains `user` and `password` for
+                    Identity Provider. If the secret is defined then `identityProviderAdminUserName`
+                    and `identityProviderPassword` are ignored. If the value is omitted
+                    or left blank then there are two scenarios: 1. `identityProviderAdminUserName`
+                    and `identityProviderPassword` are defined, then they will be
+                    used. 2. `identityProviderAdminUserName` or `identityProviderPassword`
+                    are not defined, then a new secret with the name `che-identity-secret`
+                    will be created with default value `admin` for `user` and with
+                    an auto-generated value for `password`.'
+                  type: string
+                identityProviderURL:
+                  description: Public URL of the Identity Provider server (Keycloak
+                    / RH SSO server). You should set it ONLY if you use an external
+                    Identity Provider (see the `externalIdentityProvider` field).
+                    By default this will be automatically calculated and set by the
+                    operator.
+                  type: string
+                oAuthClientName:
+                  description: Name of the OpenShift `OAuthClient` resource used to
+                    setup identity federation on the OpenShift side. Auto-generated
+                    if left blank. See also the `OpenShiftoAuth` field.
+                  type: string
+                oAuthSecret:
+                  description: Name of the secret set in the OpenShift `OAuthClient`
+                    resource used to setup identity federation on the OpenShift side.
+                    Auto-generated if left blank. See also the `OAuthClientName` field.
+                  type: string
+                openShiftoAuth:
+                  description: 'Enables the integration of the identity provider (Keycloak
+                    / RHSSO) with OpenShift OAuth. Enabled by default on OpenShift.
+                    This will allow users to directly login with their Openshift user
+                    through the Openshift login, and have their workspaces created
+                    under personal OpenShift namespaces. WARNING: the `kubeadmin`
+                    user is NOT supported, and logging through it will NOT allow accessing
+                    the Che Dashboard.'
+                  type: boolean
+                updateAdminPassword:
+                  description: Forces the default `admin` Che user to update password
+                    on first login. Defaults to `false`.
+                  type: boolean
+              type: object
+            database:
+              description: Configuration settings related to the database used by
+                the Che installation.
+              properties:
+                chePostgresDb:
+                  description: Postgres database name that the Che server uses to
+                    connect to the DB. Defaults to `dbche`.
+                  type: string
+                chePostgresHostName:
+                  description: Postgres Database hostname that the Che server uses
+                    to connect to. Defaults to postgres. This value should be overridden
+                    ONLY when using an external database (see field `externalDb`).
+                    In the default case it will be automatically set by the operator.
+                  type: string
+                chePostgresPassword:
+                  description: Postgres password that the Che server should use to
+                    connect to the DB. If omitted or left blank, it will be set to
+                    an auto-generated value.
+                  type: string
+                chePostgresPort:
+                  description: Postgres Database port that the Che server uses to
+                    connect to. Defaults to 5432. This value should be overridden
+                    ONLY when using an external database (see field `externalDb`).
+                    In the default case it will be automatically set by the operator.
+                  type: string
+                chePostgresSecret:
+                  description: 'The secret that contains Postgres `user` and `password`
+                    that the Che server should use to connect to the DB. If the secret
+                    is defined then `chePostgresUser` and `chePostgresPassword` are
+                    ignored. If the value is omitted or left blank then there are
+                    two scenarios: 1. `chePostgresUser` and `chePostgresPassword`
+                    are defined, then they will be used to connect to the DB. 2. `chePostgresUser`
+                    or `chePostgresPassword` are not defined, then a new secret with
+                    the name `che-postgres-secret` will be created with default value
+                    of `pgche` for `user` and with an auto-generated value for `password`.'
+                  type: string
+                chePostgresUser:
+                  description: Postgres user that the Che server should use to connect
+                    to the DB. Defaults to `pgche`.
+                  type: string
+                externalDb:
+                  description: 'Instructs the operator on whether or not to deploy
+                    a dedicated database. By default a dedicated Postgres database
+                    is deployed as part of the Che installation. But if `externalDb`
+                    is `true`, then no dedicated database will be deployed by the
+                    operator and you might need to provide connection details to the
+                    external DB you want to use. See also all the fields starting
+                    with: `chePostgres`.'
+                  type: boolean
+                postgresImage:
+                  description: Overrides the container image used in the Postgres
+                    database deployment. This includes the image tag. Omit it or leave
+                    it empty to use the defaut container image provided by the operator.
+                  type: string
+                postgresImagePullPolicy:
+                  description: Overrides the image pull policy used in the Postgres
+                    database deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+              type: object
+            k8s:
+              description: Configuration settings specific to Che installations made
+                on upstream Kubernetes.
+              properties:
+                ingressClass:
+                  description: 'Ingress class that will define the which controler
+                    will manage ingresses. Defaults to `nginx`. NB: This drives the
+                    `is kubernetes.io/ingress.class` annotation on Che-related ingresses.'
+                  type: string
+                ingressDomain:
+                  description: 'Global ingress domain for a K8S cluster. This MUST
+                    be explicitly specified: there are no defaults.'
+                  type: string
+                ingressStrategy:
+                  description: Strategy for ingress creation. This can be `multi-host`
+                    (host is explicitly provided in ingress), `single-host` (host
+                    is provided, path-based rules) and `default-host.*`(no host is
+                    provided, path-based rules). Defaults to `"multi-host`
+                  type: string
+                securityContextFsGroup:
+                  description: FSGroup the Che pod and Workspace pods containers should
+                    run in. Defaults to `1724`.
+                  type: string
+                securityContextRunAsUser:
+                  description: ID of the user the Che pod and Workspace pods containers
+                    should run as. Default to `1724`.
+                  type: string
+                tlsSecretName:
+                  description: Name of a secret that will be used to setup ingress
+                    TLS termination if TLS is enabled. See also the `tlsSupport` field.
+                  type: string
+              type: object
+            metrics:
+              description: Configuration settings related to the metrics collection
+                used by the Che installation.
+              properties:
+                enable:
+                  description: Enables `metrics` Che server endpoint. Default to `false`.
+                  type: boolean
+              type: object
+            server:
+              description: General configuration settings related to the Che server
+                and the plugin and devfile registries
+              properties:
+                airGapContainerRegistryHostname:
+                  description: Optional hostname (or url) to an alternate container
+                    registry to pull images from. This value overrides the container
+                    registry hostname defined in all the default container images
+                    involved in a Che deployment. This is particularly useful to install
+                    Che in an air-gapped environment.
+                  type: string
+                airGapContainerRegistryOrganization:
+                  description: Optional repository name of an alternate container
+                    registry to pull images from. This value overrides the container
+                    registry organization defined in all the default container images
+                    involved in a Che deployment. This is particularly useful to install
+                    Che in an air-gapped environment.
+                  type: string
+                allowUserDefinedWorkspaceNamespaces:
+                  description: Defines if a user is able to specify Kubernetes namespace
+                    (or OpenShift project) different from the default. It's NOT RECOMMENDED
+                    to configured true without OAuth configured. This property is
+                    also used by the OpenShift infra.
+                  type: boolean
+                cheDebug:
+                  description: Enables the debug mode for Che server. Defaults to
+                    `false`.
+                  type: string
+                cheFlavor:
+                  description: Flavor of the installation. This is either `che` for
+                    upstream Che installations, or `codeready` for CodeReady Workspaces
+                    installation. In most cases the default value should not be overriden.
+                  type: string
+                cheHost:
+                  description: Public hostname of the installed Che server. This will
+                    be automatically set by the operator. In most cases the default
+                    value set by the operator should not be overriden.
+                  type: string
+                cheImage:
+                  description: Overrides the container image used in Che deployment.
+                    This does NOT include the container image tag. Omit it or leave
+                    it empty to use the defaut container image provided by the operator.
+                  type: string
+                cheImagePullPolicy:
+                  description: Overrides the image pull policy used in Che deployment.
+                    Default value is `Always` for `nightly` or `latest` images, and
+                    `IfNotPresent` in other cases.
+                  type: string
+                cheImageTag:
+                  description: Overrides the tag of the container image used in Che
+                    deployment. Omit it or leave it empty to use the defaut image
+                    tag provided by the operator.
+                  type: string
+                cheLogLevel:
+                  description: 'Log level for the Che server: `INFO` or `DEBUG`. Defaults
+                    to `INFO`.'
+                  type: string
+                cheWorkspaceClusterRole:
+                  description: Custom cluster role bound to the user for the Che workspaces.
+                    The default roles are used if this is omitted or left blank.
+                  type: string
+                customCheProperties:
+                  additionalProperties:
+                    type: string
+                  description: Map of additional environment variables that will be
+                    applied in the generated `che` config map to be used by the Che
+                    server, in addition to the values already generated from other
+                    fields of the `CheCluster` custom resource (CR). If `customCheProperties`
+                    contains a property that would be normally generated in `che`
+                    config map from other CR fields, then the value defined in the
+                    `customCheProperties` will be used instead.
+                  type: object
+                devfileRegistryImage:
+                  description: Overrides the container image used in the Devfile registry
+                    deployment. This includes the image tag. Omit it or leave it empty
+                    to use the defaut container image provided by the operator.
+                  type: string
+                devfileRegistryMemoryLimit:
+                  description: Overrides the memory limit used in the Devfile registry
+                    deployment. Defaults to 256Mi.
+                  type: string
+                devfileRegistryMemoryRequest:
+                  description: Overrides the memory request used in the Devfile registry
+                    deployment. Defaults to 16Mi.
+                  type: string
+                devfileRegistryPullPolicy:
+                  description: Overrides the image pull policy used in the Devfile
+                    registry deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+                devfileRegistryUrl:
+                  description: Public URL of the Devfile registry, that serves sample,
+                    ready-to-use devfiles. You should set it ONLY if you use an external
+                    devfile registry (see the `externalDevfileRegistry` field). By
+                    default this will be automatically calculated by the operator.
+                  type: string
+                externalDevfileRegistry:
+                  description: Instructs the operator on whether or not to deploy
+                    a dedicated Devfile registry server. By default a dedicated devfile
+                    registry server is started. But if `externalDevfileRegistry` is
+                    `true`, then no such dedicated server will be started by the operator
+                    and you will have to manually set the `devfileRegistryUrl` field
+                  type: boolean
+                externalPluginRegistry:
+                  description: Instructs the operator on whether or not to deploy
+                    a dedicated Plugin registry server. By default a dedicated plugin
+                    registry server is started. But if `externalPluginRegistry` is
+                    `true`, then no such dedicated server will be started by the operator
+                    and you will have to manually set the `pluginRegistryUrl` field.
+                  type: boolean
+                gitSelfSignedCert:
+                  description: If enabled, then the certificate from `che-git-self-signed-cert`
+                    config map will be propagated to the Che components and provide
+                    particular configuration for Git.
+                  type: boolean
+                nonProxyHosts:
+                  description: List of hosts that should not use the configured proxy.
+                    Use `|`` as delimiter, eg `localhost|my.host.com|123.42.12.32`
+                    Only use when configuring a proxy is required (see also the `proxyURL`
+                    field).
+                  type: string
+                pluginRegistryImage:
+                  description: Overrides the container image used in the Plugin registry
+                    deployment. This includes the image tag. Omit it or leave it empty
+                    to use the defaut container image provided by the operator.
+                  type: string
+                pluginRegistryMemoryLimit:
+                  description: Overrides the memory limit used in the Plugin registry
+                    deployment. Defaults to 256Mi.
+                  type: string
+                pluginRegistryMemoryRequest:
+                  description: Overrides the memory request used in the Plugin registry
+                    deployment. Defaults to 16Mi.
+                  type: string
+                pluginRegistryPullPolicy:
+                  description: Overrides the image pull policy used in the Plugin
+                    registry deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+                pluginRegistryUrl:
+                  description: Public URL of the Plugin registry, that serves sample
+                    ready-to-use devfiles. You should set it ONLY if you use an external
+                    devfile registry (see the `externalPluginRegistry` field). By
+                    default this will be automatically calculated by the operator.
+                  type: string
+                proxyPassword:
+                  description: Password of the proxy server Only use when proxy configuration
+                    is required (see also the `proxyUser` and `proxySecret` fields).
+                  type: string
+                proxyPort:
+                  description: Port of the proxy server. Only use when configuring
+                    a proxy is required (see also the `proxyURL` field).
+                  type: string
+                proxySecret:
+                  description: The secret that contains `user` and `password` for
+                    a proxy server. If the secret is defined then `proxyUser` and
+                    `proxyPassword` are ignored
+                  type: string
+                proxyURL:
+                  description: URL (protocol+hostname) of the proxy server. This drives
+                    the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy`
+                    variables in the Che server and workspaces containers. Only use
+                    when configuring a proxy is required.
+                  type: string
+                proxyUser:
+                  description: User name of the proxy server. Only use when configuring
+                    a proxy is required (see also the `proxyURL` `proxySecret` fields).
+                  type: string
+                selfSignedCert:
+                  description: Enables the support of OpenShift clusters whose router
+                    uses self-signed certificates. When enabled, the operator retrieves
+                    the default self-signed certificate of OpenShift routes and adds
+                    it to the Java trust store of the Che server. This is usually
+                    required when activating the `tlsSupport` field on demo OpenShift
+                    clusters that have not been setup with a valid certificate for
+                    the routes. This is disabled by default.
+                  type: boolean
+                serverMemoryLimit:
+                  description: Overrides the memory limit used in the Che server deployment.
+                    Defaults to 1Gi.
+                  type: string
+                serverMemoryRequest:
+                  description: Overrides the memory request used in the Che server
+                    deployment. Defaults to 512Mi.
+                  type: string
+                serverTrustStoreConfigMapName:
+                  description: Name of the config-map with public certificates to
+                    add to Java trust store of the Che server. This is usually required
+                    when adding the OpenShift OAuth provider which has https endpoint
+                    signed with self-signed cert. So, Che server must be aware of
+                    its CA cert to be able to request it. This is disabled by default.
+                  type: string
+                tlsSupport:
+                  description: 'Instructs the operator to deploy Che in TLS mode,
+                    ie with TLS routes or ingresses. This is disabled by default.
+                    WARNING: Enabling TLS might require enabling the `selfSignedCert`
+                    field also in some cases.'
+                  type: boolean
+                workspaceNamespaceDefault:
+                  description: 'Defines Kubernetes default namespace in which user''s
+                    workspaces are created if user does not override it. It''s possible
+                    to use <username>, <userid> and <workspaceid> placeholders (e.g.:
+                    che-workspace-<username>). In that case, new namespace will be
+                    created for each user (or workspace). Is used by OpenShift infra
+                    as well to specify Project'
+                  type: string
+              type: object
+            storage:
+              description: Configuration settings related to the persistent storage
+                used by the Che installation.
+              properties:
+                postgresPVCStorageClassName:
+                  description: Storage class for the Persistent Volume Claim dedicated
+                    to the Postgres database. If omitted or left blank, default storage
+                    class is used.
+                  type: string
+                preCreateSubPaths:
+                  description: Instructs the Che server to launch a special pod to
+                    pre-create a subpath in the Persistent Volumes. Defaults to `false`,
+                    however it might need to enable it according to the configuration
+                    of your K8S cluster.
+                  type: boolean
+                pvcClaimSize:
+                  description: Size of the persistent volume claim for workspaces.
+                    Defaults to `1Gi`
+                  type: string
+                pvcJobsImage:
+                  description: Overrides the container image used to create sub-paths
+                    in the Persistent Volumes. This includes the image tag. Omit it
+                    or leave it empty to use the defaut container image provided by
+                    the operator. See also the `preCreateSubPaths` field.
+                  type: string
+                pvcStrategy:
+                  description: Persistent volume claim strategy for the Che server.
+                    This Can be:`common` (all workspaces PVCs in one volume), `per-workspace`
+                    (one PVC per workspace for all declared volumes) and `unique`
+                    (one PVC per declared volume). Defaults to `common`.
+                  type: string
+                workspacePVCStorageClassName:
+                  description: Storage class for the Persistent Volume Claims dedicated
+                    to the Che workspaces. If omitted or left blank, default storage
+                    class is used.
+                  type: string
+              type: object
+          type: object
+        status:
+          description: CheClusterStatus defines the observed state of Che installation
+          properties:
+            cheClusterRunning:
+              description: Status of a Che installation. Can be `Available`, `Unavailable`,
+                or `Available, Rolling Update in Progress`
+              type: string
+            cheURL:
+              description: Public URL to the Che server
+              type: string
+            cheVersion:
+              description: Current installed Che version
+              type: string
+            dbProvisioned:
+              description: Indicates if or not a Postgres instance has been correctly
+                provisioned
+              type: boolean
+            devfileRegistryURL:
+              description: Public URL to the Devfile registry
+              type: string
+            helpLink:
+              description: A URL that can point to some URL where to find help related
+                to the current Operator status.
+              type: string
+            keycloakProvisioned:
+              description: Indicates whether an Identity Provider instance (Keycloak
+                / RH SSO) has been provisioned with realm, client and user
+              type: boolean
+            keycloakURL:
+              description: Public URL to the Identity Provider server (Keycloak /
+                RH SSO).
+              type: string
+            message:
+              description: A human readable message indicating details about why the
+                pod is in this condition.
+              type: string
+            openShiftoAuthProvisioned:
+              description: Indicates whether an Identity Provider instance (Keycloak
+                / RH SSO) has been configured to integrate with the OpenShift OAuth.
+              type: boolean
+            pluginRegistryURL:
+              description: Public URL to the Plugin registry
+              type: string
+            reason:
+              description: A brief CamelCase message indicating details about why
+                the pod is in this state.
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584615281/eclipse-che-preview-kubernetes.crd.yaml.diff
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584615281/eclipse-che-preview-kubernetes.crd.yaml.diff
@@ -1,0 +1,134 @@
+--- /home/tolusha/gocode/src/github.com/eclipse/che-operator/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584253673/eclipse-che-preview-kubernetes.crd.yaml	2020-03-19 12:12:28.014013721 +0200
++++ /home/tolusha/gocode/src/github.com/eclipse/che-operator/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584615281/eclipse-che-preview-kubernetes.crd.yaml	2020-03-19 12:54:41.548682162 +0200
+@@ -1,5 +1,5 @@
+ #
+-#  Copyright (c) 2012-2019 Red Hat, Inc.
++#  Copyright (c) 2012-2020 Red Hat, Inc.
+ #    This program and the accompanying materials are made
+ #    available under the terms of the Eclipse Public License 2.0
+ #    which is available at https://www.eclipse.org/legal/epl-2.0/
+@@ -94,6 +94,16 @@
+                     field). If omitted or left blank, it will be set to an auto-generated
+                     password.
+                   type: string
++                identityProviderPostgresSecret:
++                  description: 'The secret that contains `password` for The Identity
++                    Provider (Keycloak / RH SSO) to connect to the database. If the
++                    secret is defined then `identityProviderPostgresPassword` will
++                    be ignored. If the value is omitted or left blank then there are
++                    two scenarios: 1. `identityProviderPostgresPassword` is defined,
++                    then it will be used to connect to the database. 2. `identityProviderPostgresPassword`
++                    is not defined, then a new secret with the name `che-identity-postgres-secret`
++                    will be created with an auto-generated value for `password`.'
++                  type: string
+                 identityProviderRealm:
+                   description: Name of a Identity provider (Keycloak / RH SSO) realm
+                     that should be used for Che. This is useful to override it ONLY
+@@ -101,6 +111,17 @@
+                     field). If omitted or left blank, it will be set to the value
+                     of the `flavour` field.
+                   type: string
++                identityProviderSecret:
++                  description: 'The secret that contains `user` and `password` for
++                    Identity Provider. If the secret is defined then `identityProviderAdminUserName`
++                    and `identityProviderPassword` are ignored. If the value is omitted
++                    or left blank then there are two scenarios: 1. `identityProviderAdminUserName`
++                    and `identityProviderPassword` are defined, then they will be
++                    used. 2. `identityProviderAdminUserName` or `identityProviderPassword`
++                    are not defined, then a new secret with the name `che-identity-secret`
++                    will be created with default value `admin` for `user` and with
++                    an auto-generated value for `password`.'
++                  type: string
+                 identityProviderURL:
+                   description: Public URL of the Identity Provider server (Keycloak
+                     / RH SSO server). You should set it ONLY if you use an external
+@@ -120,10 +141,10 @@
+                   type: string
+                 openShiftoAuth:
+                   description: 'Enables the integration of the identity provider (Keycloak
+-                    / RHSSO) with OpenShift OAuth. Enabled by defaumt on OpenShift.
++                    / RHSSO) with OpenShift OAuth. Enabled by default on OpenShift.
+                     This will allow users to directly login with their Openshift user
+-                    throug the Openshift login, and have their workspaces created
+-                    under personnal OpenShift namespaces. WARNING: the `kuebadmin`
++                    through the Openshift login, and have their workspaces created
++                    under personal OpenShift namespaces. WARNING: the `kubeadmin`
+                     user is NOT supported, and logging through it will NOT allow accessing
+                     the Che Dashboard.'
+                   type: boolean
+@@ -157,6 +178,17 @@
+                     ONLY when using an external database (see field `externalDb`).
+                     In the default case it will be automatically set by the operator.
+                   type: string
++                chePostgresSecret:
++                  description: 'The secret that contains Postgres `user` and `password`
++                    that the Che server should use to connect to the DB. If the secret
++                    is defined then `chePostgresUser` and `chePostgresPassword` are
++                    ignored. If the value is omitted or left blank then there are
++                    two scenarios: 1. `chePostgresUser` and `chePostgresPassword`
++                    are defined, then they will be used to connect to the DB. 2. `chePostgresUser`
++                    or `chePostgresPassword` are not defined, then a new secret with
++                    the name `che-postgres-secret` will be created with default value
++                    of `pgche` for `user` and with an auto-generated value for `password`.'
++                  type: string
+                 chePostgresUser:
+                   description: Postgres user that the Che server should use to connect
+                     to the DB. Defaults to `pgche`.
+@@ -293,13 +325,6 @@
+                     config map from other CR fields, then the value defined in the
+                     `customCheProperties` will be used instead.
+                   type: object
+-                serverTrustStoreConfigMapName:
+-                  description: Name of the config-map with public certificates to
+-                    add to Java trust store of the Che server. This is usually required
+-                    when adding the OpenShift OAuth provider which has https endpoint
+-                    signed with self-signed cert. So, Che server must be aware of
+-                    its CA cert to be able to request it. This is disabled by default.
+-                  type: string
+                 devfileRegistryImage:
+                   description: Overrides the container image used in the Devfile registry
+                     deployment. This includes the image tag. Omit it or leave it empty
+@@ -374,13 +399,18 @@
+                     default this will be automatically calculated by the operator.
+                   type: string
+                 proxyPassword:
+-                  description: Password of the proxy server  Only use when proxy configuration
+-                    is required (see also the `proxyUser` field).
++                  description: Password of the proxy server Only use when proxy configuration
++                    is required (see also the `proxyUser` and `proxySecret` fields).
+                   type: string
+                 proxyPort:
+                   description: Port of the proxy server. Only use when configuring
+                     a proxy is required (see also the `proxyURL` field).
+                   type: string
++                proxySecret:
++                  description: The secret that contains `user` and `password` for
++                    a proxy server. If the secret is defined then `proxyUser` and
++                    `proxyPassword` are ignored
++                  type: string
+                 proxyURL:
+                   description: URL (protocol+hostname) of the proxy server. This drives
+                     the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy`
+@@ -389,7 +419,7 @@
+                   type: string
+                 proxyUser:
+                   description: User name of the proxy server. Only use when configuring
+-                    a proxy is required (see also the `proxyURL` field).
++                    a proxy is required (see also the `proxyURL` `proxySecret` fields).
+                   type: string
+                 selfSignedCert:
+                   description: Enables the support of OpenShift clusters whose router
+@@ -408,6 +438,13 @@
+                   description: Overrides the memory request used in the Che server
+                     deployment. Defaults to 512Mi.
+                   type: string
++                serverTrustStoreConfigMapName:
++                  description: Name of the config-map with public certificates to
++                    add to Java trust store of the Che server. This is usually required
++                    when adding the OpenShift OAuth provider which has https endpoint
++                    signed with self-signed cert. So, Che server must be aware of
++                    its CA cert to be able to request it. This is disabled by default.
++                  type: string
+                 tlsSupport:
+                   description: 'Instructs the operator to deploy Che in TLS mode,
+                     ie with TLS routes or ingresses. This is disabled by default.

--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584615281/eclipse-che-preview-kubernetes.v9.9.9-nightly.1584615281.clusterserviceversion.yaml
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584615281/eclipse-che-preview-kubernetes.v9.9.9-nightly.1584615281.clusterserviceversion.yaml
@@ -1,0 +1,374 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "org.eclipse.che/v1",
+          "kind": "CheCluster",
+          "metadata": {
+             "name": "eclipse-che"
+          },
+          "spec": {
+            "k8s": {
+                "ingressDomain": "",
+                "tlsSecretName": ""
+              },
+             "server": {
+                "cheImageTag": "nightly",
+                "devfileRegistryImage": "quay.io/eclipse/che-devfile-registry:nightly",
+                "pluginRegistryImage": "quay.io/eclipse/che-plugin-registry:nightly",
+                "tlsSupport": true,
+                "selfSignedCert": false
+             },
+             "database": {
+                "externalDb": false,
+                "chePostgresHostName": "",
+                "chePostgresPort": "",
+                "chePostgresUser": "",
+                "chePostgresPassword": "",
+                "chePostgresDb": ""
+             },
+             "auth": {
+                "identityProviderImage": "quay.io/eclipse/che-keycloak:nightly",
+                "externalIdentityProvider": false,
+                "identityProviderURL": "",
+                "identityProviderRealm": "",
+                "identityProviderClientId": ""
+             },
+             "storage": {
+                "pvcStrategy": "per-workspace",
+                "pvcClaimSize": "1Gi",
+                "preCreateSubPaths": true
+             }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Developer Tools
+    certified: "false"
+    containerImage: quay.io/eclipse/che-operator:nightly
+    createdAt: "2020-03-19T10:54:41Z"
+    description: A Kube-native development solution that delivers portable and collaborative
+      developer workspaces.
+    repository: https://github.com/eclipse/che-operator
+    support: Eclipse Foundation
+  name: eclipse-che-preview-kubernetes.v9.9.9-nightly.1584615281
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Eclipse Che cluster with DB and Auth Server
+      displayName: Eclipse Che Cluster
+      kind: CheCluster
+      name: checlusters.org.eclipse.che
+      specDescriptors:
+      - description: TLS routes
+        displayName: TLS Mode
+        path: server.tlsSupport
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      statusDescriptors:
+      - description: Ingress to access Eclipse Che
+        displayName: Eclipse Che URL
+        path: cheURL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      - description: Ingress to access Keycloak Admin Console
+        displayName: Keycloak Admin Console URL
+        path: keycloakURL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      - description: Eclipse Che server version
+        displayName: Eclipse Che version
+        path: cheVersion
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:label
+      - description: The current status of the application
+        displayName: Status
+        path: cheClusterRunning
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Reason of the current status
+        displayName: Reason
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Message explaining the current status
+        displayName: Message
+        path: message
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Link providing help related to the current status
+        displayName: Help link
+        path: helpLink
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      version: v1
+  description: |
+    A collaborative Kubernetes-native development solution that delivers Kubernetes workspaces and in-browser IDE for rapid cloud application development.
+    This operator installs PostgreSQL, Keycloak, Registries and the Eclipse Che server, as well as configures all these services.
+    ## Prerequisites
+    - Operator Lifecycle Manager (OLM) needs to be installed.
+    - Kubernetes Platform. For OpenShift, the installation is directly made from OperatorHub UI in the admin console.
+
+    OLM installation can be checked by running the command:
+    ```
+    $ kubectl get pods --all-namespaces | grep olm
+    olm             catalog-operator-7b8cd7f8bf-2v7zj                       1/1     Running   0          10m
+    olm             olm-operator-5c5c798cd5-s6ll5                           1/1     Running   0          10m
+    olm             olm-operators-fm5wc                                     1/1     Running   0          10m
+    olm             operatorhubio-catalog-d78km                             1/1     Running   0          10m
+    olm             packageserver-5c5f64947b-trghp                          1/1     Running   0          9m56s
+    olm             packageserver-5c5f64947b-zqvxg                          1/1     Running   0          9m56s
+    ```
+
+    ## How to Install
+    Install `Eclipse Che Operator` by following instructions in top right button `Install`.
+
+    A new pod che-operator is created in `my-eclipse-che` namespace
+
+    ```
+    $ kubectl get pods --all-namespaces | grep my-eclipse-che
+    my-eclipse-che   che-operator-554c564476-fl98z                           1/1     Running   0          13s
+    ```
+
+    The operator is now providing new Custom Resources Definitions: `checluster.org.eclipse.che`
+
+    Create a new Eclipse Che instance by creating a new CheCluster resource:
+
+    On the bottom of this page, there is a section `Custom Resource Definitions` with `Eclipse Che Cluster` name.
+
+    Click on `View YAML Example` *Link* and copy the content to a new file named `my-eclipse-che.yaml`
+    **Important!** Make sure you provide **K8s.ingressDomain** which is a global ingress domain of your k8s cluster, for example, `gcp.my-ide.cloud`
+    Create the new CheCluster by creating the resource in the `my-eclipse-che` namespace :
+    ```
+    $ kubectl create -f my-eclipse-che.yaml -n my-eclipse-che
+    ```
+    ***important:*** The operator is only tracking resources in its own namespace. If CheCluster is not created in this namespace it's ignored.
+    The operator will now create pods for Eclipse Che. The deployment status can be tracked by looking at the Operator logs by using the command:
+    ```
+    $ kubectl logs -n my-eclipse-che che-operator-554c564476-fl98z
+    ```
+    ***important:*** pod name is different on each installation
+
+    When all Eclipse Che containers are running, the Eclipse Che URL is printed
+
+
+    Eclipse Che URL can be tracked by searching for available trace:
+    ```
+    $ kubectl logs -f -n my-eclipse-che che-operator-7b6b4bcb9c-m4m2m | grep "Eclipse Che is now available"
+    time="2019-08-01T13:31:05Z" level=info msg="Eclipse Che is now available at: http://che-my-eclipse-che.gcp.my-ide.cloud"
+    ```
+    When Eclipse Che is ready, the Eclipse Che URL is displayed in CheCluster resource in `status` section
+    ```
+    $ kubectl describe checluster/eclipse-che -n my-eclipse-che
+    ```
+
+    ```
+    Status:
+      Che Cluster Running:           Available
+      Che URL:                       http://che-my-eclipse-che.gcp.my-ide.cloud
+      Che Version:                   7.0.0
+      ...
+    ```
+
+    By opening this URL in a web browser, Eclipse Che is ready to use.
+    ## Defaults
+    By default, the operator deploys Eclipse Che with:
+    * Bundled PostgreSQL and Keycloak
+    * Per-Workspace PVC strategy
+    * Auto-generated passwords
+    * HTTP mode (non-secure ingresses)
+    ## Installation Options
+    Eclipse Che operator installation options include:
+    * Connection to external database and Keycloak
+    * Configuration of default passwords and object names
+    * TLS mode
+    * PVC strategy (once shared PVC for all workspaces, PVC per workspace, or PVC per volume)
+    * Authentication options
+    ### External Database and Keycloak
+    To instruct the operator to skip deploying PostgreSQL and Keycloak and connect to an existing DB and Keycloak instead:
+    * set respective fields to `true` in a custom resource spec
+    * provide the operator with connection and authentication details:
+      ```
+      externalDb: true
+      chePostgresHostname: 'yourPostgresHost'
+      chePostgresPort: '5432'
+      chePostgresUser: 'myuser'
+      chePostgresPassword: 'mypass'
+      chePostgresDb: 'mydb'
+      externalIdentityProvider: true
+      identityProviderURL: 'https://my-keycloak.com'
+      identityProviderRealm: 'myrealm'
+      identityProviderClientId: 'myClient'
+      ```
+    ### TLS Mode
+    To activate TLS mode, set the respective field in the CR spec to `true` (in the `server` block):
+    ```
+    tlsSupport: true
+    ```
+    You will also need to provide name of tls secret that will be used for Eclipse Che and workspaces ingresses:
+    ```
+    tlsSecretName: 'my-ingress-tls-secret'
+    ```
+  displayName: Eclipse Che
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAANMAAAD0CAYAAAABrhNXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAaNklEQVR42u3de3QU9dkH8O/zm91EQK0U77dqVdTW++1V20KigUSQahLjsSSbtp4eeqqVLHILCcoiyQZEIbF61B6PVQJ6XiOkr6TlYiABr603wHotar1bBUWUYDY787x/JIGoSchmZ+c3M/t8/iS7M8+M5+vs7szz/IiZIYRIntJdgBB+IWESwiYSJiFsImESwiYSJiFsImESwiaBvv5ARLprEwB4ddaJTBQF8w/JsKbQmI0v665JAL3dUqK+7jNJmPTiNWOHWYhNB1AOILPrn+MA369MazaNe+Iz3TWmMwmTB3AEyrwwu4SIbwVwWB+v+hxEt6gg7qLs1rjumtORhMnlePUlF5hk1RFw4QDf8rrFmBLMa12tu/Z0I2FyKV53yVGWyTVgLgGQ8IknoImMQBnlNL+t+1jShYTJZXjlhKFW8KsbQJgNYP8ktxYDcI8yh95E41bt1H1sfidhcpH4mtETCHQHgONs3vTHAEXUMy33UQSW7uP0KwmTC/DqS84xyaol4Bcp3tULiqiMxrY8pfuY/UjCpBG3ZB1sxfgmgK4HYDi1WwI9SnGaTuPXv6v7HPiJhEkDfv7coPX5AdeB+RaADtRURRtAC9UB7Qvo4md26z4nfiBhcljH6qwcRbgDwKm6a+nyATNVGrkt9USQrtAkSJgcwquyT2ZlLWLQON219FofsMEghGls6ybdtXiVhCnFuOnnw62gEQHoOvTz3KM7sAVSy5RS0yln3X91V+M1EqYU4ZasgBWjawGuAnCI7noStAOM+coaUkvjVrXrLsYrJEwp0LHmkksUrFoAp+uuJSnMbzLR1EBua5PuUrxAwmSj7tYIBhfprsVOBDQTU5jyWl7RXYubSZhs0KM1YiaA/XTXkyIdAN+tMmgOZbfu0F2MG0mYksAMMtdkh4h4AYDDddfj0FF3tnrsOOROurrB1F2Nm0iYBolXjT7fVFRHwEW6a9FkkyIK09iWDboLcQsJU4KSbY3wGwKaCNZkyt34ju5adJMwDRA/fdEQa2fmZBAqARygux536Wr1+CY+m6546ivd1Wg7CxKmfUtha4TP8EeAmpuurR4Spn7w46PONi2qJdAo3bV4CROeM1iFKXf907prcfS4JUzfx82XjrDM+M0Ot0b4TWerB8yplLvxfd3FOHLAEqYeJ2NPawTmAviB7np8YheA21QG5lN26ze6i0klCVOXjtVZOUpxHZh+orsWn3qfmWYH8lqW6C4kVdI+TLwq+2Q2+HZmjNddSzogoIUsI0yXrduiuxa7pW2YuOnnw62MwEwwTwEoQ3c96aWr1SMen+qnKbRpF6a901GthQAdqrueNPcFGAvUzkMW09UNMd3FJCutwtSxenS2ItQCdIbuWsS3vMFENwbGtvxddyHJSIsw8ZpRx1hkVIM5pLsW0TcCmsk0ymjculd11zIYvg5TmrRG+E1nq4cK3kxjmr/UXUwifBkmZpD5+OiriHEbQMfqrkcMynYQ5nmp1cN3YepsjUAtgS7WXYuwA7+oGGHK2/CE7kr2WalfwsRrxxxpcWwOgN8BJEuJ+gwBTWThBrqs9T+6a+mL58PEjxRlWAd99gcw5kFaI3yO20D0JxVEFWW3fq27mu9V5+UwdbVG1AE4XnctwlEfMlOF26bQejJMvDbrLJNRS8Bo3bUIfRj8T0NRGY1pfVZ3LYDHwsSrc39o0TdzpDVC7OWeKbSeCFOP1ogIgIO0FCHcrrPVwxxSo2sKrevD1LVqRC2Anzq+c+FFW5m4IjB2Q4PTO3ZtmLj50pFsmrczcLnTJ0V4HzHWESFMua3/cmqfrgsTt2QdZHWgHIwwgEynToTwpTjA96sMqqTs1m2p3plrwiStESJ1uqbQBnEXZbfGU7YXN4SpY1VWllKoBXBmqg5UCACvW4wpwbzW1anYuNYw8d+zjrYCFJXpqMJJBDSRESijnOa37dyuljDxyglDrYyvZkBaI4Q2XVNozaE30bhVO23ZopNhktYI4UIfAxSxYwqtY2HitVnndT0C9DOHT5YQA/GCIiqjsS1PDXYDKQ8Tr/7FERapCKQ1Qrhf5xTaOE2n8evfTfjNqQrT3tYIvgWgA3WfJSEGjtsAWpjoFNqUhKmzNQK1AP1Y92kRIgkfMFPlQFs9bA0TPz7qVLbUIgbydJ8FIezChFbDojDltWzu93V2hElaI4T/dbV6cHAa5a79tNdXJBMmbskKWDG6FszVIBys+3CFcMAOMOYra0jtd1s9Bh2mjrXZlyrmWgCn6T46IRzH/CYTTQ3ktjbt/acEw8RrR53EbFQzuEj38QihGwHNxBSmvJZXEgqT9Xj2bWC+QVaNEKInjoFQpca0zvvuXwJ9vwdT5XlUIXpiC6T+Vyn1597+Gkh0c0KkIwb+YUCV0diWfwBAbx/oJExC9G/AN3MlTEL0qudE2ZYBTZSVMAnxHQQ0Udz4Y6IPwEqYhNiDX1SdU2OfHMy7pU1CCMY2EMLqy0MvGGyQALkyifTWuXKhNfQmyku+nV3CJNISAc2krMk0ZuNrdm1TwiTSzRtMdKORgtXeJUwiXXwBwtzO4ZQtKRlOKWESftc5Ntm0ZtO4Jz5L5Y4kTMK3CLyerMAUumzdFif2J2HyBu58GkwmPg3QW8w01chr/T8ndyr/cVyPX1QKoxTUBcwY9D2QNLELwFyVgdMCeS2OBgmQK5N7MbZBoUrtOPROurrBBABmjDIfH30VgRaC8SPdJboIg2ip6uAZNL71E11F9N0cuDbbNStbp5nOG4n9zMXuMb99BoAhugvWiQnPGSaX0WUbnnF0vwl12kqYHEdAE5kqTOPWvzWQ16f5yiIfMlPFQOfc2U3C5F5vMHhKIHfDqsG8mddmj7Y6B96cpftAHLAbhDvU7o5quuKpr3QVIWFynx43EpNb5W7vaox8K4DDdB9YKhDQRLAmU+7Gd3TXImFyj5TdSOSWrP2tGKYBKIdf1glmvKRIhSl3/UbdpewpScKkH4HXk+Iwjdn4cir345MxbdtBmKd2HLLnF023kDDptZWJKwJjNzQ4udOO1Vk5ilAL4Ke6T0AiZQN8t1LBm2lM85e6i+mNhEmPXQBuS3TJEjvx8+cGre0H/tYLo617DnrUXUt/JEzOcsWNxG8V5OZFF3oZQexmEiaHMPifhoWw0zcSB1zf46NOZVMtZkKu7lrQPRx/5yGL6eqGmO5iBkrClHpabyQmqnOhOqoDcLzze9/3si1u1ltu5EFXe+wGYYHKwCmBvJYlXggSAARyN6xUXx5yCghhAI7dAGVCq2J1jjG2pdSLQeqLXJmSREATWbiBLmv9j+5aksFrxxxpcWwOUru49/vMNNsrV+7+yMc8OzFeUuAyytvwhO5SbD2stVnnmcx1BLrYxq0OahFmN5Mw2cO1NxLtwgwyHx99FTFuA+jYZDZFoEdJGdNoTPN7uo/LThKm5Lj+RqLdeM3YYRZi0wHMBLBfQu8FnjeIwjS25Sndx5GScyNhGhwCmsk0ymjculd116IDrxl1jEVGNZhDA3j5xwBF1DMt91EElu7aU3ZOJEwJe4OJbgykYMaaF3WsHp3d+WgSnfH9v3IMwD39NTX6iYRp4L4AY4HXbiQ6YW+rh7UQoEOBrl80jUAZ5TS/rbs+x86DhGmf4gD/WRmBmyln3XbdxbhZ56NJ7dMtqMeDuevX667H8eOXMPWNgBayjLBTM9aEt/WWG5lO1H0jMa9lie5ChLelc5h6tEa0+OJGotArHcPUeSMR5lTK3fi+7mKEf6RVmJjwnMEqTLnrn9Zdi/CfNHlqnD8C6PfG060XSpBEqvj9ytQ1Yy2udcaaSA++DdOeGWtj9c9YE/4RiUTUlreCpQAe+O7f/BimTQqqzE0z1oQ/FBTXnL9lK2oBvhg+D5PvWyOEHr+8ZsGRgUB8DsC/Qz+/M/ghTGnXGiGcUVS0aEg8s30ywawE6IB9vd7TYdo7Y63V1TPWhPcUhqommPxNHSUwbMabYeqasWZ4ZMaa8I4rJ1afpRTqmGlUou/1Wpg6Z6xZQ2tp3Kp23cUI/ygqivzQysiYw4RBD+j0SJh6zFjL889oKKHfpEn3Bre3bbvOBEUAHJTMtlwfJia0GpYKU27LZt21CH8pLK3J2bZrey2IbFnUwM1hep+ZZgdypTVC2Cu/NDpSMW5niy+3c/FSF4ap54w1aY0Q9rnyN5GDjHiwnC2EOQULwbkpTF0z1gK+m7Em9IpEImrz1mAJxelWTuESpa4Ik99nrAl98kPR0Vu2oo6AM1O9L81h4o8ANdfw+Yw14byC4gVHA2YUjBLAzm9GfdMSprhF2PThwZvf3Tli/NU33vOhjhqEP02YFBkabAvOAMwZAIY4uW/Hw/TCB4fgL8+fgv9+NeRMAM8Vhmoip5/Qfl8kEpErk0gCU35o/lXUxgsB/EhHBY6N+vrgy/3xwPMnY/NHI3r78/NghFcsq5DvTCJhV06sOVcprgPwM6f2ubx+1vc+Oqb8yvR1ewANL5+I1a8fA4v7/Oh6HghPFJZEH1VKTWtYUi6/5ol9KiipPgJAZF+tEU5J2ZXJtAgtbx2FhzediJ3fZCTy1jaAFx4Y6Jj/wAMRuc8kvqeoKJJhZQb/YIFuIeBAHTX0dmVKSZpf/mQEZvztItz77E8SDRIADAVozs54xr/zS6pLAXbklxjhDYWhqglmZsZrDKrVFaS+2Hpl+njnUDy86UQ88+7hthXIQCugwo1Ly+XZvDRW+KvoKWxgMYA83bUAKfzO9E2HgZWvHYfGl49Hh2XvxY6ALMB6saA4uoxVcFpj/XR5ajyN9GiNuA7a74v2L6krEwN44p0jUf/CSOzYnfDHucHYwaD53wwfVrvqT5Oln8nHsrIigRHHZF7LbFUDdLDuer7L1u9M/972A1Su+h/86cnTnAoSABxE4PlDvvh6S35x9HKndiqcdVVx9aUjjs54kZnvdWOQ+pLwZXN72354+KWTsPGdw8H6fhsYSYSVBcXRZgqo8PIHy2UGhA8UldScaIGjFlCku5bBGHCY2k2Fx145Hn995TjE4oPq6rUfIYdN66XC4ujdZjA2568PRHboLkkkLhRaOGwXx6ab4HKkoDXCKfv8zsRMePa9w1D/wkh8tiuhBbcdPhJ8Tsy3qPaT7mxouFrm5nkCU35JNESgBQDs+wnYAb19Z+o3TG9tPxAPPn8yXvt0uO7aE8CvEWHK8vrKNborEX27cmLVBUoZdQBfqLuWwUjop/G7nj4NG946AuzM0+s2olOZsbowFG1SMCc31N8ks8ZdpKi06ijTVDUglPjthnyfYWp960jdtSWFGZebMMYWFkfv6cg0Zj92/0xZBUOj7umopsWzQdhfdz2poP3hwBTLYMLkQMx8vTBUMykSifj9eF2pMFQ1wcz45lUCzwf8GSTA/2HqdiQz37tla8azV5VUXay7mHRRUFJ9Tn5JdCOzegyE43TXk2qufjwjBc63oJ6UVo/Uyi+NjlAmbmbgehrkdFQvSrcwAQAxUGRa1riCkurbpNXDPt3TUdnCXCb8QHc9TkuXj3m9GQbQnJ1mxpudrR4iGYWlNTmftW3fxKBaIP2CBKTnlenbGMcQ6MGCUPQ3RBxevqRyi+6SvKSoZN7JJoxFbPE4X/3OPQgSpm6MbGZ6SVo9Bmb8xJrh+ylrpgmaAsCxJ53dTML0bQqEkOKOy/NLahYE2tsXNzREYrqLcpM901HBCxl0qO563CSdvzP1iYHhBJ5vZma8XFBSPV53PW5RMLE6e8vWjJcI9CAACdJ3yJWpfyMBaioojjYbQFnDsopXdRekwxXXVB1jGKoahJDuWtxMwjQQhBwT2FRYHL1bxdTNDQ3labEQdXdrBEAzAbi4ZcAd5GPewAWZMNnMtN4qLKkuKyp6xMc3I5nyQzVFu7jjVYDmQII0IBKmxI1gUK2ZufW5gonzE15E2O0KimvOLyiZ/yQxPwLgWN31eIl8zBu8s6GsDX5p9fjlNQuODATic9wyHdWLJExJ6mr1uLSwpPqOjoxAtddaPbqnozLMeQAdoLseL5P/A9ljCINmBmLma16aQts1HfX1rkeAJEhJkiuTvY4i0IMFJTV/ZBUta1xS8YzugnqTH1pwKlnmYmbk6q7FTyRMqXE+WXiqoDi61AgGZjQ8MOMT3QUBPaajsnk9KH1aI5wiYUodAiFkxuMFuls9Jk26N7h99+e/NdmqBuCZoY5eI9+ZUm9Y16oeL+eHahwfrlhYWpOzbdf2l7w2HdWL5MrknBOJ+ZGCkuh6Ujwl1a0ehRPnnQTDWMQWX+65AVMeJWFy3iVs0QsFJdX3G0Ga3fCXis/s3PiVv4kcZMSD5QwKg707HdWLJEx6BACaZHWgyK5Wjz2tEXG6lYHDdB9gOpLvTBp1t3rEMzO3FIai4wa7nfxQdPTLWzNe6GqNkCBpIlcmFyDwycz4W0FxtJmVMbmxfuZrA3lfQfGCowEzCkYJQ74Z6SZhchNCDrG5ubA4encbYjetWhbZ2dvLJkyKDA22BWcA5gwAQ3SXLTrJxzz3CTJh8hAK9tLq0dkaEWzL6G6NkCC5SJ+rYBSGahJeIFqkxIsKCMctalOK6wD8THdBIoULRIuUOscCNijFDPkk4WoSJm8gyA8Mrif/pxPCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWzSd5iIbgcgS1AK8W2xrmx8T59hWlE/axpZ5mkENOiuXghXYDSToc5ZUT9rWm9/7rM5kGjvE/9XFVdfahHVAjhN9/EIocGbAN+4Ymnl37r/obfcDChMAJCVFQmMOCbzWmarWiaDijSxg0HzexvFllSYuu0Z/k64DtJcKPzJAmMZq+C0xvrpn/b2AlvC1K3wV9FT2MBiAHm6j1wIuzDQCqhw49Lyzf2+zs4wdSsMVU1gVrUAfqz7RAgxaIT3mXl249LKJQN5eW+5Sfo+0/L62SuN9tipBA4zsDPZ7QnhsDaA5x5oxEYONEh9SfrK1FNBSfURACIAySLDwu2YgEeVUtMalpS/l/CbU/ExrzdXTqw5V2a8CRd7HozwimUVTw12A46FqWt3lB+afxUxLwTwIyfPlBB9+JiIIqef0H5fJBKxktmQw2HqtHcuNslcbKFLjBj39De/PVFawtRtz4oNhBLIQEXhECI0waSy5Q/NetvO7WoNU7f8UHQ0MeoAnJmSHQgBAITXmWlK49JZq1Ox+ZT8NJ6oxvqKDWecGDuHwb8G8F+n9y98jvA5gcOfvx87PVVB6nPXTl+ZevrW+quQ9VdFUuIA399hZlaufHjatlTvzBUf83qTXxodqRi3M+Nyx3YqfIOBdSAON9ZX/suxfbo1TN0KS2ty2ORaEH7q+M6FB9G/mVDZWD/L8Z47V3xn6s/yJbOaDx424mwi+j3AKb9UC8/6GuC5u4cPO11HkPriqitTTz1aPa4HYCS9QeEHFhjL4hZPf+zhSq0/Xrn+Y15v8kMLTiXLXAxCru5ahEaEf8KyylYsm/2s7lIAj4apW1erRx2A43XXIhz1IYMrGpdW1APkmnWWXf+dqT9drR6nEDgM4Cvd9YiUayPwAqM9dkpna4R7gtQXz1yZevrlNQuODATic6TVw5+I0GQadMNfH5j1H9219MXTH/N6UxiqOo/ZqAP4Yt21CFu8qIDwo0srntBdyL74Lkxdh9Xd6nEbgGN1VyMGg7cRUKXaT7qzoeFqU3c1A6rYn2HqFAotHLaLY9MBmglgP931iAHpIMbddrZGOMXXYep2xTVVxxiGqgYhpLsW0Q9GMytjcmP9zNd0lzKo8tMhTN0KJlZnQ1EtgDN01yL2YtAbivjG5fUVf9ddS1LH4eWfxhO14qHKljNOjJ3d1erxadIbFEkh4AsGlQfa28/wepD6PEa/Xpl66tHqMQVAhu560owFxjIjA1Mb/lLxme5i7JJWH/N6k18aHUkWLQJ4vO5a0gKhhYjDy5dUbtFdit3SPkzdCktrciyL6wj4ie5afOo9Bt+U7FBHN0ur70z9Wb5kVvMhQ0ec1fVo0pe66/GRXQDPPTAQO9nPQepLWl6ZesovjY5QJm6WVo+kMBhLjWBgRsMDMz7RXYwjBywf8/pWWFpzNltWLUCjdNfiMc+xQlnjkopndBfiJAnTAEirx4B9xOBZbmuNcIqEaYCKihYNiWe2TyZwJYADdNfjMrsJfEdHRqD6sftnpm0rjIQpQUWlVUeZpqqRKbSdiNCkYE5uqL/pHd216CZhGqSC4przAa4D4SLdtWjyEiwVXvFQ+UbdhbiFhCkpTPkl0RCBFgA4XHc1DtlO4Hleao1wioTJBmnS6tFBjLtVTN3c0FAu9+F6IWGy0ZW/nneCYRo1DBTprsVWjGYKqPDyB8tf0V2Km0mYUiA/VHMJMS+G91s93mTG1MZlFU26C/ECeZwoBRrrZ63v0erhxaeidzCofPfw/c+QICVHrkw2Gj+xZvh+yprpkVYPC4xlrILTGuunS79XguRjnkOKSuadbMJYBGCc7lp6w0AroMKNS8s3667FqyRMDissrclhy7oDoFN119LlAwZXpusjQHaS70wOW75kVvPBQw8+0wWtHm1drREneWU6qhfJlckhmlo9mIBH2bKmr3ho9ru6z4GfyMc8FygoqT6HQbUE/CKV+yHCC2yhbMWyiqd0H7MfSZhcpDBUNYEtdQcIx9m86Y+JKHL6Ce33RSIRS/dx+pWEyWUmTIoMDbRl3kDg2QD2T3JzMWLc48XpqF4kYXKpZFs9iNAEk8qWPzTrbd3Hki4kTC535cSqC5Qy6gC+cEBvILzOTFMal85arbv2dCNh8oQBtHoQPifmW7Z/0HFXa2skrrvidCRh8pAerR7lADK7/jkO8P0dZmblyoenyWr0GkmYPKhw4ryTYBiL2EKQlTHFq6tG+E1CYRJCJEYeJxLCJhImIWwiYRLCJhImIWwiYRLCJv8P9sXhC7xE4kIAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDQtMTNUMDg6MTY6MDgrMDI6MDCcYZVaAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA0LTEzVDA4OjE2OjA4KzAyOjAw7Twt5gAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      deployments:
+      - name: che-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: che-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: che-operator
+            spec:
+              containers:
+              - command:
+                - /usr/local/bin/che-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: che-operator
+                - name: CHE_VERSION
+                  value: 7.10.0
+                - name: IMAGE_default_che_server
+                  value: quay.io/eclipse/che-server:7.10.0
+                - name: IMAGE_default_plugin_registry
+                  value: quay.io/eclipse/che-plugin-registry:7.10.0
+                - name: IMAGE_default_devfile_registry
+                  value: quay.io/eclipse/che-devfile-registry:7.10.0
+                - name: IMAGE_default_pvc_jobs
+                  value: registry.access.redhat.com/ubi8-minimal:8.1-398
+                - name: IMAGE_default_postgres
+                  value: centos/postgresql-96-centos7:9.6
+                - name: IMAGE_default_keycloak
+                  value: quay.io/eclipse/che-keycloak:7.10.0
+                - name: IMAGE_default_che_workspace_plugin_broker_metadata
+                  value: quay.io/eclipse/che-plugin-metadata-broker:v3.1.1
+                - name: IMAGE_default_che_workspace_plugin_broker_artifacts
+                  value: quay.io/eclipse/che-plugin-artifacts-broker:v3.1.1
+                - name: IMAGE_default_che_server_secure_exposer_jwt_proxy_image
+                  value: quay.io/eclipse/che-jwtproxy:810d89c
+                image: quay.io/eclipse/che-operator:nightly
+                imagePullPolicy: Always
+                name: che-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              restartPolicy: Always
+              serviceAccountName: che-operator
+              terminationGracePeriodSeconds: 5
+      permissions:
+      - rules:
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - serviceaccounts
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - pods/exec
+          - pods/log
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - org.eclipse.che
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: che-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - eclipse che
+  - workspaces
+  - devtools
+  - developer
+  - ide
+  - java
+  links:
+  - name: Product Page
+    url: http://www.eclipse.org/che
+  - name: Documentation
+    url: https://www.eclipse.org/che/docs
+  - name: Operator GitHub Repo
+    url: https://github.com/eclipse/che-operator
+  maintainers:
+  - email: dfestal@redhat.com
+    name: David Festal
+  maturity: stable
+  provider:
+    name: Eclipse Foundation
+  replaces: eclipse-che-preview-kubernetes.v9.9.9-nightly.1584253673
+  version: 9.9.9-nightly.1584615281

--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584615281/eclipse-che-preview-kubernetes.v9.9.9-nightly.1584615281.clusterserviceversion.yaml.diff
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584615281/eclipse-che-preview-kubernetes.v9.9.9-nightly.1584615281.clusterserviceversion.yaml.diff
@@ -1,0 +1,25 @@
+--- /home/tolusha/gocode/src/github.com/eclipse/che-operator/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584253673/eclipse-che-preview-kubernetes.v9.9.9-nightly.1584253673.clusterserviceversion.yaml	2020-03-19 12:12:28.018013733 +0200
++++ /home/tolusha/gocode/src/github.com/eclipse/che-operator/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/9.9.9-nightly.1584615281/eclipse-che-preview-kubernetes.v9.9.9-nightly.1584615281.clusterserviceversion.yaml	2020-03-19 12:54:41.548682162 +0200
+@@ -49,12 +49,12 @@
+     categories: Developer Tools
+     certified: "false"
+     containerImage: quay.io/eclipse/che-operator:nightly
+-    createdAt: "2020-03-15T06:27:54Z"
++    createdAt: "2020-03-19T10:54:41Z"
+     description: A Kube-native development solution that delivers portable and collaborative
+       developer workspaces.
+     repository: https://github.com/eclipse/che-operator
+     support: Eclipse Foundation
+-  name: eclipse-che-preview-kubernetes.v9.9.9-nightly.1584253673
++  name: eclipse-che-preview-kubernetes.v9.9.9-nightly.1584615281
+   namespace: placeholder
+ spec:
+   apiservicedefinitions: {}
+@@ -370,5 +370,5 @@
+   maturity: stable
+   provider:
+     name: Eclipse Foundation
+-  replaces: eclipse-che-preview-kubernetes.v9.9.9-nightly.1583509666
+-  version: 9.9.9-nightly.1584253673
++  replaces: eclipse-che-preview-kubernetes.v9.9.9-nightly.1584253673
++  version: 9.9.9-nightly.1584615281

--- a/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/eclipse-che-preview-kubernetes.package.yaml
+++ b/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/eclipse-che-preview-kubernetes.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: eclipse-che-preview-kubernetes.v9.9.9-nightly.1584253673
+- currentCSV: eclipse-che-preview-kubernetes.v9.9.9-nightly.1584615281
   name: nightly
 - currentCSV: eclipse-che-preview-kubernetes.v7.10.0
   name: stable

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584615281/eclipse-che-preview-openshift.crd.yaml
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584615281/eclipse-che-preview-openshift.crd.yaml
@@ -1,0 +1,553 @@
+#
+#  Copyright (c) 2012-2020 Red Hat, Inc.
+#    This program and the accompanying materials are made
+#    available under the terms of the Eclipse Public License 2.0
+#    which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+#  SPDX-License-Identifier: EPL-2.0
+#
+#  Contributors:
+#    Red Hat, Inc. - initial API and implementation
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: checlusters.org.eclipse.che
+spec:
+  group: org.eclipse.che
+  names:
+    kind: CheCluster
+    listKind: CheClusterList
+    plural: checlusters
+    singular: checluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Desired configuration of the Che installation. Based on these
+            settings, the operator automatically creates and maintains several config
+            maps that will contain the appropriate environment variables the various
+            components of the Che installation. These generated config maps should
+            NOT be updated manually.
+          properties:
+            auth:
+              description: Configuration settings related to the Authentication used
+                by the Che installation.
+              properties:
+                externalIdentityProvider:
+                  description: 'Instructs the operator on whether or not to deploy
+                    a dedicated Identity Provider (Keycloak or RH SSO instance). By
+                    default a dedicated Identity Provider server is deployed as part
+                    of the Che installation. But if `externalIdentityProvider` is
+                    `true`, then no dedicated identity provider will be deployed by
+                    the operator and you might need to provide details about the external
+                    identity provider you want to use. See also all the other fields
+                    starting with: `identityProvider`.'
+                  type: boolean
+                identityProviderAdminUserName:
+                  description: Overrides the name of the Identity Provider admin user.
+                    Defaults to `admin`.
+                  type: string
+                identityProviderClientId:
+                  description: Name of a Identity provider (Keycloak / RH SSO) `client-id`
+                    that should be used for Che. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to the value
+                    of the `flavour` field suffixed with `-public`.
+                  type: string
+                identityProviderImage:
+                  description: Overrides the container image used in the Identity
+                    Provider (Keycloak / RH SSO) deployment. This includes the image
+                    tag. Omit it or leave it empty to use the defaut container image
+                    provided by the operator.
+                  type: string
+                identityProviderImagePullPolicy:
+                  description: Overrides the image pull policy used in the Identity
+                    Provider (Keycloak / RH SSO) deployment. Default value is `Always`
+                    for `nightly` or `latest` images, and `IfNotPresent` in other
+                    cases.
+                  type: string
+                identityProviderPassword:
+                  description: Overrides the password of Keycloak admin user. This
+                    is useful to override it ONLY if you use an external Identity
+                    Provider (see the `externalIdentityProvider` field). If omitted
+                    or left blank, it will be set to an auto-generated password.
+                  type: string
+                identityProviderPostgresPassword:
+                  description: Password for The Identity Provider (Keycloak / RH SSO)
+                    to connect to the database. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to an auto-generated
+                    password.
+                  type: string
+                identityProviderPostgresSecret:
+                  description: 'The secret that contains `password` for The Identity
+                    Provider (Keycloak / RH SSO) to connect to the database. If the
+                    secret is defined then `identityProviderPostgresPassword` will
+                    be ignored. If the value is omitted or left blank then there are
+                    two scenarios: 1. `identityProviderPostgresPassword` is defined,
+                    then it will be used to connect to the database. 2. `identityProviderPostgresPassword`
+                    is not defined, then a new secret with the name `che-identity-postgres-secret`
+                    will be created with an auto-generated value for `password`.'
+                  type: string
+                identityProviderRealm:
+                  description: Name of a Identity provider (Keycloak / RH SSO) realm
+                    that should be used for Che. This is useful to override it ONLY
+                    if you use an external Identity Provider (see the `externalIdentityProvider`
+                    field). If omitted or left blank, it will be set to the value
+                    of the `flavour` field.
+                  type: string
+                identityProviderSecret:
+                  description: 'The secret that contains `user` and `password` for
+                    Identity Provider. If the secret is defined then `identityProviderAdminUserName`
+                    and `identityProviderPassword` are ignored. If the value is omitted
+                    or left blank then there are two scenarios: 1. `identityProviderAdminUserName`
+                    and `identityProviderPassword` are defined, then they will be
+                    used. 2. `identityProviderAdminUserName` or `identityProviderPassword`
+                    are not defined, then a new secret with the name `che-identity-secret`
+                    will be created with default value `admin` for `user` and with
+                    an auto-generated value for `password`.'
+                  type: string
+                identityProviderURL:
+                  description: Public URL of the Identity Provider server (Keycloak
+                    / RH SSO server). You should set it ONLY if you use an external
+                    Identity Provider (see the `externalIdentityProvider` field).
+                    By default this will be automatically calculated and set by the
+                    operator.
+                  type: string
+                oAuthClientName:
+                  description: Name of the OpenShift `OAuthClient` resource used to
+                    setup identity federation on the OpenShift side. Auto-generated
+                    if left blank. See also the `OpenShiftoAuth` field.
+                  type: string
+                oAuthSecret:
+                  description: Name of the secret set in the OpenShift `OAuthClient`
+                    resource used to setup identity federation on the OpenShift side.
+                    Auto-generated if left blank. See also the `OAuthClientName` field.
+                  type: string
+                openShiftoAuth:
+                  description: 'Enables the integration of the identity provider (Keycloak
+                    / RHSSO) with OpenShift OAuth. Enabled by default on OpenShift.
+                    This will allow users to directly login with their Openshift user
+                    through the Openshift login, and have their workspaces created
+                    under personal OpenShift namespaces. WARNING: the `kubeadmin`
+                    user is NOT supported, and logging through it will NOT allow accessing
+                    the Che Dashboard.'
+                  type: boolean
+                updateAdminPassword:
+                  description: Forces the default `admin` Che user to update password
+                    on first login. Defaults to `false`.
+                  type: boolean
+              type: object
+            database:
+              description: Configuration settings related to the database used by
+                the Che installation.
+              properties:
+                chePostgresDb:
+                  description: Postgres database name that the Che server uses to
+                    connect to the DB. Defaults to `dbche`.
+                  type: string
+                chePostgresHostName:
+                  description: Postgres Database hostname that the Che server uses
+                    to connect to. Defaults to postgres. This value should be overridden
+                    ONLY when using an external database (see field `externalDb`).
+                    In the default case it will be automatically set by the operator.
+                  type: string
+                chePostgresPassword:
+                  description: Postgres password that the Che server should use to
+                    connect to the DB. If omitted or left blank, it will be set to
+                    an auto-generated value.
+                  type: string
+                chePostgresPort:
+                  description: Postgres Database port that the Che server uses to
+                    connect to. Defaults to 5432. This value should be overridden
+                    ONLY when using an external database (see field `externalDb`).
+                    In the default case it will be automatically set by the operator.
+                  type: string
+                chePostgresSecret:
+                  description: 'The secret that contains Postgres `user` and `password`
+                    that the Che server should use to connect to the DB. If the secret
+                    is defined then `chePostgresUser` and `chePostgresPassword` are
+                    ignored. If the value is omitted or left blank then there are
+                    two scenarios: 1. `chePostgresUser` and `chePostgresPassword`
+                    are defined, then they will be used to connect to the DB. 2. `chePostgresUser`
+                    or `chePostgresPassword` are not defined, then a new secret with
+                    the name `che-postgres-secret` will be created with default value
+                    of `pgche` for `user` and with an auto-generated value for `password`.'
+                  type: string
+                chePostgresUser:
+                  description: Postgres user that the Che server should use to connect
+                    to the DB. Defaults to `pgche`.
+                  type: string
+                externalDb:
+                  description: 'Instructs the operator on whether or not to deploy
+                    a dedicated database. By default a dedicated Postgres database
+                    is deployed as part of the Che installation. But if `externalDb`
+                    is `true`, then no dedicated database will be deployed by the
+                    operator and you might need to provide connection details to the
+                    external DB you want to use. See also all the fields starting
+                    with: `chePostgres`.'
+                  type: boolean
+                postgresImage:
+                  description: Overrides the container image used in the Postgres
+                    database deployment. This includes the image tag. Omit it or leave
+                    it empty to use the defaut container image provided by the operator.
+                  type: string
+                postgresImagePullPolicy:
+                  description: Overrides the image pull policy used in the Postgres
+                    database deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+              type: object
+            k8s:
+              description: Configuration settings specific to Che installations made
+                on upstream Kubernetes.
+              properties:
+                ingressClass:
+                  description: 'Ingress class that will define the which controler
+                    will manage ingresses. Defaults to `nginx`. NB: This drives the
+                    `is kubernetes.io/ingress.class` annotation on Che-related ingresses.'
+                  type: string
+                ingressDomain:
+                  description: 'Global ingress domain for a K8S cluster. This MUST
+                    be explicitly specified: there are no defaults.'
+                  type: string
+                ingressStrategy:
+                  description: Strategy for ingress creation. This can be `multi-host`
+                    (host is explicitly provided in ingress), `single-host` (host
+                    is provided, path-based rules) and `default-host.*`(no host is
+                    provided, path-based rules). Defaults to `"multi-host`
+                  type: string
+                securityContextFsGroup:
+                  description: FSGroup the Che pod and Workspace pods containers should
+                    run in. Defaults to `1724`.
+                  type: string
+                securityContextRunAsUser:
+                  description: ID of the user the Che pod and Workspace pods containers
+                    should run as. Default to `1724`.
+                  type: string
+                tlsSecretName:
+                  description: Name of a secret that will be used to setup ingress
+                    TLS termination if TLS is enabled. See also the `tlsSupport` field.
+                  type: string
+              type: object
+            metrics:
+              description: Configuration settings related to the metrics collection
+                used by the Che installation.
+              properties:
+                enable:
+                  description: Enables `metrics` Che server endpoint. Default to `false`.
+                  type: boolean
+              type: object
+            server:
+              description: General configuration settings related to the Che server
+                and the plugin and devfile registries
+              properties:
+                airGapContainerRegistryHostname:
+                  description: Optional hostname (or url) to an alternate container
+                    registry to pull images from. This value overrides the container
+                    registry hostname defined in all the default container images
+                    involved in a Che deployment. This is particularly useful to install
+                    Che in an air-gapped environment.
+                  type: string
+                airGapContainerRegistryOrganization:
+                  description: Optional repository name of an alternate container
+                    registry to pull images from. This value overrides the container
+                    registry organization defined in all the default container images
+                    involved in a Che deployment. This is particularly useful to install
+                    Che in an air-gapped environment.
+                  type: string
+                allowUserDefinedWorkspaceNamespaces:
+                  description: Defines if a user is able to specify Kubernetes namespace
+                    (or OpenShift project) different from the default. It's NOT RECOMMENDED
+                    to configured true without OAuth configured. This property is
+                    also used by the OpenShift infra.
+                  type: boolean
+                cheDebug:
+                  description: Enables the debug mode for Che server. Defaults to
+                    `false`.
+                  type: string
+                cheFlavor:
+                  description: Flavor of the installation. This is either `che` for
+                    upstream Che installations, or `codeready` for CodeReady Workspaces
+                    installation. In most cases the default value should not be overriden.
+                  type: string
+                cheHost:
+                  description: Public hostname of the installed Che server. This will
+                    be automatically set by the operator. In most cases the default
+                    value set by the operator should not be overriden.
+                  type: string
+                cheImage:
+                  description: Overrides the container image used in Che deployment.
+                    This does NOT include the container image tag. Omit it or leave
+                    it empty to use the defaut container image provided by the operator.
+                  type: string
+                cheImagePullPolicy:
+                  description: Overrides the image pull policy used in Che deployment.
+                    Default value is `Always` for `nightly` or `latest` images, and
+                    `IfNotPresent` in other cases.
+                  type: string
+                cheImageTag:
+                  description: Overrides the tag of the container image used in Che
+                    deployment. Omit it or leave it empty to use the defaut image
+                    tag provided by the operator.
+                  type: string
+                cheLogLevel:
+                  description: 'Log level for the Che server: `INFO` or `DEBUG`. Defaults
+                    to `INFO`.'
+                  type: string
+                cheWorkspaceClusterRole:
+                  description: Custom cluster role bound to the user for the Che workspaces.
+                    The default roles are used if this is omitted or left blank.
+                  type: string
+                customCheProperties:
+                  additionalProperties:
+                    type: string
+                  description: Map of additional environment variables that will be
+                    applied in the generated `che` config map to be used by the Che
+                    server, in addition to the values already generated from other
+                    fields of the `CheCluster` custom resource (CR). If `customCheProperties`
+                    contains a property that would be normally generated in `che`
+                    config map from other CR fields, then the value defined in the
+                    `customCheProperties` will be used instead.
+                  type: object
+                devfileRegistryImage:
+                  description: Overrides the container image used in the Devfile registry
+                    deployment. This includes the image tag. Omit it or leave it empty
+                    to use the defaut container image provided by the operator.
+                  type: string
+                devfileRegistryMemoryLimit:
+                  description: Overrides the memory limit used in the Devfile registry
+                    deployment. Defaults to 256Mi.
+                  type: string
+                devfileRegistryMemoryRequest:
+                  description: Overrides the memory request used in the Devfile registry
+                    deployment. Defaults to 16Mi.
+                  type: string
+                devfileRegistryPullPolicy:
+                  description: Overrides the image pull policy used in the Devfile
+                    registry deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+                devfileRegistryUrl:
+                  description: Public URL of the Devfile registry, that serves sample,
+                    ready-to-use devfiles. You should set it ONLY if you use an external
+                    devfile registry (see the `externalDevfileRegistry` field). By
+                    default this will be automatically calculated by the operator.
+                  type: string
+                externalDevfileRegistry:
+                  description: Instructs the operator on whether or not to deploy
+                    a dedicated Devfile registry server. By default a dedicated devfile
+                    registry server is started. But if `externalDevfileRegistry` is
+                    `true`, then no such dedicated server will be started by the operator
+                    and you will have to manually set the `devfileRegistryUrl` field
+                  type: boolean
+                externalPluginRegistry:
+                  description: Instructs the operator on whether or not to deploy
+                    a dedicated Plugin registry server. By default a dedicated plugin
+                    registry server is started. But if `externalPluginRegistry` is
+                    `true`, then no such dedicated server will be started by the operator
+                    and you will have to manually set the `pluginRegistryUrl` field.
+                  type: boolean
+                gitSelfSignedCert:
+                  description: If enabled, then the certificate from `che-git-self-signed-cert`
+                    config map will be propagated to the Che components and provide
+                    particular configuration for Git.
+                  type: boolean
+                nonProxyHosts:
+                  description: List of hosts that should not use the configured proxy.
+                    Use `|`` as delimiter, eg `localhost|my.host.com|123.42.12.32`
+                    Only use when configuring a proxy is required (see also the `proxyURL`
+                    field).
+                  type: string
+                pluginRegistryImage:
+                  description: Overrides the container image used in the Plugin registry
+                    deployment. This includes the image tag. Omit it or leave it empty
+                    to use the defaut container image provided by the operator.
+                  type: string
+                pluginRegistryMemoryLimit:
+                  description: Overrides the memory limit used in the Plugin registry
+                    deployment. Defaults to 256Mi.
+                  type: string
+                pluginRegistryMemoryRequest:
+                  description: Overrides the memory request used in the Plugin registry
+                    deployment. Defaults to 16Mi.
+                  type: string
+                pluginRegistryPullPolicy:
+                  description: Overrides the image pull policy used in the Plugin
+                    registry deployment. Default value is `Always` for `nightly` or
+                    `latest` images, and `IfNotPresent` in other cases.
+                  type: string
+                pluginRegistryUrl:
+                  description: Public URL of the Plugin registry, that serves sample
+                    ready-to-use devfiles. You should set it ONLY if you use an external
+                    devfile registry (see the `externalPluginRegistry` field). By
+                    default this will be automatically calculated by the operator.
+                  type: string
+                proxyPassword:
+                  description: Password of the proxy server Only use when proxy configuration
+                    is required (see also the `proxyUser` and `proxySecret` fields).
+                  type: string
+                proxyPort:
+                  description: Port of the proxy server. Only use when configuring
+                    a proxy is required (see also the `proxyURL` field).
+                  type: string
+                proxySecret:
+                  description: The secret that contains `user` and `password` for
+                    a proxy server. If the secret is defined then `proxyUser` and
+                    `proxyPassword` are ignored
+                  type: string
+                proxyURL:
+                  description: URL (protocol+hostname) of the proxy server. This drives
+                    the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy`
+                    variables in the Che server and workspaces containers. Only use
+                    when configuring a proxy is required.
+                  type: string
+                proxyUser:
+                  description: User name of the proxy server. Only use when configuring
+                    a proxy is required (see also the `proxyURL` `proxySecret` fields).
+                  type: string
+                selfSignedCert:
+                  description: Enables the support of OpenShift clusters whose router
+                    uses self-signed certificates. When enabled, the operator retrieves
+                    the default self-signed certificate of OpenShift routes and adds
+                    it to the Java trust store of the Che server. This is usually
+                    required when activating the `tlsSupport` field on demo OpenShift
+                    clusters that have not been setup with a valid certificate for
+                    the routes. This is disabled by default.
+                  type: boolean
+                serverMemoryLimit:
+                  description: Overrides the memory limit used in the Che server deployment.
+                    Defaults to 1Gi.
+                  type: string
+                serverMemoryRequest:
+                  description: Overrides the memory request used in the Che server
+                    deployment. Defaults to 512Mi.
+                  type: string
+                serverTrustStoreConfigMapName:
+                  description: Name of the config-map with public certificates to
+                    add to Java trust store of the Che server. This is usually required
+                    when adding the OpenShift OAuth provider which has https endpoint
+                    signed with self-signed cert. So, Che server must be aware of
+                    its CA cert to be able to request it. This is disabled by default.
+                  type: string
+                tlsSupport:
+                  description: 'Instructs the operator to deploy Che in TLS mode,
+                    ie with TLS routes or ingresses. This is disabled by default.
+                    WARNING: Enabling TLS might require enabling the `selfSignedCert`
+                    field also in some cases.'
+                  type: boolean
+                workspaceNamespaceDefault:
+                  description: 'Defines Kubernetes default namespace in which user''s
+                    workspaces are created if user does not override it. It''s possible
+                    to use <username>, <userid> and <workspaceid> placeholders (e.g.:
+                    che-workspace-<username>). In that case, new namespace will be
+                    created for each user (or workspace). Is used by OpenShift infra
+                    as well to specify Project'
+                  type: string
+              type: object
+            storage:
+              description: Configuration settings related to the persistent storage
+                used by the Che installation.
+              properties:
+                postgresPVCStorageClassName:
+                  description: Storage class for the Persistent Volume Claim dedicated
+                    to the Postgres database. If omitted or left blank, default storage
+                    class is used.
+                  type: string
+                preCreateSubPaths:
+                  description: Instructs the Che server to launch a special pod to
+                    pre-create a subpath in the Persistent Volumes. Defaults to `false`,
+                    however it might need to enable it according to the configuration
+                    of your K8S cluster.
+                  type: boolean
+                pvcClaimSize:
+                  description: Size of the persistent volume claim for workspaces.
+                    Defaults to `1Gi`
+                  type: string
+                pvcJobsImage:
+                  description: Overrides the container image used to create sub-paths
+                    in the Persistent Volumes. This includes the image tag. Omit it
+                    or leave it empty to use the defaut container image provided by
+                    the operator. See also the `preCreateSubPaths` field.
+                  type: string
+                pvcStrategy:
+                  description: Persistent volume claim strategy for the Che server.
+                    This Can be:`common` (all workspaces PVCs in one volume), `per-workspace`
+                    (one PVC per workspace for all declared volumes) and `unique`
+                    (one PVC per declared volume). Defaults to `common`.
+                  type: string
+                workspacePVCStorageClassName:
+                  description: Storage class for the Persistent Volume Claims dedicated
+                    to the Che workspaces. If omitted or left blank, default storage
+                    class is used.
+                  type: string
+              type: object
+          type: object
+        status:
+          description: CheClusterStatus defines the observed state of Che installation
+          properties:
+            cheClusterRunning:
+              description: Status of a Che installation. Can be `Available`, `Unavailable`,
+                or `Available, Rolling Update in Progress`
+              type: string
+            cheURL:
+              description: Public URL to the Che server
+              type: string
+            cheVersion:
+              description: Current installed Che version
+              type: string
+            dbProvisioned:
+              description: Indicates if or not a Postgres instance has been correctly
+                provisioned
+              type: boolean
+            devfileRegistryURL:
+              description: Public URL to the Devfile registry
+              type: string
+            helpLink:
+              description: A URL that can point to some URL where to find help related
+                to the current Operator status.
+              type: string
+            keycloakProvisioned:
+              description: Indicates whether an Identity Provider instance (Keycloak
+                / RH SSO) has been provisioned with realm, client and user
+              type: boolean
+            keycloakURL:
+              description: Public URL to the Identity Provider server (Keycloak /
+                RH SSO).
+              type: string
+            message:
+              description: A human readable message indicating details about why the
+                pod is in this condition.
+              type: string
+            openShiftoAuthProvisioned:
+              description: Indicates whether an Identity Provider instance (Keycloak
+                / RH SSO) has been configured to integrate with the OpenShift OAuth.
+              type: boolean
+            pluginRegistryURL:
+              description: Public URL to the Plugin registry
+              type: string
+            reason:
+              description: A brief CamelCase message indicating details about why
+                the pod is in this state.
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584615281/eclipse-che-preview-openshift.crd.yaml.diff
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584615281/eclipse-che-preview-openshift.crd.yaml.diff
@@ -1,0 +1,134 @@
+--- /home/tolusha/gocode/src/github.com/eclipse/che-operator/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584253674/eclipse-che-preview-openshift.crd.yaml	2020-03-19 12:12:28.022013746 +0200
++++ /home/tolusha/gocode/src/github.com/eclipse/che-operator/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584615281/eclipse-che-preview-openshift.crd.yaml	2020-03-19 12:54:41.704684257 +0200
+@@ -1,5 +1,5 @@
+ #
+-#  Copyright (c) 2012-2019 Red Hat, Inc.
++#  Copyright (c) 2012-2020 Red Hat, Inc.
+ #    This program and the accompanying materials are made
+ #    available under the terms of the Eclipse Public License 2.0
+ #    which is available at https://www.eclipse.org/legal/epl-2.0/
+@@ -94,6 +94,16 @@
+                     field). If omitted or left blank, it will be set to an auto-generated
+                     password.
+                   type: string
++                identityProviderPostgresSecret:
++                  description: 'The secret that contains `password` for The Identity
++                    Provider (Keycloak / RH SSO) to connect to the database. If the
++                    secret is defined then `identityProviderPostgresPassword` will
++                    be ignored. If the value is omitted or left blank then there are
++                    two scenarios: 1. `identityProviderPostgresPassword` is defined,
++                    then it will be used to connect to the database. 2. `identityProviderPostgresPassword`
++                    is not defined, then a new secret with the name `che-identity-postgres-secret`
++                    will be created with an auto-generated value for `password`.'
++                  type: string
+                 identityProviderRealm:
+                   description: Name of a Identity provider (Keycloak / RH SSO) realm
+                     that should be used for Che. This is useful to override it ONLY
+@@ -101,6 +111,17 @@
+                     field). If omitted or left blank, it will be set to the value
+                     of the `flavour` field.
+                   type: string
++                identityProviderSecret:
++                  description: 'The secret that contains `user` and `password` for
++                    Identity Provider. If the secret is defined then `identityProviderAdminUserName`
++                    and `identityProviderPassword` are ignored. If the value is omitted
++                    or left blank then there are two scenarios: 1. `identityProviderAdminUserName`
++                    and `identityProviderPassword` are defined, then they will be
++                    used. 2. `identityProviderAdminUserName` or `identityProviderPassword`
++                    are not defined, then a new secret with the name `che-identity-secret`
++                    will be created with default value `admin` for `user` and with
++                    an auto-generated value for `password`.'
++                  type: string
+                 identityProviderURL:
+                   description: Public URL of the Identity Provider server (Keycloak
+                     / RH SSO server). You should set it ONLY if you use an external
+@@ -120,10 +141,10 @@
+                   type: string
+                 openShiftoAuth:
+                   description: 'Enables the integration of the identity provider (Keycloak
+-                    / RHSSO) with OpenShift OAuth. Enabled by defaumt on OpenShift.
++                    / RHSSO) with OpenShift OAuth. Enabled by default on OpenShift.
+                     This will allow users to directly login with their Openshift user
+-                    throug the Openshift login, and have their workspaces created
+-                    under personnal OpenShift namespaces. WARNING: the `kuebadmin`
++                    through the Openshift login, and have their workspaces created
++                    under personal OpenShift namespaces. WARNING: the `kubeadmin`
+                     user is NOT supported, and logging through it will NOT allow accessing
+                     the Che Dashboard.'
+                   type: boolean
+@@ -157,6 +178,17 @@
+                     ONLY when using an external database (see field `externalDb`).
+                     In the default case it will be automatically set by the operator.
+                   type: string
++                chePostgresSecret:
++                  description: 'The secret that contains Postgres `user` and `password`
++                    that the Che server should use to connect to the DB. If the secret
++                    is defined then `chePostgresUser` and `chePostgresPassword` are
++                    ignored. If the value is omitted or left blank then there are
++                    two scenarios: 1. `chePostgresUser` and `chePostgresPassword`
++                    are defined, then they will be used to connect to the DB. 2. `chePostgresUser`
++                    or `chePostgresPassword` are not defined, then a new secret with
++                    the name `che-postgres-secret` will be created with default value
++                    of `pgche` for `user` and with an auto-generated value for `password`.'
++                  type: string
+                 chePostgresUser:
+                   description: Postgres user that the Che server should use to connect
+                     to the DB. Defaults to `pgche`.
+@@ -293,13 +325,6 @@
+                     config map from other CR fields, then the value defined in the
+                     `customCheProperties` will be used instead.
+                   type: object
+-                serverTrustStoreConfigMapName:
+-                  description: Name of the config-map with public certificates to
+-                    add to Java trust store of the Che server. This is usually required
+-                    when adding the OpenShift OAuth provider which has https endpoint
+-                    signed with self-signed cert. So, Che server must be aware of
+-                    its CA cert to be able to request it. This is disabled by default.
+-                  type: string
+                 devfileRegistryImage:
+                   description: Overrides the container image used in the Devfile registry
+                     deployment. This includes the image tag. Omit it or leave it empty
+@@ -374,13 +399,18 @@
+                     default this will be automatically calculated by the operator.
+                   type: string
+                 proxyPassword:
+-                  description: Password of the proxy server  Only use when proxy configuration
+-                    is required (see also the `proxyUser` field).
++                  description: Password of the proxy server Only use when proxy configuration
++                    is required (see also the `proxyUser` and `proxySecret` fields).
+                   type: string
+                 proxyPort:
+                   description: Port of the proxy server. Only use when configuring
+                     a proxy is required (see also the `proxyURL` field).
+                   type: string
++                proxySecret:
++                  description: The secret that contains `user` and `password` for
++                    a proxy server. If the secret is defined then `proxyUser` and
++                    `proxyPassword` are ignored
++                  type: string
+                 proxyURL:
+                   description: URL (protocol+hostname) of the proxy server. This drives
+                     the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy`
+@@ -389,7 +419,7 @@
+                   type: string
+                 proxyUser:
+                   description: User name of the proxy server. Only use when configuring
+-                    a proxy is required (see also the `proxyURL` field).
++                    a proxy is required (see also the `proxyURL` `proxySecret` fields).
+                   type: string
+                 selfSignedCert:
+                   description: Enables the support of OpenShift clusters whose router
+@@ -408,6 +438,13 @@
+                   description: Overrides the memory request used in the Che server
+                     deployment. Defaults to 512Mi.
+                   type: string
++                serverTrustStoreConfigMapName:
++                  description: Name of the config-map with public certificates to
++                    add to Java trust store of the Che server. This is usually required
++                    when adding the OpenShift OAuth provider which has https endpoint
++                    signed with self-signed cert. So, Che server must be aware of
++                    its CA cert to be able to request it. This is disabled by default.
++                  type: string
+                 tlsSupport:
+                   description: 'Instructs the operator to deploy Che in TLS mode,
+                     ie with TLS routes or ingresses. This is disabled by default.

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584615281/eclipse-che-preview-openshift.v9.9.9-nightly.1584615281.clusterserviceversion.yaml
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584615281/eclipse-che-preview-openshift.v9.9.9-nightly.1584615281.clusterserviceversion.yaml
@@ -1,0 +1,419 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "org.eclipse.che/v1",
+          "kind": "CheCluster",
+          "metadata": {
+             "name": "eclipse-che"
+          },
+          "spec": {
+             "server": {
+                "cheImageTag": "nightly",
+                "devfileRegistryImage": "quay.io/eclipse/che-devfile-registry:nightly",
+                "pluginRegistryImage": "quay.io/eclipse/che-plugin-registry:nightly",
+                "tlsSupport": true,
+                "selfSignedCert": false
+             },
+             "database": {
+                "externalDb": false,
+                "chePostgresHostName": "",
+                "chePostgresPort": "",
+                "chePostgresUser": "",
+                "chePostgresPassword": "",
+                "chePostgresDb": ""
+             },
+             "auth": {
+                "openShiftoAuth": true,
+                "identityProviderImage": "quay.io/eclipse/che-keycloak:nightly",
+                "externalIdentityProvider": false,
+                "identityProviderURL": "",
+                "identityProviderRealm": "",
+                "identityProviderClientId": ""
+             },
+             "storage": {
+                "pvcStrategy": "per-workspace",
+                "pvcClaimSize": "1Gi",
+                "preCreateSubPaths": true
+             }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Developer Tools, OpenShift Optional
+    certified: "false"
+    containerImage: quay.io/eclipse/che-operator:nightly
+    createdAt: "2020-03-19T10:54:41Z"
+    description: A Kube-native development solution that delivers portable and collaborative
+      developer workspaces in OpenShift.
+    repository: https://github.com/eclipse/che-operator
+    support: Eclipse Foundation
+  name: eclipse-che-preview-openshift.v9.9.9-nightly.1584615281
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Eclipse Che cluster with DB and Auth Server
+      displayName: Eclipse Che Cluster
+      kind: CheCluster
+      name: checlusters.org.eclipse.che
+      specDescriptors:
+      - description: Log in to Eclipse Che with OpenShift credentials
+        displayName: OpenShift oAuth
+        path: auth.openShiftoAuth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - description: TLS routes
+        displayName: TLS Mode
+        path: server.tlsSupport
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      statusDescriptors:
+      - description: Route to access Eclipse Che
+        displayName: Eclipse Che URL
+        path: cheURL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      - description: Route to access Keycloak Admin Console
+        displayName: Keycloak Admin Console URL
+        path: keycloakURL
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      - description: Eclipse Che server version
+        displayName: Eclipse Che version
+        path: cheVersion
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:label
+      - description: The current status of the application
+        displayName: Status
+        path: cheClusterRunning
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Reason of the current status
+        displayName: Reason
+        path: reason
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Message explaining the current status
+        displayName: Message
+        path: message
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Link providing help related to the current status
+        displayName: Help link
+        path: helpLink
+        x-descriptors:
+        - urn:alm:descriptor:org.w3:link
+      version: v1
+  description: |
+    A collaborative Kubernetes-native development solution that delivers OpenShift workspaces and in-browser IDE for rapid cloud application development.
+    This operator installs PostgreSQL, Keycloak, and the Eclipse Che server, as well as configures all three services.
+
+    ## How to Install
+
+    Press the **Install** button, choose the upgrade strategy, and wait for the **Installed** Operator status.
+
+    When the operator is installed, create a new CR of Kind CheCluster (click the **Create New** button).
+    The CR spec contains all defaults (see below).
+
+    You can start using Eclipse Che when the CR status is set to **Available**, and you see a URL to Eclipse Che.
+
+    ## Defaults
+
+    By default, the operator deploys Eclipse Che with:
+
+    * Bundled PostgreSQL and Keycloak
+
+    * Per-Workspace PVC strategy
+
+    * Auto-generated passwords
+
+    * HTTP mode (non-secure routes)
+
+    * Regular login extended with OpenShift OAuth authentication
+
+    ## Installation Options
+
+    Eclipse Che operator installation options include:
+
+    * Connection to external database and Keycloak
+
+    * Configuration of default passwords and object names
+
+    * TLS mode
+
+    * PVC strategy (once shared PVC for all workspaces, PVC per workspace, or PVC per volume)
+
+    * Authentication options
+
+    ### External Database and Keycloak
+
+    To instruct the operator to skip deploying PostgreSQL and Keycloak and connect to an existing DB and Keycloak instead:
+
+    * set respective fields to `true` in a custom resource spec
+
+    * provide the operator with connection and authentication details:
+
+
+
+      `externalDb: true`
+
+
+      `chePostgresHostname: 'yourPostgresHost'`
+
+
+      `chePostgresPort: '5432'`
+
+
+      `chePostgresUser: 'myuser'`
+
+
+      `chePostgresPassword: 'mypass'`
+
+
+      `chePostgresDb: 'mydb'`
+
+
+      `externalIdentityProvider: true`
+
+
+      `identityProviderURL: 'https://my-keycloak.com'`
+
+
+      `identityProviderRealm: 'myrealm'`
+
+
+      `identityProviderClientId: 'myClient'`
+
+
+    ### TLS Mode
+
+    To activate TLS mode, set the respective field in the CR spec to `true` (in the `server` block):
+
+
+    ```
+    tlsSupport: true
+    ```
+
+    #### Self-signed Certificates
+
+    To use Eclipse Che with TLS enabled, but the OpenShift router does not use certificates signed by a public authority, you can use self-signed certificates, which the operator can fetch for you:
+
+
+    ```
+    selfSignedCert: true
+    ```
+
+
+    You can also manually create a secret:
+
+
+
+    ```
+    oc create secret self-signed-certificate generic --from-file=/path/to/certificate/ca.crt -n=$codeReadyNamespace
+    ```
+  displayName: Eclipse Che
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAANMAAAD0CAYAAAABrhNXAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAaNklEQVR42u3de3QU9dkH8O/zm91EQK0U77dqVdTW++1V20KigUSQahLjsSSbtp4eeqqVLHILCcoiyQZEIbF61B6PVQJ6XiOkr6TlYiABr603wHotar1bBUWUYDY787x/JIGoSchmZ+c3M/t8/iS7M8+M5+vs7szz/IiZIYRIntJdgBB+IWESwiYSJiFsImESwiYSJiFsImESwiaBvv5ARLprEwB4ddaJTBQF8w/JsKbQmI0v665JAL3dUqK+7jNJmPTiNWOHWYhNB1AOILPrn+MA369MazaNe+Iz3TWmMwmTB3AEyrwwu4SIbwVwWB+v+hxEt6gg7qLs1rjumtORhMnlePUlF5hk1RFw4QDf8rrFmBLMa12tu/Z0I2FyKV53yVGWyTVgLgGQ8IknoImMQBnlNL+t+1jShYTJZXjlhKFW8KsbQJgNYP8ktxYDcI8yh95E41bt1H1sfidhcpH4mtETCHQHgONs3vTHAEXUMy33UQSW7uP0KwmTC/DqS84xyaol4Bcp3tULiqiMxrY8pfuY/UjCpBG3ZB1sxfgmgK4HYDi1WwI9SnGaTuPXv6v7HPiJhEkDfv7coPX5AdeB+RaADtRURRtAC9UB7Qvo4md26z4nfiBhcljH6qwcRbgDwKm6a+nyATNVGrkt9USQrtAkSJgcwquyT2ZlLWLQON219FofsMEghGls6ybdtXiVhCnFuOnnw62gEQHoOvTz3KM7sAVSy5RS0yln3X91V+M1EqYU4ZasgBWjawGuAnCI7noStAOM+coaUkvjVrXrLsYrJEwp0LHmkksUrFoAp+uuJSnMbzLR1EBua5PuUrxAwmSj7tYIBhfprsVOBDQTU5jyWl7RXYubSZhs0KM1YiaA/XTXkyIdAN+tMmgOZbfu0F2MG0mYksAMMtdkh4h4AYDDddfj0FF3tnrsOOROurrB1F2Nm0iYBolXjT7fVFRHwEW6a9FkkyIK09iWDboLcQsJU4KSbY3wGwKaCNZkyt34ju5adJMwDRA/fdEQa2fmZBAqARygux536Wr1+CY+m6546ivd1Wg7CxKmfUtha4TP8EeAmpuurR4Spn7w46PONi2qJdAo3bV4CROeM1iFKXf907prcfS4JUzfx82XjrDM+M0Ot0b4TWerB8yplLvxfd3FOHLAEqYeJ2NPawTmAviB7np8YheA21QG5lN26ze6i0klCVOXjtVZOUpxHZh+orsWn3qfmWYH8lqW6C4kVdI+TLwq+2Q2+HZmjNddSzogoIUsI0yXrduiuxa7pW2YuOnnw62MwEwwTwEoQ3c96aWr1SMen+qnKbRpF6a901GthQAdqrueNPcFGAvUzkMW09UNMd3FJCutwtSxenS2ItQCdIbuWsS3vMFENwbGtvxddyHJSIsw8ZpRx1hkVIM5pLsW0TcCmsk0ymjculd11zIYvg5TmrRG+E1nq4cK3kxjmr/UXUwifBkmZpD5+OiriHEbQMfqrkcMynYQ5nmp1cN3YepsjUAtgS7WXYuwA7+oGGHK2/CE7kr2WalfwsRrxxxpcWwOgN8BJEuJ+gwBTWThBrqs9T+6a+mL58PEjxRlWAd99gcw5kFaI3yO20D0JxVEFWW3fq27mu9V5+UwdbVG1AE4XnctwlEfMlOF26bQejJMvDbrLJNRS8Bo3bUIfRj8T0NRGY1pfVZ3LYDHwsSrc39o0TdzpDVC7OWeKbSeCFOP1ogIgIO0FCHcrrPVwxxSo2sKrevD1LVqRC2Anzq+c+FFW5m4IjB2Q4PTO3ZtmLj50pFsmrczcLnTJ0V4HzHWESFMua3/cmqfrgsTt2QdZHWgHIwwgEynToTwpTjA96sMqqTs1m2p3plrwiStESJ1uqbQBnEXZbfGU7YXN4SpY1VWllKoBXBmqg5UCACvW4wpwbzW1anYuNYw8d+zjrYCFJXpqMJJBDSRESijnOa37dyuljDxyglDrYyvZkBaI4Q2XVNozaE30bhVO23ZopNhktYI4UIfAxSxYwqtY2HitVnndT0C9DOHT5YQA/GCIiqjsS1PDXYDKQ8Tr/7FERapCKQ1Qrhf5xTaOE2n8evfTfjNqQrT3tYIvgWgA3WfJSEGjtsAWpjoFNqUhKmzNQK1AP1Y92kRIgkfMFPlQFs9bA0TPz7qVLbUIgbydJ8FIezChFbDojDltWzu93V2hElaI4T/dbV6cHAa5a79tNdXJBMmbskKWDG6FszVIBys+3CFcMAOMOYra0jtd1s9Bh2mjrXZlyrmWgCn6T46IRzH/CYTTQ3ktjbt/acEw8RrR53EbFQzuEj38QihGwHNxBSmvJZXEgqT9Xj2bWC+QVaNEKInjoFQpca0zvvuXwJ9vwdT5XlUIXpiC6T+Vyn1597+Gkh0c0KkIwb+YUCV0diWfwBAbx/oJExC9G/AN3MlTEL0qudE2ZYBTZSVMAnxHQQ0Udz4Y6IPwEqYhNiDX1SdU2OfHMy7pU1CCMY2EMLqy0MvGGyQALkyifTWuXKhNfQmyku+nV3CJNISAc2krMk0ZuNrdm1TwiTSzRtMdKORgtXeJUwiXXwBwtzO4ZQtKRlOKWESftc5Ntm0ZtO4Jz5L5Y4kTMK3CLyerMAUumzdFif2J2HyBu58GkwmPg3QW8w01chr/T8ndyr/cVyPX1QKoxTUBcwY9D2QNLELwFyVgdMCeS2OBgmQK5N7MbZBoUrtOPROurrBBABmjDIfH30VgRaC8SPdJboIg2ip6uAZNL71E11F9N0cuDbbNStbp5nOG4n9zMXuMb99BoAhugvWiQnPGSaX0WUbnnF0vwl12kqYHEdAE5kqTOPWvzWQ16f5yiIfMlPFQOfc2U3C5F5vMHhKIHfDqsG8mddmj7Y6B96cpftAHLAbhDvU7o5quuKpr3QVIWFynx43EpNb5W7vaox8K4DDdB9YKhDQRLAmU+7Gd3TXImFyj5TdSOSWrP2tGKYBKIdf1glmvKRIhSl3/UbdpewpScKkH4HXk+Iwjdn4cir345MxbdtBmKd2HLLnF023kDDptZWJKwJjNzQ4udOO1Vk5ilAL4Ke6T0AiZQN8t1LBm2lM85e6i+mNhEmPXQBuS3TJEjvx8+cGre0H/tYLo617DnrUXUt/JEzOcsWNxG8V5OZFF3oZQexmEiaHMPifhoWw0zcSB1zf46NOZVMtZkKu7lrQPRx/5yGL6eqGmO5iBkrClHpabyQmqnOhOqoDcLzze9/3si1u1ltu5EFXe+wGYYHKwCmBvJYlXggSAARyN6xUXx5yCghhAI7dAGVCq2J1jjG2pdSLQeqLXJmSREATWbiBLmv9j+5aksFrxxxpcWwOUru49/vMNNsrV+7+yMc8OzFeUuAyytvwhO5SbD2stVnnmcx1BLrYxq0OahFmN5Mw2cO1NxLtwgwyHx99FTFuA+jYZDZFoEdJGdNoTPN7uo/LThKm5Lj+RqLdeM3YYRZi0wHMBLBfQu8FnjeIwjS25Sndx5GScyNhGhwCmsk0ymjculd116IDrxl1jEVGNZhDA3j5xwBF1DMt91EElu7aU3ZOJEwJe4OJbgykYMaaF3WsHp3d+WgSnfH9v3IMwD39NTX6iYRp4L4AY4HXbiQ6YW+rh7UQoEOBrl80jUAZ5TS/rbs+x86DhGmf4gD/WRmBmyln3XbdxbhZ56NJ7dMtqMeDuevX667H8eOXMPWNgBayjLBTM9aEt/WWG5lO1H0jMa9lie5ChLelc5h6tEa0+OJGotArHcPUeSMR5lTK3fi+7mKEf6RVmJjwnMEqTLnrn9Zdi/CfNHlqnD8C6PfG060XSpBEqvj9ytQ1Yy2udcaaSA++DdOeGWtj9c9YE/4RiUTUlreCpQAe+O7f/BimTQqqzE0z1oQ/FBTXnL9lK2oBvhg+D5PvWyOEHr+8ZsGRgUB8DsC/Qz+/M/ghTGnXGiGcUVS0aEg8s30ywawE6IB9vd7TYdo7Y63V1TPWhPcUhqommPxNHSUwbMabYeqasWZ4ZMaa8I4rJ1afpRTqmGlUou/1Wpg6Z6xZQ2tp3Kp23cUI/ygqivzQysiYw4RBD+j0SJh6zFjL889oKKHfpEn3Bre3bbvOBEUAHJTMtlwfJia0GpYKU27LZt21CH8pLK3J2bZrey2IbFnUwM1hep+ZZgdypTVC2Cu/NDpSMW5niy+3c/FSF4ap54w1aY0Q9rnyN5GDjHiwnC2EOQULwbkpTF0z1gK+m7Em9IpEImrz1mAJxelWTuESpa4Ik99nrAl98kPR0Vu2oo6AM1O9L81h4o8ANdfw+Yw14byC4gVHA2YUjBLAzm9GfdMSprhF2PThwZvf3Tli/NU33vOhjhqEP02YFBkabAvOAMwZAIY4uW/Hw/TCB4fgL8+fgv9+NeRMAM8Vhmoip5/Qfl8kEpErk0gCU35o/lXUxgsB/EhHBY6N+vrgy/3xwPMnY/NHI3r78/NghFcsq5DvTCJhV06sOVcprgPwM6f2ubx+1vc+Oqb8yvR1ewANL5+I1a8fA4v7/Oh6HghPFJZEH1VKTWtYUi6/5ol9KiipPgJAZF+tEU5J2ZXJtAgtbx2FhzediJ3fZCTy1jaAFx4Y6Jj/wAMRuc8kvqeoKJJhZQb/YIFuIeBAHTX0dmVKSZpf/mQEZvztItz77E8SDRIADAVozs54xr/zS6pLAXbklxjhDYWhqglmZsZrDKrVFaS+2Hpl+njnUDy86UQ88+7hthXIQCugwo1Ly+XZvDRW+KvoKWxgMYA83bUAKfzO9E2HgZWvHYfGl49Hh2XvxY6ALMB6saA4uoxVcFpj/XR5ajyN9GiNuA7a74v2L6krEwN44p0jUf/CSOzYnfDHucHYwaD53wwfVrvqT5Oln8nHsrIigRHHZF7LbFUDdLDuer7L1u9M/972A1Su+h/86cnTnAoSABxE4PlDvvh6S35x9HKndiqcdVVx9aUjjs54kZnvdWOQ+pLwZXN72354+KWTsPGdw8H6fhsYSYSVBcXRZgqo8PIHy2UGhA8UldScaIGjFlCku5bBGHCY2k2Fx145Hn995TjE4oPq6rUfIYdN66XC4ujdZjA2568PRHboLkkkLhRaOGwXx6ab4HKkoDXCKfv8zsRMePa9w1D/wkh8tiuhBbcdPhJ8Tsy3qPaT7mxouFrm5nkCU35JNESgBQDs+wnYAb19Z+o3TG9tPxAPPn8yXvt0uO7aE8CvEWHK8vrKNborEX27cmLVBUoZdQBfqLuWwUjop/G7nj4NG946AuzM0+s2olOZsbowFG1SMCc31N8ks8ZdpKi06ijTVDUglPjthnyfYWp960jdtSWFGZebMMYWFkfv6cg0Zj92/0xZBUOj7umopsWzQdhfdz2poP3hwBTLYMLkQMx8vTBUMykSifj9eF2pMFQ1wcz45lUCzwf8GSTA/2HqdiQz37tla8azV5VUXay7mHRRUFJ9Tn5JdCOzegyE43TXk2qufjwjBc63oJ6UVo/Uyi+NjlAmbmbgehrkdFQvSrcwAQAxUGRa1riCkurbpNXDPt3TUdnCXCb8QHc9TkuXj3m9GQbQnJ1mxpudrR4iGYWlNTmftW3fxKBaIP2CBKTnlenbGMcQ6MGCUPQ3RBxevqRyi+6SvKSoZN7JJoxFbPE4X/3OPQgSpm6MbGZ6SVo9Bmb8xJrh+ylrpgmaAsCxJ53dTML0bQqEkOKOy/NLahYE2tsXNzREYrqLcpM901HBCxl0qO563CSdvzP1iYHhBJ5vZma8XFBSPV53PW5RMLE6e8vWjJcI9CAACdJ3yJWpfyMBaioojjYbQFnDsopXdRekwxXXVB1jGKoahJDuWtxMwjQQhBwT2FRYHL1bxdTNDQ3labEQdXdrBEAzAbi4ZcAd5GPewAWZMNnMtN4qLKkuKyp6xMc3I5nyQzVFu7jjVYDmQII0IBKmxI1gUK2ZufW5gonzE15E2O0KimvOLyiZ/yQxPwLgWN31eIl8zBu8s6GsDX5p9fjlNQuODATic9wyHdWLJExJ6mr1uLSwpPqOjoxAtddaPbqnozLMeQAdoLseL5P/A9ljCINmBmLma16aQts1HfX1rkeAJEhJkiuTvY4i0IMFJTV/ZBUta1xS8YzugnqTH1pwKlnmYmbk6q7FTyRMqXE+WXiqoDi61AgGZjQ8MOMT3QUBPaajsnk9KH1aI5wiYUodAiFkxuMFuls9Jk26N7h99+e/NdmqBuCZoY5eI9+ZUm9Y16oeL+eHahwfrlhYWpOzbdf2l7w2HdWL5MrknBOJ+ZGCkuh6Ujwl1a0ehRPnnQTDWMQWX+65AVMeJWFy3iVs0QsFJdX3G0Ga3fCXis/s3PiVv4kcZMSD5QwKg707HdWLJEx6BACaZHWgyK5Wjz2tEXG6lYHDdB9gOpLvTBp1t3rEMzO3FIai4wa7nfxQdPTLWzNe6GqNkCBpIlcmFyDwycz4W0FxtJmVMbmxfuZrA3lfQfGCowEzCkYJQ74Z6SZhchNCDrG5ubA4encbYjetWhbZ2dvLJkyKDA22BWcA5gwAQ3SXLTrJxzz3CTJh8hAK9tLq0dkaEWzL6G6NkCC5SJ+rYBSGahJeIFqkxIsKCMctalOK6wD8THdBIoULRIuUOscCNijFDPkk4WoSJm8gyA8Mrif/pxPCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWwiYRLCJhImIWzSd5iIbgcgS1AK8W2xrmx8T59hWlE/axpZ5mkENOiuXghXYDSToc5ZUT9rWm9/7rM5kGjvE/9XFVdfahHVAjhN9/EIocGbAN+4Ymnl37r/obfcDChMAJCVFQmMOCbzWmarWiaDijSxg0HzexvFllSYuu0Z/k64DtJcKPzJAmMZq+C0xvrpn/b2AlvC1K3wV9FT2MBiAHm6j1wIuzDQCqhw49Lyzf2+zs4wdSsMVU1gVrUAfqz7RAgxaIT3mXl249LKJQN5eW+5Sfo+0/L62SuN9tipBA4zsDPZ7QnhsDaA5x5oxEYONEh9SfrK1FNBSfURACIAySLDwu2YgEeVUtMalpS/l/CbU/ExrzdXTqw5V2a8CRd7HozwimUVTw12A46FqWt3lB+afxUxLwTwIyfPlBB9+JiIIqef0H5fJBKxktmQw2HqtHcuNslcbKFLjBj39De/PVFawtRtz4oNhBLIQEXhECI0waSy5Q/NetvO7WoNU7f8UHQ0MeoAnJmSHQgBAITXmWlK49JZq1Ox+ZT8NJ6oxvqKDWecGDuHwb8G8F+n9y98jvA5gcOfvx87PVVB6nPXTl+ZevrW+quQ9VdFUuIA399hZlaufHjatlTvzBUf83qTXxodqRi3M+Nyx3YqfIOBdSAON9ZX/suxfbo1TN0KS2ty2ORaEH7q+M6FB9G/mVDZWD/L8Z47V3xn6s/yJbOaDx424mwi+j3AKb9UC8/6GuC5u4cPO11HkPriqitTTz1aPa4HYCS9QeEHFhjL4hZPf+zhSq0/Xrn+Y15v8kMLTiXLXAxCru5ahEaEf8KyylYsm/2s7lIAj4apW1erRx2A43XXIhz1IYMrGpdW1APkmnWWXf+dqT9drR6nEDgM4Cvd9YiUayPwAqM9dkpna4R7gtQXz1yZevrlNQuODATic6TVw5+I0GQadMNfH5j1H9219MXTH/N6UxiqOo/ZqAP4Yt21CFu8qIDwo0srntBdyL74Lkxdh9Xd6nEbgGN1VyMGg7cRUKXaT7qzoeFqU3c1A6rYn2HqFAotHLaLY9MBmglgP931iAHpIMbddrZGOMXXYep2xTVVxxiGqgYhpLsW0Q9GMytjcmP9zNd0lzKo8tMhTN0KJlZnQ1EtgDN01yL2YtAbivjG5fUVf9ddS1LH4eWfxhO14qHKljNOjJ3d1erxadIbFEkh4AsGlQfa28/wepD6PEa/Xpl66tHqMQVAhu560owFxjIjA1Mb/lLxme5i7JJWH/N6k18aHUkWLQJ4vO5a0gKhhYjDy5dUbtFdit3SPkzdCktrciyL6wj4ie5afOo9Bt+U7FBHN0ur70z9Wb5kVvMhQ0ec1fVo0pe66/GRXQDPPTAQO9nPQepLWl6ZesovjY5QJm6WVo+kMBhLjWBgRsMDMz7RXYwjBywf8/pWWFpzNltWLUCjdNfiMc+xQlnjkopndBfiJAnTAEirx4B9xOBZbmuNcIqEaYCKihYNiWe2TyZwJYADdNfjMrsJfEdHRqD6sftnpm0rjIQpQUWlVUeZpqqRKbSdiNCkYE5uqL/pHd216CZhGqSC4przAa4D4SLdtWjyEiwVXvFQ+UbdhbiFhCkpTPkl0RCBFgA4XHc1DtlO4Hleao1wioTJBmnS6tFBjLtVTN3c0FAu9+F6IWGy0ZW/nneCYRo1DBTprsVWjGYKqPDyB8tf0V2Km0mYUiA/VHMJMS+G91s93mTG1MZlFU26C/ECeZwoBRrrZ63v0erhxaeidzCofPfw/c+QICVHrkw2Gj+xZvh+yprpkVYPC4xlrILTGuunS79XguRjnkOKSuadbMJYBGCc7lp6w0AroMKNS8s3667FqyRMDissrclhy7oDoFN119LlAwZXpusjQHaS70wOW75kVvPBQw8+0wWtHm1drREneWU6qhfJlckhmlo9mIBH2bKmr3ho9ru6z4GfyMc8FygoqT6HQbUE/CKV+yHCC2yhbMWyiqd0H7MfSZhcpDBUNYEtdQcIx9m86Y+JKHL6Ce33RSIRS/dx+pWEyWUmTIoMDbRl3kDg2QD2T3JzMWLc48XpqF4kYXKpZFs9iNAEk8qWPzTrbd3Hki4kTC535cSqC5Qy6gC+cEBvILzOTFMal85arbv2dCNh8oQBtHoQPifmW7Z/0HFXa2skrrvidCRh8pAerR7lADK7/jkO8P0dZmblyoenyWr0GkmYPKhw4ryTYBiL2EKQlTHFq6tG+E1CYRJCJEYeJxLCJhImIWwiYRLCJhImIWwiYRLCJv8P9sXhC7xE4kIAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTktMDQtMTNUMDg6MTY6MDgrMDI6MDCcYZVaAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE5LTA0LTEzVDA4OjE2OjA4KzAyOjAw7Twt5gAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - get
+          - delete
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          verbs:
+          - get
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - users
+          verbs:
+          - list
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consolelinks
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - patch
+          - delete
+        serviceAccountName: che-operator
+      deployments:
+      - name: che-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: che-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: che-operator
+            spec:
+              containers:
+              - command:
+                - /usr/local/bin/che-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: che-operator
+                - name: CHE_VERSION
+                  value: 7.10.0
+                - name: IMAGE_default_che_server
+                  value: quay.io/eclipse/che-server:7.10.0
+                - name: IMAGE_default_plugin_registry
+                  value: quay.io/eclipse/che-plugin-registry:7.10.0
+                - name: IMAGE_default_devfile_registry
+                  value: quay.io/eclipse/che-devfile-registry:7.10.0
+                - name: IMAGE_default_pvc_jobs
+                  value: registry.access.redhat.com/ubi8-minimal:8.1-398
+                - name: IMAGE_default_postgres
+                  value: centos/postgresql-96-centos7:9.6
+                - name: IMAGE_default_keycloak
+                  value: quay.io/eclipse/che-keycloak:7.10.0
+                - name: IMAGE_default_che_workspace_plugin_broker_metadata
+                  value: quay.io/eclipse/che-plugin-metadata-broker:v3.1.1
+                - name: IMAGE_default_che_workspace_plugin_broker_artifacts
+                  value: quay.io/eclipse/che-plugin-artifacts-broker:v3.1.1
+                - name: IMAGE_default_che_server_secure_exposer_jwt_proxy_image
+                  value: quay.io/eclipse/che-jwtproxy:810d89c
+                image: quay.io/eclipse/che-operator:nightly
+                imagePullPolicy: Always
+                name: che-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              restartPolicy: Always
+              serviceAccountName: che-operator
+              terminationGracePeriodSeconds: 5
+      permissions:
+      - rules:
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - serviceaccounts
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - pods/exec
+          - pods/log
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - org.eclipse.che
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: che-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - workspaces
+  - devtools
+  - developer
+  - ide
+  - java
+  links:
+  - name: Product Page
+    url: http://www.eclipse.org/che
+  - name: Documentation
+    url: https://www.eclipse.org/che/docs
+  - name: Operator GitHub Repo
+    url: https://github.com/eclipse/che-operator
+  maintainers:
+  - email: dfestal@redhat.com
+    name: David Festal
+  maturity: stable
+  provider:
+    name: Eclipse Foundation
+  replaces: eclipse-che-preview-openshift.v9.9.9-nightly.1584253674
+  version: 9.9.9-nightly.1584615281

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584615281/eclipse-che-preview-openshift.v9.9.9-nightly.1584615281.clusterserviceversion.yaml.diff
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584615281/eclipse-che-preview-openshift.v9.9.9-nightly.1584615281.clusterserviceversion.yaml.diff
@@ -1,0 +1,25 @@
+--- /home/tolusha/gocode/src/github.com/eclipse/che-operator/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584253674/eclipse-che-preview-openshift.v9.9.9-nightly.1584253674.clusterserviceversion.yaml	2020-03-19 12:12:28.022013746 +0200
++++ /home/tolusha/gocode/src/github.com/eclipse/che-operator/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/9.9.9-nightly.1584615281/eclipse-che-preview-openshift.v9.9.9-nightly.1584615281.clusterserviceversion.yaml	2020-03-19 12:54:41.700684202 +0200
+@@ -46,12 +46,12 @@
+     categories: Developer Tools, OpenShift Optional
+     certified: "false"
+     containerImage: quay.io/eclipse/che-operator:nightly
+-    createdAt: "2020-03-15T06:27:54Z"
++    createdAt: "2020-03-19T10:54:41Z"
+     description: A Kube-native development solution that delivers portable and collaborative
+       developer workspaces in OpenShift.
+     repository: https://github.com/eclipse/che-operator
+     support: Eclipse Foundation
+-  name: eclipse-che-preview-openshift.v9.9.9-nightly.1584253674
++  name: eclipse-che-preview-openshift.v9.9.9-nightly.1584615281
+   namespace: placeholder
+ spec:
+   apiservicedefinitions: {}
+@@ -415,5 +415,5 @@
+   maturity: stable
+   provider:
+     name: Eclipse Foundation
+-  replaces: eclipse-che-preview-openshift.v9.9.9-nightly.1583509667
+-  version: 9.9.9-nightly.1584253674
++  replaces: eclipse-che-preview-openshift.v9.9.9-nightly.1584253674
++  version: 9.9.9-nightly.1584615281

--- a/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/eclipse-che-preview-openshift.package.yaml
+++ b/olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/eclipse-che-preview-openshift.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: eclipse-che-preview-openshift.v9.9.9-nightly.1584253674
+- currentCSV: eclipse-che-preview-openshift.v9.9.9-nightly.1584615281
   name: nightly
 - currentCSV: eclipse-che-preview-openshift.v7.10.0
   name: stable

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -208,15 +208,18 @@ type CheClusterSpecServer struct {
 	NonProxyHosts string `json:"nonProxyHosts,omitempty"`
 	// User name of the proxy server.
 	// Only use when configuring a proxy is required
-	// (see also the `proxyURL` field).
+	// (see also the `proxyURL` `proxySecret` fields).
 	// +optional
 	ProxyUser string `json:"proxyUser,omitempty"`
 	// Password of the proxy server
-	//
 	// Only use when proxy configuration is required
-	// (see also the `proxyUser` field).
+	// (see also the `proxyUser` and `proxySecret` fields).
 	// +optional
 	ProxyPassword string `json:"proxyPassword,omitempty"`
+	// The secret that contains `user` and `password` for a proxy server.
+	// If the secret is defined then `proxyUser` and `proxyPassword` are ignored
+	// +optional
+	ProxySecret string `json:"proxySecret,omitempty"`
 	// Overrides the memory request used in the Che server deployment. Defaults to 512Mi.
 	// +optional
 	ServerMemoryRequest string `json:"serverMemoryRequest,omitempty"`
@@ -255,6 +258,14 @@ type CheClusterSpecDB struct {
 	// Postgres database name that the Che server uses to connect to the DB. Defaults to `dbche`.
 	// +optional
 	ChePostgresDb string `json:"chePostgresDb,omitempty"`
+	// The secret that contains Postgres `user` and `password` that the Che server should use to connect to the DB.
+	// If the secret is defined then `chePostgresUser` and `chePostgresPassword` are ignored.
+	// If the value is omitted or left blank then there are two scenarios:
+	// 1. `chePostgresUser` and `chePostgresPassword` are defined, then they will be used to connect to the DB.
+	// 2. `chePostgresUser` or `chePostgresPassword` are not defined, then a new secret with the name `che-postgres-secret`
+	// will be created with default value of `pgche` for `user` and with an auto-generated value for `password`.
+	// +optional
+	ChePostgresSecret string `json:"chePostgresSecret,omitempty"`
 	// Overrides the container image used in the Postgres database deployment. This includes the image tag.
 	// Omit it or leave it empty to use the defaut container image provided by the operator.
 	// +optional
@@ -288,6 +299,15 @@ type CheClusterSpecAuth struct {
 	// If omitted or left blank, it will be set to an auto-generated password.
 	// +optional
 	IdentityProviderPassword string `json:"identityProviderPassword,omitempty"`
+	// The secret that contains `user` and `password` for Identity Provider.
+	// If the secret is defined then `identityProviderAdminUserName` and `identityProviderPassword` are ignored.
+	// If the value is omitted or left blank then there are two scenarios:
+	// 1. `identityProviderAdminUserName` and `identityProviderPassword` are defined, then they will be used.
+	// 2. `identityProviderAdminUserName` or `identityProviderPassword` are not defined, then a new secret
+	// with the name `che-identity-secret` will be created with default value `admin` for `user` and
+	// with an auto-generated value for `password`.
+	// +optional
+	IdentityProviderSecret string `json:"identityProviderSecret,omitempty"`
 	// Name of a Identity provider (Keycloak / RH SSO) realm that should be used for Che.
 	// This is useful to override it ONLY if you use an external Identity Provider (see the `externalIdentityProvider` field).
 	// If omitted or left blank, it will be set to the value of the `flavour` field.
@@ -303,13 +323,21 @@ type CheClusterSpecAuth struct {
 	// If omitted or left blank, it will be set to an auto-generated password.
 	// +optional
 	IdentityProviderPostgresPassword string `json:"identityProviderPostgresPassword,omitempty"`
+	// The secret that contains `password` for The Identity Provider (Keycloak / RH SSO) to connect to the database.
+	// If the secret is defined then `identityProviderPostgresPassword` will be ignored.
+	// If the value is omitted or left blank then there are two scenarios:
+	// 1. `identityProviderPostgresPassword` is defined, then it will be used to connect to the database.
+	// 2. `identityProviderPostgresPassword` is not defined, then a new secret with the name `che-identity-postgres-secret`
+	// will be created with an auto-generated value for `password`.
+	// +optional
+	IdentityProviderPostgresSecret string `json:"identityProviderPostgresSecret,omitempty"`
 	// Forces the default `admin` Che user to update password on first login. Defaults to `false`.
 	// +optional
 	UpdateAdminPassword bool `json:"updateAdminPassword"`
-	// Enables the integration of the identity provider (Keycloak / RHSSO) with OpenShift OAuth. Enabled by defaumt on OpenShift.
-	// This will allow users to directly login with their Openshift user throug the Openshift login,
-	// and have their workspaces created under personnal OpenShift namespaces.
-	// WARNING: the `kuebadmin` user is NOT supported, and logging through it will NOT allow accessing the Che Dashboard.
+	// Enables the integration of the identity provider (Keycloak / RHSSO) with OpenShift OAuth. Enabled by default on OpenShift.
+	// This will allow users to directly login with their Openshift user through the Openshift login,
+	// and have their workspaces created under personal OpenShift namespaces.
+	// WARNING: the `kubeadmin` user is NOT supported, and logging through it will NOT allow accessing the Che Dashboard.
 	// +optional
 	OpenShiftoAuth bool `json:"openShiftoAuth"`
 	// Name of the OpenShift `OAuthClient` resource used to setup identity federation on the OpenShift side. Auto-generated if left blank.
@@ -448,8 +476,8 @@ type CheCluster struct {
 	// the various components of the Che installation.
 	// These generated config maps should NOT be updated manually.
 	Spec   CheClusterSpec   `json:"spec,omitempty"`
-	
-	// CheClusterStatus defines the observed state of Che installation	
+
+	// CheClusterStatus defines the observed state of Che installation
 	Status CheClusterStatus `json:"status,omitempty"`
 }
 

--- a/pkg/apis/org/v1/zz_generated.openapi.go
+++ b/pkg/apis/org/v1/zz_generated.openapi.go
@@ -150,6 +150,13 @@ func schema_pkg_apis_org_v1_CheClusterSpecAuth(ref common.ReferenceCallback) com
 							Format:      "",
 						},
 					},
+					"identityProviderSecret": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The secret that contains `user` and `password` for Identity Provider. If the secret is defined then `identityProviderAdminUserName` and `identityProviderPassword` are ignored. If the value is omitted or left blank then there are two scenarios: 1. `identityProviderAdminUserName` and `identityProviderPassword` are defined, then they will be used. 2. `identityProviderAdminUserName` or `identityProviderPassword` are not defined, then a new secret with the name `che-identity-secret` will be created with default value `admin` for `user` and with an auto-generated value for `password`.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"identityProviderRealm": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of a Identity provider (Keycloak / RH SSO) realm that should be used for Che. This is useful to override it ONLY if you use an external Identity Provider (see the `externalIdentityProvider` field). If omitted or left blank, it will be set to the value of the `flavour` field.",
@@ -171,6 +178,13 @@ func schema_pkg_apis_org_v1_CheClusterSpecAuth(ref common.ReferenceCallback) com
 							Format:      "",
 						},
 					},
+					"identityProviderPostgresSecret": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The secret that contains `password` for The Identity Provider (Keycloak / RH SSO) to connect to the database. If the secret is defined then `identityProviderPostgresPassword` will be ignored. If the value is omitted or left blank then there are two scenarios: 1. `identityProviderPostgresPassword` is defined, then it will be used to connect to the database. 2. `identityProviderPostgresPassword` is not defined, then a new secret with the name `che-identity-postgres-secret` will be created with an auto-generated value for `password`.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"updateAdminPassword": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Forces the default `admin` Che user to update password on first login. Defaults to `false`.",
@@ -180,7 +194,7 @@ func schema_pkg_apis_org_v1_CheClusterSpecAuth(ref common.ReferenceCallback) com
 					},
 					"openShiftoAuth": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Enables the integration of the identity provider (Keycloak / RHSSO) with OpenShift OAuth. Enabled by defaumt on OpenShift. This will allow users to directly login with their Openshift user throug the Openshift login, and have their workspaces created under personnal OpenShift namespaces. WARNING: the `kuebadmin` user is NOT supported, and logging through it will NOT allow accessing the Che Dashboard.",
+							Description: "Enables the integration of the identity provider (Keycloak / RHSSO) with OpenShift OAuth. Enabled by default on OpenShift. This will allow users to directly login with their Openshift user through the Openshift login, and have their workspaces created under personal OpenShift namespaces. WARNING: the `kubeadmin` user is NOT supported, and logging through it will NOT allow accessing the Che Dashboard.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -264,6 +278,13 @@ func schema_pkg_apis_org_v1_CheClusterSpecDB(ref common.ReferenceCallback) commo
 					"chePostgresDb": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Postgres database name that the Che server uses to connect to the DB. Defaults to `dbche`.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"chePostgresSecret": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The secret that contains Postgres `user` and `password` that the Che server should use to connect to the DB. If the secret is defined then `chePostgresUser` and `chePostgresPassword` are ignored. If the value is omitted or left blank then there are two scenarios: 1. `chePostgresUser` and `chePostgresPassword` are defined, then they will be used to connect to the DB. 2. `chePostgresUser` or `chePostgresPassword` are not defined, then a new secret with the name `che-postgres-secret` will be created with default value of `pgche` for `user` and with an auto-generated value for `password`.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -583,14 +604,21 @@ func schema_pkg_apis_org_v1_CheClusterSpecServer(ref common.ReferenceCallback) c
 					},
 					"proxyUser": {
 						SchemaProps: spec.SchemaProps{
-							Description: "User name of the proxy server. Only use when configuring a proxy is required (see also the `proxyURL` field).",
+							Description: "User name of the proxy server. Only use when configuring a proxy is required (see also the `proxyURL` `proxySecret` fields).",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"proxyPassword": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Password of the proxy server\n\nOnly use when proxy configuration is required (see also the `proxyUser` field).",
+							Description: "Password of the proxy server Only use when proxy configuration is required (see also the `proxyUser` and `proxySecret` fields).",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"proxySecret": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The secret that contains `user` and `password` for a proxy server. If the secret is defined then `proxyUser` and `proxyPassword` are ignored",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/controller/che/create.go
+++ b/pkg/controller/che/create.go
@@ -277,7 +277,6 @@ func (r *ReconcileChe) CreateNewRoleBinding(instance *orgv1.CheCluster, roleBind
 
 func (r *ReconcileChe) CreateIdentityProviderItems(instance *orgv1.CheCluster, request reconcile.Request, cheFlavor string, keycloakDeploymentName string, isOpenShift4 bool) (err error) {
 	tests := r.tests
-	keycloakAdminPassword := instance.Spec.Auth.IdentityProviderPassword
 	oAuthClientName := instance.Spec.Auth.OAuthClientName
 	if len(oAuthClientName) < 1 {
 		oAuthClientName = instance.Name + "-openshift-identity-provider-" + strings.ToLower(util.GeneratePasswd(6))
@@ -303,7 +302,7 @@ func (r *ReconcileChe) CreateIdentityProviderItems(instance *orgv1.CheCluster, r
 	}
 
 	if !tests {
-		openShiftIdentityProviderCommand, err := deploy.GetOpenShiftIdentityProviderProvisionCommand(instance, oAuthClientName, oauthSecret, keycloakAdminPassword, isOpenShift4)
+		openShiftIdentityProviderCommand, err := deploy.GetOpenShiftIdentityProviderProvisionCommand(instance, oAuthClientName, oauthSecret, isOpenShift4)
 		if err != nil {
 			logrus.Errorf("Failed to build identity provider provisioning command")
 			return err
@@ -330,6 +329,18 @@ func (r *ReconcileChe) CreateIdentityProviderItems(instance *orgv1.CheCluster, r
 	return nil
 }
 
+func (r *ReconcileChe) CreateSecret(instance *orgv1.CheCluster, m map[string][]byte, name string) (err error) {
+	secret := &corev1.Secret{}
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: instance.Namespace}, secret); err != nil && errors.IsNotFound(err) {
+		secret := deploy.NewSecret(instance, name, m)
+		if err := r.CreateNewSecret(instance, secret); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (r *ReconcileChe) CreateTLSSecret(instance *orgv1.CheCluster, url string, name string) (err error) {
 	// create a secret with either router tls cert (or OpenShift API crt) when on OpenShift infra
 	// and router is configured with a self signed certificate
@@ -341,7 +352,7 @@ func (r *ReconcileChe) CreateTLSSecret(instance *orgv1.CheCluster, url string, n
 			logrus.Errorf("Failed to extract crt for secret %s. Failed to create a secret with a self signed crt: %s", name, err)
 			return err
 		} else {
-			secret := deploy.NewSecret(instance, name, crt)
+			secret := deploy.NewSecret(instance, name, map[string][]byte{"ca.crt": crt})
 			if err := r.CreateNewSecret(instance, secret); err != nil {
 				return err
 			}
@@ -363,60 +374,83 @@ func (r *ReconcileChe) GenerateAndSaveFields(instance *orgv1.CheCluster, request
 
 	cheMultiUser := deploy.GetCheMultiUser(instance)
 	if cheMultiUser == "true" {
-		chePostgresPassword := util.GetValue(instance.Spec.Database.ChePostgresPassword, util.GeneratePasswd(12))
-		if len(instance.Spec.Database.ChePostgresPassword) < 1 {
-			instance.Spec.Database.ChePostgresPassword = chePostgresPassword
-			if err := r.UpdateCheCRSpec(instance, "auto-generated CheCluster DB password", "password-hidden"); err != nil {
-				return err
+		if len(instance.Spec.Database.ChePostgresSecret) < 1 {
+			if len(instance.Spec.Database.ChePostgresUser) < 1 || len(instance.Spec.Database.ChePostgresPassword) < 1 {
+				chePostgresSecret := deploy.DefaultChePostgresSecret
+				r.CreateSecret(instance, map[string][]byte{"user": []byte(deploy.DefaultChePostgresUser), "password": []byte(util.GeneratePasswd(12))}, chePostgresSecret)
+				instance.Spec.Database.ChePostgresSecret = chePostgresSecret
+				if err := r.UpdateCheCRSpec(instance, "Postgres Secret", chePostgresSecret); err != nil {
+					return err
+				}
+			} else {
+				if len(instance.Spec.Database.ChePostgresUser) < 1 {
+					instance.Spec.Database.ChePostgresUser = deploy.DefaultChePostgresUser
+					if err := r.UpdateCheCRSpec(instance, "Postgres User", instance.Spec.Database.ChePostgresUser); err != nil {
+						return err
+					}
+				}
+				if len(instance.Spec.Database.ChePostgresPassword) < 1 {
+					instance.Spec.Database.ChePostgresPassword = util.GeneratePasswd(12)
+					if err := r.UpdateCheCRSpec(instance, "auto-generated CheCluster DB password", "password-hidden"); err != nil {
+						return err
+					}
+				}
 			}
-
 		}
-		keycloakPostgresPassword := util.GetValue(instance.Spec.Auth.IdentityProviderPostgresPassword, util.GeneratePasswd(12))
-		if len(instance.Spec.Auth.IdentityProviderPostgresPassword) < 1 {
-			instance.Spec.Auth.IdentityProviderPostgresPassword = keycloakPostgresPassword
+		if len(instance.Spec.Auth.IdentityProviderPostgresSecret) < 1 {
+			keycloakPostgresPassword := util.GeneratePasswd(12)
 			keycloakDeployment, err := r.GetEffectiveDeployment(instance, "keycloak")
 			if err != nil {
 				logrus.Info("Disregard the error. No existing Identity provider deployment found. Generating passwd")
 			} else {
 				keycloakPostgresPassword = util.GetDeploymentEnv(keycloakDeployment, "DB_PASSWORD")
 			}
-			if err := r.UpdateCheCRSpec(instance, "auto-generated Keycloak DB password", "password-hidden"); err != nil {
-				return err
+
+			if len(instance.Spec.Auth.IdentityProviderPostgresPassword) < 1 {
+				identityPostgresSecret := deploy.DefaultCheIdentityPostgresSecret
+				r.CreateSecret(instance, map[string][]byte{"password": []byte(keycloakPostgresPassword)}, identityPostgresSecret)
+				instance.Spec.Auth.IdentityProviderPostgresSecret = identityPostgresSecret
+				if err := r.UpdateCheCRSpec(instance, "Identity Provider Postgres Secret", identityPostgresSecret); err != nil {
+					return err
+				}
 			}
 		}
-		if len(instance.Spec.Auth.IdentityProviderPassword) < 1 {
-			keycloakAdminPassword := util.GetValue(instance.Spec.Auth.IdentityProviderPassword, util.GeneratePasswd(12))
-			keycloakDeployment, err := r.GetEffectiveDeployment(instance, "keycloak")
-			if err != nil {
-				logrus.Info("Disregard the error. No existing Identity provider deployment found. Generating passwd")
-			} else {
-				keycloakAdminPassword = util.GetDeploymentEnv(keycloakDeployment, "SSO_ADMIN_PASSWORD")
-			}
-			instance.Spec.Auth.IdentityProviderPassword = keycloakAdminPassword
-			if err := r.UpdateCheCRSpec(instance, "Keycloak admin password", "password hidden"); err != nil {
-				return err
-			}
-		}
-		if len(instance.Spec.Auth.IdentityProviderAdminUserName) < 1 {
+
+		if len(instance.Spec.Auth.IdentityProviderSecret) < 1 {
 			keycloakAdminUserName := util.GetValue(instance.Spec.Auth.IdentityProviderAdminUserName, "admin")
+			keycloakAdminPassword := util.GetValue(instance.Spec.Auth.IdentityProviderPassword, util.GeneratePasswd(12))
+
 			keycloakDeployment, err := r.GetEffectiveDeployment(instance, "keycloak")
 			if err != nil {
-				logrus.Info("Disregard the error. No existing Identity provider deployment found. Generating admin username")
+				logrus.Info("Disregard the error. No existing Identity provider deployment found. Generating admin username and password")
 			} else {
 				keycloakAdminUserName = util.GetDeploymentEnv(keycloakDeployment, "SSO_ADMIN_USERNAME")
+				keycloakAdminPassword = util.GetDeploymentEnv(keycloakDeployment, "SSO_ADMIN_PASSWORD")
 			}
-			instance.Spec.Auth.IdentityProviderAdminUserName = keycloakAdminUserName
-			if err := r.UpdateCheCRSpec(instance, "Keycloak admin username", keycloakAdminUserName); err != nil {
-				return err
+
+			if len(instance.Spec.Auth.IdentityProviderAdminUserName) < 1 || len(instance.Spec.Auth.IdentityProviderPassword) < 1 {
+				identityProviderSecret := deploy.DefaultCheIdentitySecret
+				r.CreateSecret(instance, map[string][]byte{"user": []byte(keycloakAdminUserName), "password": []byte(keycloakAdminPassword)}, identityProviderSecret)
+				instance.Spec.Auth.IdentityProviderSecret = identityProviderSecret
+				if err := r.UpdateCheCRSpec(instance, "Identity Provider Secret", identityProviderSecret); err != nil {
+					return err
+				}
+			} else {
+				if len(instance.Spec.Auth.IdentityProviderPassword) < 1 {
+					instance.Spec.Auth.IdentityProviderPassword = keycloakAdminPassword
+					if err := r.UpdateCheCRSpec(instance, "Keycloak admin password", "password hidden"); err != nil {
+						return err
+					}
+				}
+				if len(instance.Spec.Auth.IdentityProviderAdminUserName) < 1 {
+					instance.Spec.Auth.IdentityProviderAdminUserName = keycloakAdminUserName
+					if err := r.UpdateCheCRSpec(instance, "Keycloak admin username", keycloakAdminUserName); err != nil {
+						return err
+					}
+				}
 			}
 		}
-		chePostgresUser := util.GetValue(instance.Spec.Database.ChePostgresUser, "pgche")
-		if len(instance.Spec.Database.ChePostgresUser) < 1 {
-			instance.Spec.Database.ChePostgresUser = chePostgresUser
-			if err := r.UpdateCheCRSpec(instance, "Postgres User", chePostgresUser); err != nil {
-				return err
-			}
-		}
+
 		chePostgresDb := util.GetValue(instance.Spec.Database.ChePostgresDb, "dbche")
 		if len(instance.Spec.Database.ChePostgresDb) < 1 {
 			instance.Spec.Database.ChePostgresDb = chePostgresDb

--- a/pkg/controller/che/update.go
+++ b/pkg/controller/che/update.go
@@ -236,12 +236,11 @@ func (r *ReconcileChe) ReconcileTLSObjects(instance *orgv1.CheCluster, request r
 
 func (r *ReconcileChe) ReconcileIdentityProvider(instance *orgv1.CheCluster, isOpenShift4 bool) (deleted bool, err error) {
 	if instance.Spec.Auth.OpenShiftoAuth == false && instance.Status.OpenShiftoAuthProvisioned == true {
-		keycloakAdminPassword := instance.Spec.Auth.IdentityProviderPassword
 		keycloakDeployment := &appsv1.Deployment{}
 		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: "keycloak", Namespace: instance.Namespace}, keycloakDeployment); err != nil {
 			logrus.Errorf("Deployment %s not found: %s", keycloakDeployment.Name, err)
 		}
-		deleteOpenShiftIdentityProviderProvisionCommand := deploy.GetDeleteOpenShiftIdentityProviderProvisionCommand(instance, keycloakAdminPassword, isOpenShift4)
+		deleteOpenShiftIdentityProviderProvisionCommand := deploy.GetDeleteOpenShiftIdentityProviderProvisionCommand(instance, isOpenShift4)
 		podToExec, err := k8sclient.GetDeploymentPod(keycloakDeployment.Name, instance.Namespace)
 		if err != nil {
 			logrus.Errorf("Failed to retrieve pod name. Further exec will fail")

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -46,6 +46,7 @@ const (
 	DefaultChePostgresHostName = "postgres"
 	DefaultChePostgresPort     = "5432"
 	DefaultChePostgresDb       = "dbche"
+	DefaultChePostgresSecret   = "che-postgres-secret"
 	DefaultPvcStrategy         = "common"
 	DefaultPvcClaimSize        = "1Gi"
 	DefaultIngressStrategy     = "multi-host"
@@ -94,6 +95,8 @@ const (
 	DefaultConsoleLinkName                = "che"
 	DefaultConsoleLinkSection             = "Red Hat Applications"
 	DefaultConsoleLinkImage               = "/dashboard/assets/branding/loader.svg"
+	DefaultCheIdentitySecret              = "che-identity-secret"
+	DefaultCheIdentityPostgresSecret      = "che-identity-postgres-secret"
 	defaultConsoleLinkUpstreamDisplayName = "Eclipse Che"
 	defaultConsoleLinkDisplayName         = "CodeReady Workspaces"
 )

--- a/pkg/deploy/deployment_postgres.go
+++ b/pkg/deploy/deployment_postgres.go
@@ -151,26 +151,6 @@ func NewPostgresDeployment(cr *orgv1.CheCluster, isOpenshift bool, cheFlavor str
 			})
 	}
 
-	identityProviderPostgresSecret := cr.Spec.Auth.IdentityProviderPostgresSecret
-	if len(identityProviderPostgresSecret) > 0 {
-		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-			Name: "IDENTITY_POSTGRES_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					Key: "password",
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: identityProviderPostgresSecret,
-					},
-				},
-			},
-		})
-	} else {
-		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-			Name:  "IDENTITY_POSTGRES_PASSWORD",
-			Value: cr.Spec.Auth.IdentityProviderPostgresPassword,
-		})
-	}
-
 	if !isOpenshift {
 		var runAsUser int64 = 26
 		deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{

--- a/pkg/deploy/exec_commands.go
+++ b/pkg/deploy/exec_commands.go
@@ -22,10 +22,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func GetPostgresProvisionCommand() (command string) {
+func GetPostgresProvisionCommand(identityProviderPostgresSecret string) (command string) {
 	command = "OUT=$(psql postgres -tAc \"SELECT 1 FROM pg_roles WHERE rolname='keycloak'\"); " +
 		"if [ $OUT -eq 1 ]; then echo \"DB exists\"; exit 0; fi " +
-		"&& psql -c \"CREATE USER keycloak WITH PASSWORD '${IDENTITY_POSTGRES_PASSWORD}'\" " +
+		"&& psql -c \"CREATE USER keycloak WITH PASSWORD '" + identityProviderPostgresSecret + "'\" " +
 		"&& psql -c \"CREATE DATABASE keycloak\" " +
 		"&& psql -c \"GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak\" " +
 		"&& psql -c \"ALTER USER ${POSTGRESQL_USER} WITH SUPERUSER\""

--- a/pkg/deploy/secret.go
+++ b/pkg/deploy/secret.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewSecret(cr *orgv1.CheCluster, name string, crt []byte) *corev1.Secret {
+func NewSecret(cr *orgv1.CheCluster, name string, data map[string][]byte) *corev1.Secret {
 	labels := GetLabels(cr, util.GetValue(cr.Spec.Server.CheFlavor, DefaultCheFlavor))
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
@@ -30,8 +30,6 @@ func NewSecret(cr *orgv1.CheCluster, name string, crt []byte) *corev1.Secret {
 			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
-		Data: map[string][]byte{
-			"ca.crt": crt,
-		},
+		Data: data,
 	}
 }

--- a/pkg/util/k8s_helpers.go
+++ b/pkg/util/k8s_helpers.go
@@ -9,31 +9,23 @@
 // Contributors:
 //   Red Hat, Inc. - initial API and implementation
 //
-package che
+package util
 
 import (
 	"bytes"
-	"context"
-	"crypto/tls"
-	"encoding/pem"
+	"fmt"
 	"io"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
 
-	orgv1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
-	"github.com/eclipse/che-operator/pkg/deploy"
-	"github.com/eclipse/che-operator/pkg/util"
-	routev1 "github.com/openshift/api/route/v1"
+	"github.com/prometheus/common/log"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/http/httpproxy"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
@@ -42,7 +34,7 @@ type k8s struct {
 }
 
 func GetK8Client() *k8s {
-	tests := util.IsTestMode()
+	tests := IsTestMode()
 	if !tests {
 		cfg, err := config.GetConfig()
 		if err != nil {
@@ -286,107 +278,48 @@ func (cl *k8s) GetDeploymentPod(name string, ns string) (podName string, err err
 	return podName, nil
 }
 
-// GetEndpointTlsCrt creates a test TLS route and gets it to extract certificate chain
-// There's an easier way which is to read tls secret in default (3.11) or openshift-ingress (4.0) namespace
-// which however requires extra privileges for operator service account
-func (r *ReconcileChe) GetEndpointTlsCrt(instance *orgv1.CheCluster, endpointUrl string) (certificate []byte, err error) {
-	testRoute := &routev1.Route{}
-	var requestURL string
-	if len(endpointUrl) < 1 {
-		testRoute = deploy.NewTlsRoute(instance, "test", "test", 8080)
-		logrus.Infof("Creating a test route %s to extract router crt", testRoute.Name)
-		if err := r.CreateNewRoute(instance, testRoute); err != nil {
-			logrus.Errorf("Failed to create test route %s: %s", testRoute.Name, err)
-			return nil, err
-		}
-		// sometimes timing conditions apply, and host isn't available right away
-		if len(testRoute.Spec.Host) < 1 {
-			time.Sleep(time.Duration(1) * time.Second)
-			testRoute = r.GetEffectiveRoute(instance, "test")
-		}
-		requestURL = "https://" + testRoute.Spec.Host
-
-	} else {
-		requestURL = endpointUrl
-	}
-
-	//adding the proxy settings to the Transport object
-	transport := &http.Transport{}
-
-	if instance.Spec.Server.ProxyURL != "" {
-		logrus.Infof("Configuring proxy with %s to extract crt from the following URL: %s", instance.Spec.Server.ProxyURL, requestURL)
-		r.configureProxy(instance, transport)
-	}
-
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	client := &http.Client{
-		Transport: transport,
-	}
-	req, err := http.NewRequest("GET", requestURL, nil)
-	resp, err := client.Do(req)
+// Reads 'user' and 'password' from the given secret
+func (cl *k8s) ReadSecret(name string, ns string) (user string, password string, err error) {
+	secret, err := cl.clientset.CoreV1().Secrets(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
-		logrus.Errorf("An error occurred when reaching test TLS route: %s", err)
-		if r.tests {
-			fakeCrt := make([]byte, 5)
-			return fakeCrt, nil
-		}
-		return nil, err
+		return "", "", err
 	}
-
-	for i := range resp.TLS.PeerCertificates {
-		cert := resp.TLS.PeerCertificates[i].Raw
-		crt := pem.EncodeToMemory(&pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: cert,
-		})
-		certificate = append(certificate, crt...)
-	}
-
-	if len(endpointUrl) < 1 {
-		logrus.Infof("Deleting a test route %s to extract routes crt", testRoute.Name)
-		if err := r.client.Delete(context.TODO(), testRoute); err != nil {
-			logrus.Errorf("Failed to delete test route %s: %s", testRoute.Name, err)
-		}
-	}
-	return certificate, nil
+	return string(secret.Data["user"]), string(secret.Data["password"]), nil
 }
 
-func (r *ReconcileChe) configureProxy(instance *orgv1.CheCluster, transport *http.Transport) () {
-	proxyParts := strings.Split(instance.Spec.Server.ProxyURL, "://")
-	proxyProtocol := ""
-	proxyHost := ""
-	if len(proxyParts) == 1 {
-		proxyProtocol = ""
-		proxyHost = proxyParts[0]
-	} else {
-		proxyProtocol = proxyParts[0]
-		proxyHost = proxyParts[1]
+func (cl *k8s) RunExec(command []string, podName, namespace string) (string, string, error) {
 
+	req := cl.clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec")
+
+	req.VersionedParams(&corev1.PodExecOptions{
+		Command: command,
+		Stdin:   false,
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     false,
+	}, scheme.ParameterCodec)
+
+	cfg, _ := config.GetConfig()
+	exec, err := remotecommand.NewSPDYExecutor(cfg, "POST", req.URL())
+	if err != nil {
+		return "", "", fmt.Errorf("error while creating executor: %v", err)
 	}
 
-	proxyURL := proxyHost
-	if instance.Spec.Server.ProxyPort != "" {
-		proxyURL = proxyURL + ":" + instance.Spec.Server.ProxyPort
-	}
-	if len(instance.Spec.Server.ProxyUser) > 1 && len(instance.Spec.Server.ProxyPassword) > 1 {
-		proxyURL = instance.Spec.Server.ProxyUser + ":" + instance.Spec.Server.ProxyPassword + "@" + proxyURL
+	var stdout, stderr bytes.Buffer
+	var stdin io.Reader
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  stdin,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return stdout.String(), stderr.String(), err
 	}
 
-	if proxyProtocol != "" {
-		proxyURL = proxyProtocol + "://" + proxyURL
-	}
-	config := httpproxy.Config{
-		HTTPProxy:  proxyURL,
-		HTTPSProxy: proxyURL,
-		NoProxy:    strings.Replace(instance.Spec.Server.NonProxyHosts, "|", ",", -1),
-	}
-	proxyFunc := config.ProxyFunc()
-	transport.Proxy = func(r *http.Request) (*url.URL, error) {
-		theProxyUrl, err := proxyFunc(r.URL)
-		if err != nil {
-			logrus.Warnf("Error when trying to get the proxy to access TLS endpoint URL: %s - %s", r.URL, err)
-		}
-		logrus.Infof("Using proxy: %s to access TLS endpoint URL: %s", theProxyUrl, r.URL)
-		return theProxyUrl, err
-	}
+	return stdout.String(), stderr.String(), nil
 }

--- a/pkg/util/k8s_helpers_test.go
+++ b/pkg/util/k8s_helpers_test.go
@@ -9,7 +9,7 @@
 // Contributors:
 //   Red Hat, Inc. - initial API and implementation
 //
-package che
+package util
 
 import (
 	"github.com/sirupsen/logrus"

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -31,7 +31,7 @@ const (
 
 func TestGenerateProxyEnvs(t *testing.T) {
 
-	proxyUrl, noProxy := GenerateProxyEnvs(proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword)
+	proxyUrl, noProxy, _ := GenerateProxyEnvs(proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword, "", "")
 
 	if !reflect.DeepEqual(proxyUrl, expectedProxyURLWithUsernamePassword) {
 		t.Errorf("Test failed. Expected %s but got %s", expectedProxyURLWithUsernamePassword, proxyUrl)
@@ -42,7 +42,7 @@ func TestGenerateProxyEnvs(t *testing.T) {
 
 	}
 
-	proxyUrl, _ = GenerateProxyEnvs(proxyHost, proxyPort, nonProxyHosts, "", proxyPassword)
+	proxyUrl, _, _ = GenerateProxyEnvs(proxyHost, proxyPort, nonProxyHosts, "", proxyPassword, "", "")
 	if !reflect.DeepEqual(proxyUrl, expectedProxyURLWithoutUsernamePassword) {
 		t.Errorf("Test failed. Expected %s but got %s", expectedProxyURLWithoutUsernamePassword, proxyUrl)
 	}
@@ -54,7 +54,7 @@ func TestGenerateProxyJavaOpts(t *testing.T) {
 		logrus.Errorf("Failed to set env %s", err)
 	}
 
-	javaOpts := GenerateProxyJavaOpts(proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword)
+	javaOpts, _ := GenerateProxyJavaOpts(proxyHost, proxyPort, nonProxyHosts, proxyUser, proxyPassword, "", "")
 	expectedJavaOpts := " -Dhttp.proxyHost=myproxy.com -Dhttp.proxyPort=1234 -Dhttps.proxyHost=myproxy.com " +
 		"-Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts='localhost|myhost.com' -Dhttp.proxyUser=user " +
 		"-Dhttp.proxyPassword=password -Dhttps.proxyUser=user -Dhttps.proxyPassword=password"
@@ -63,7 +63,7 @@ func TestGenerateProxyJavaOpts(t *testing.T) {
 
 	}
 
-	javaOpts = GenerateProxyJavaOpts(proxyHost, proxyPort, nonProxyHosts, "", proxyPassword)
+	javaOpts, _ = GenerateProxyJavaOpts(proxyHost, proxyPort, nonProxyHosts, "", proxyPassword, "", "")
 	expectedJavaOptsWithoutUsernamePassword := " -Dhttp.proxyHost=myproxy.com -Dhttp.proxyPort=1234 -Dhttps.proxyHost=myproxy.com " +
 		"-Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts='localhost|myhost.com'"
 


### PR DESCRIPTION
### What does this PR do
PR allows to use secret to store user's credentials. 
New fields are introduced:
```
spec.database.chePostgresSecret
spec.auth.identityProviderPostgresSecret
spec.auth.identityProviderSecret
```
There are several scenarios:
1. If user set credentials in a CR then the behavior won't be changed. 
2. To use secret with custom user/password user should create it first and then set the secret name in a corresponding field of the CR. `operator` will mount corresponding env variables using the given secret.

```bash
kubectl create secret generic <SECRET> --from-literal=username=<USERNAME> --from-literal=password=<PASSWORD> -n <CHE_NAMESPACE>
```

3. If use won't set neither credentials no secrets in the CR then operator will create secret by himself with default usernames and auto-generated passwords.

### Reference issue
https://github.com/eclipse/che/issues/16243

