### PR TITLE
Remove leftovers after refactoring that might prevent che deployed

### DIFF
--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -782,10 +782,6 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 			}
 		}
 		guessedDevfileRegistryURL := protocol + "://" + host
-
-		if err != nil {
-			return reconcile.Result{}, err
-		}
 		if devfileRegistryURL == "" {
 			devfileRegistryURL = guessedDevfileRegistryURL
 		}
@@ -942,9 +938,6 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 		}
 
 		guessedPluginRegistryURL := protocol + "://" + host
-		if err != nil {
-			return reconcile.Result{}, err
-		}
 		guessedPluginRegistryURL += "/v3"
 		if pluginRegistryURL == "" {
 			pluginRegistryURL = guessedPluginRegistryURL


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

After refactoring done in this PR [1] I found some leftovers that might prevent che deployed.

[1] https://github.com/eclipse/che-operator/pull/212

Already fixed in master.