### PR TITLE
Take `WorkspaceNamespaceDefault` into account even when OpenShift OAuth is enabled

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -88,18 +88,21 @@ func GetConfigMapData(cr *orgv1.CheCluster) (cheEnv map[string]string) {
 	if isOpenShift {
 		infra = "openshift"
 	}
-	defaultTargetNamespace := util.GetValue(cr.Spec.Server.WorkspaceNamespaceDefault, cr.Namespace)
-	namespaceAllowUserDefined := strconv.FormatBool(cr.Spec.Server.AllowUserDefinedWorkspaceNamespaces)
 	tls := "false"
 	openShiftIdentityProviderId := "NULL"
 	openshiftOAuth := cr.Spec.Auth.OpenShiftoAuth
+	defaultTargetNamespaceDefault := cr.Namespace  // By default Che SA has right in the namespace where Che in installed ...
 	if openshiftOAuth && isOpenShift {
-		defaultTargetNamespace = "<username>-" + cheFlavor
+		// ... But if the workspace is created under the openshift identity of the end-user,
+		// Then we'll have rights to create any new namespace 
+		defaultTargetNamespaceDefault = "<username>-" + cheFlavor
 		openShiftIdentityProviderId = "openshift-v3"
 		if isOpenshift4 {
 			openShiftIdentityProviderId = "openshift-v4"
 		}
 	}
+	defaultTargetNamespace := util.GetValue(cr.Spec.Server.WorkspaceNamespaceDefault, defaultTargetNamespaceDefault)
+	namespaceAllowUserDefined := strconv.FormatBool(cr.Spec.Server.AllowUserDefinedWorkspaceNamespaces)
 	tlsSupport := cr.Spec.Server.TlsSupport
 	protocol := "http"
 	wsprotocol := "ws"


### PR DESCRIPTION
This fixes issue https://github.com/eclipse/che/issues/16574 that also affects CRW 2.1 (which is why this PR is done against the `7.9.x` branch).

This could be included in `CRW 2.1.0`, if the issue is considered as blocking the release, or kept for a `2.1.1`.

I tested that on the staging-based CRW 2.1 QE cluster on this Che server: https://console-openshift-console.apps.test-ocp43.codereadyqe.com/k8s/ns/david-test/clusterserviceversions/crwoperator.v2.1.0/org.eclipse.che~v1~CheCluster/codeready-workspaces/

Fixed operator docker image: `quay.io/dfestal/che-operator:fix-che-16574` 

In terms of potential respins, this only impacts the `che-operator` and `operator-metadata` and the catalog itself.