### PR TITLE
Add method to determine if operation under k8s resource is permitted

### DIFF
--- a/pkg/util/k8s_helpers.go
+++ b/pkg/util/k8s_helpers.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
 type k8s struct {
@@ -322,4 +323,19 @@ func (cl *k8s) RunExec(command []string, podName, namespace string) (string, str
 	}
 
 	return stdout.String(), stderr.String(), nil
+}
+
+func (cl *k8s) IsResourceOperationPermitted(resourceAttr *authorizationv1.ResourceAttributes) (ok bool, err error) {
+	lsar := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: resourceAttr,
+		}, 
+	}
+	
+	ssar, err := cl.clientset.AuthorizationV1().SelfSubjectAccessReviews().Create(lsar)
+	if err != nil {
+		return false, err
+	}
+
+	return ssar.Status.Allowed, nil
 }


### PR DESCRIPTION
Can be useful for:
https://github.com/eclipse/che-operator/pull/166

Add method to determine if operation under k8s resource is permitted 

Example how we can used it:
```
func checkGetOpenshiftUsersPermission(cr *orgv1.CheCluster) error {
	getUsersResAttr := &authorizationv1.ResourceAttributes{
			Namespace: cr.Namespace,
			Verb: "get",
			Group: "user.openshift.io",
			Resource: "user",
	}
	ok, err := k8sclient.IsResourceOperationPermitted(getUsersResAttr);
	if  err != nil {
		return fmt.Errorf("fail to check permissions to get Openshift cluster users.")
	}

	if !ok {
		return fmt.Errorf("not enougth permissions to get Openshift cluster users.")
	}

	return nil
}
```
Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>