### PR TITLE
Add Che CR validator

### DIFF
--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -255,6 +255,14 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 		logrus.Errorf("An error occurred when detecting current infra: %s", err)
 	}
 
+	// Check Che CR correctness
+	if isValid, errorMessage := ValidateCheCR(instance, isOpenShift); !isValid {
+		// Che cannot be deployed with current configuration.
+		// Print error message in logs  and wait until the configuration is changed.
+		logrus.Errorf(errorMessage)
+		return reconcile.Result{}, nil
+	}
+
 	if isOpenShift {
 		// delete oAuthClient before CR is deleted
 		doInstallOpenShiftoAuthProvider := instance.Spec.Auth.OpenShiftoAuth

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -256,10 +256,10 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 	}
 
 	// Check Che CR correctness
-	if isValid, errorMessage := ValidateCheCR(instance, isOpenShift); !isValid {
+	if err := ValidateCheCR(instance, isOpenShift); err != nil {
 		// Che cannot be deployed with current configuration.
-		// Print error message in logs  and wait until the configuration is changed.
-		logrus.Errorf(errorMessage)
+		// Print error message in logs and wait until the configuration is changed.
+		logrus.Error(err)
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/che/che_cr_validator.go
+++ b/pkg/controller/che/che_cr_validator.go
@@ -1,0 +1,56 @@
+//
+// Copyright (c) 2012-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package che
+
+import (
+	"fmt"
+
+	orgv1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
+)
+
+// ValidateCheCR checks Che CR configuration.
+// It should detect:
+// - configurations which miss required field(s) to deploy Che
+// - self-contradictory configurations
+// - configurations with which it is impossible to deploy Che
+func ValidateCheCR(checluster *orgv1.CheCluster, isOpenshift bool) (bool, string) {
+	var isValid bool
+	var errorMessage string
+
+	if !isOpenshift {
+		if checluster.Spec.K8s.IngressDomain == "" {
+			return false, fmt.Sprintf("Required parameter \"Spec.K8s.IngressDomain\" is not set.")
+		}
+	}
+
+	isValid, errorMessage = checkTLSConfiguration(checluster, isOpenshift)
+	if !isValid {
+		return isValid, errorMessage
+	}
+
+	return true, ""
+}
+
+func checkTLSConfiguration(checluster *orgv1.CheCluster, isOpenshift bool) (bool, string) {
+	if !checluster.Spec.Server.TlsSupport {
+		return true, ""
+	}
+
+	if !isOpenshift {
+		// Check TLS secret name is set
+		if checluster.Spec.K8s.TlsSecretName == "" {
+			return false, fmt.Sprintf("TLS is enabled, but required parameter \"Spec.K8s.TlsSecretName\" is not set.")
+		}
+	}
+
+	return true, ""
+}

--- a/pkg/controller/che/che_cr_validator.go
+++ b/pkg/controller/che/che_cr_validator.go
@@ -22,35 +22,12 @@ import (
 // - configurations which miss required field(s) to deploy Che
 // - self-contradictory configurations
 // - configurations with which it is impossible to deploy Che
-func ValidateCheCR(checluster *orgv1.CheCluster, isOpenshift bool) (bool, string) {
-	var isValid bool
-	var errorMessage string
-
+func ValidateCheCR(checluster *orgv1.CheCluster, isOpenshift bool) error {
 	if !isOpenshift {
 		if checluster.Spec.K8s.IngressDomain == "" {
-			return false, fmt.Sprintf("Required parameter \"Spec.K8s.IngressDomain\" is not set.")
+			return fmt.Errorf("Required field \"spec.K8s.IngressDomain\" is not set")
 		}
 	}
 
-	isValid, errorMessage = checkTLSConfiguration(checluster, isOpenshift)
-	if !isValid {
-		return isValid, errorMessage
-	}
-
-	return true, ""
-}
-
-func checkTLSConfiguration(checluster *orgv1.CheCluster, isOpenshift bool) (bool, string) {
-	if !checluster.Spec.Server.TlsSupport {
-		return true, ""
-	}
-
-	if !isOpenshift {
-		// Check TLS secret name is set
-		if checluster.Spec.K8s.TlsSecretName == "" {
-			return false, fmt.Sprintf("TLS is enabled, but required parameter \"Spec.K8s.TlsSecretName\" is not set.")
-		}
-	}
-
-	return true, ""
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What this PR does

This PR adds simple validation of Che CR at the beginning of reconcile loop. If an mistake found in the CR, corresponding message will be printed into Operator logs and it will wait till CR is changed.
For now it checks very basic things, like ingress domain for Kubernetes, but could be easily extended for other cases.

### Which issues this PR references

I ran into issue that Che operator may fall into infinite reconcile loop if some fields of CR are misconfigured. It wasn't fault of reconcile logic as it is just required to have some fields specified.
So this is additional changes in terms of https://github.com/eclipse/che-operator/pull/220