### PR TITLE
Add s390x support with docker buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,21 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-
-    - name: Build the Docker image
-      run: docker build .
+      - name: Checkout code
+        uses: actions/checkout@v2
+        
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        
+      - name: Build and Push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/s390x
+          push: false


### PR DESCRIPTION
Signed-off-by: Shahid Shaikh <shahid@us.ibm.com>

### What does this PR do?
Add `docker buildx` support to GitHub actions. Currently adding support for amd64 and s390x image build which can be expanded later to other architectures and multi-arch images can be pushed to `quay.io` registry.

### What issues does this PR fix or reference?
This PR is part of [this](https://github.com/eclipse/che/issues/16655) initiative.