### PR TITLE
More effective usage of heap && Make Che server JAVA_OPTS suitable for Java 8 and Java 11

### DIFF
--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -67,10 +67,7 @@ const (
 	DefaultCheVolumeClaimName           = "che-data-volume"
 	DefaultPostgresVolumeClaimName      = "postgres-data"
 
-	DefaultJavaOpts = "-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 " +
-		"-XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 " +
-		"-XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap " +
-		"-Dsun.zip.disableMemoryMapping=true -Xms20m"
+	DefaultJavaOpts = "-XX:MaxRAMPercentage=85.0"
 	DefaultWorkspaceJavaOpts = "-XX:MaxRAM=150m -XX:MaxRAMFraction=2 -XX:+UseParallelGC " +
 		"-XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 " +
 		"-Dsun.zip.disableMemoryMapping=true " +


### PR DESCRIPTION
More effective usage of heap && Make Che server JAVA_OPTS suitable for Java 8 and Java 11

For 1 GB container 842.94M  instead of 455.50M
```
docker run -m 1GB openjdk:8u242-jre-slim java \
          -XX:MaxRAMPercentage=85.0 \
          -XshowSettings:vm \
          -version
VM settings:
    Max. Heap Size (Estimated): 842.94M
    Ergonomics Machine Class: server
    Using VM: OpenJDK 64-Bit Server VM

openjdk version "1.8.0_242"
OpenJDK Runtime Environment (build 1.8.0_242-b08)
OpenJDK 64-Bit Server VM (build 25.242-b08, mixed mode)
```
```
docker run -m 1GB openjdk:8u242-jre-slim java \
         -XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m \
          -XshowSettings:vm \
          -version
VM settings:
    Min. Heap Size: 20.00M
    Max. Heap Size (Estimated): 455.50M
    Ergonomics Machine Class: server
    Using VM: OpenJDK 64-Bit Server VM

openjdk version "1.8.0_242"
OpenJDK Runtime Environment (build 1.8.0_242-b08)
OpenJDK 64-Bit Server VM (build 25.242-b08, mixed mode)
```
Related to https://github.com/eclipse/che/issues/16665