### PR TITLE
fix doc in org_v1_che_cr.yaml: version of...

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -73,7 +73,7 @@ spec:
     chePostgresPassword: ''
     # Postgres database name that Che server uses to connect to. Defaults to dbche
     chePostgresDb: ''
-    # Postgres deployment in format image:tag. Defaults to registry.redhat.io/rhscl/postgresql-96-rhel7 (see operator metadata CSV yaml environment variable IMAGE_default_postgres for tag or digest used)
+    # Postgres deployment in format image:tag. Default in https://github.com/eclipse/che-operator/blob/master/deploy/operator.yaml#L57-L58 or operator metadata CSV environment variable IMAGE_default_postgres)
     postgresImage: ''
   storage:
     # persistent volume claim strategy for Che server. Can be common (all workspaces PVCs in one volume),

--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -73,7 +73,7 @@ spec:
     chePostgresPassword: ''
     # Postgres database name that Che server uses to connect to. Defaults to dbche
     chePostgresDb: ''
-    # Postgres deployment in format image:tag. Defaults to registry.redhat.io/rhscl/postgresql-96-rhel7 (see pkg/deploy/defaults.go for latest tag)
+    # Postgres deployment in format image:tag. Defaults to registry.redhat.io/rhscl/postgresql-96-rhel7 (see operator metadata CSV yaml environment variable IMAGE_default_postgres for tag or digest used)
     postgresImage: ''
   storage:
     # persistent volume claim strategy for Che server. Can be common (all workspaces PVCs in one volume),


### PR DESCRIPTION
fix doc in org_v1_che_cr.yaml: version of registry.redhat.io/rhscl/postgresql-96-rhel7 used is NOT in pkg/deploy/defaults.go, but in the operator metadata CSV now

Change-Id: I8c0630b86fe78d5e7f3869b82a0633bb3b9d2174
Signed-off-by: nickboldt <nboldt@redhat.com>