### PR TITLE
Update OLM installation version

### DIFF
--- a/olm/olm.sh
+++ b/olm/olm.sh
@@ -112,7 +112,6 @@ EOF
   else
     curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.14.1/install.sh | bash -s 0.14.1
     kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-marketplace/master/deploy/upstream/01_namespace.yaml
-    kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-marketplace/master/deploy/upstream/02_catalogsourceconfig.crd.yaml
     kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-marketplace/master/deploy/upstream/03_operatorsource.crd.yaml
     kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-marketplace/master/deploy/upstream/04_service_account.yaml
     kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-marketplace/master/deploy/upstream/05_role.yaml

--- a/olm/olm.sh
+++ b/olm/olm.sh
@@ -110,7 +110,7 @@ EOF
     marketplaceNamespace="openshift-marketplace";
     applyCheOperatorSource
   else
-    curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.12.0/install.sh | bash -s 0.12.0
+    curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/0.14.1/install.sh | bash -s 0.14.1
     kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-marketplace/master/deploy/upstream/01_namespace.yaml
     kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-marketplace/master/deploy/upstream/02_catalogsourceconfig.crd.yaml
     kubectl apply -f https://raw.githubusercontent.com/operator-framework/operator-marketplace/master/deploy/upstream/03_operatorsource.crd.yaml


### PR DESCRIPTION
Update 0.12.0 olm version to 0.14.1. Testing che-operator updates seems is more stable in 0.14.1 than 0.12.0.

Also OLM catalogsource CRD is deprecated: https://raw.githubusercontent.com/operator-framework/operator-marketplace/master/deploy/upstream/02_catalogsourceconfig.crd.yaml

Related issue:https://github.com/eclipse/che/issues/16738
Signed-off-by: flacatus <flacatus@redhat.com>