### PR TITLE
CRW-579 don't include dupe entries; if not...

### DIFF
--- a/olm/addDigests.sh
+++ b/olm/addDigests.sh
@@ -57,6 +57,7 @@ ${SCRIPTS_DIR}/buildDigestMap.sh -w ${BASE_DIR} -c ${CSV_FILE} -v ${VERSION} ${Q
 names=" "
 count=1
 RELATED_IMAGES='. * { spec : { relatedImages: [ '
+if [[ ! "${QUIET}" ]]; then cat ${BASE_DIR}/generated/digests-mapping.txt; fi
 for mapping in $(cat ${BASE_DIR}/generated/digests-mapping.txt)
 do
   source=$(echo "${mapping}" | sed -e 's/\(.*\)=.*/\1/')
@@ -64,15 +65,13 @@ do
   sed -i -e "s;${source};${dest};" ${CSV_FILE}
   name=$(echo "${dest}" | sed -e 's;.*/\([^\/][^\/]*\)@.*;\1;')
   nameWithSpaces=" ${name} "
-  if [[ "${names}" == *${nameWithSpaces}* ]]; then
-    name="${name}-${count}"
-    count=$(($count+1))
+  if [[ "${names}" != *${nameWithSpaces}* ]]; then
+    if [ "${names}" != " " ]; then
+      RELATED_IMAGES="${RELATED_IMAGES},"
+    fi
+    RELATED_IMAGES="${RELATED_IMAGES} { name: \"${name}\", image: \"${dest}\", tag: \"${source}\"}"
+    names="${names} ${name} "
   fi
-  if [ "${names}" != " " ]; then
-    RELATED_IMAGES="${RELATED_IMAGES},"
-  fi
-  RELATED_IMAGES="${RELATED_IMAGES} { name: \"${name}\", image: \"${dest}\", tag: \"${source}\"}"
-  names="${names} ${name} "
 done
 RELATED_IMAGES="${RELATED_IMAGES} ] } }"
 mv ${CSV_FILE} ${CSV_FILE}.old

--- a/olm/buildDigestMap.sh
+++ b/olm/buildDigestMap.sh
@@ -72,7 +72,7 @@ for image in ${OPERATOR_IMAGE} ${IMAGE_LIST} ${REGISTRY_IMAGES_ALL}; do
     *@)
       continue;;
     *)
-      digest="$(skopeo inspect docker://${image} 2>/dev/null | jq -r '.Digest')"
+      digest="$(skopeo inspect --tls-verify=false docker://${image} 2>/dev/null | jq -r '.Digest')"
       if [[ ${digest} ]]; then
         if [[ ! "${QUIET}" ]]; then echo -n "[INFO] Got digest"; fi
         echo "    $digest # ${image}"


### PR DESCRIPTION
CRW-579 don't include dupe entries; if not quiet, echo contents of digests-mapping.txt; add --tls-verify=false when doing skopeo inspect

Change-Id: I4599c0929e13db76b19750066cd6aedc3ea8eb3b
Signed-off-by: nickboldt <nboldt@redhat.com>