### PR TITLE
Propagate custom CA certificate into Keycloak trust store

### DIFF
--- a/pkg/deploy/deployment.go
+++ b/pkg/deploy/deployment.go
@@ -33,6 +33,7 @@ var deploymentDiffOpts = cmp.Options{
 	cmpopts.IgnoreFields(appsv1.DeploymentStrategy{}, "RollingUpdate"),
 	cmpopts.IgnoreFields(corev1.Container{}, "TerminationMessagePath", "TerminationMessagePolicy"),
 	cmpopts.IgnoreFields(corev1.PodSpec{}, "DNSPolicy", "SchedulerName", "SecurityContext"),
+	cmpopts.IgnoreFields(corev1.ConfigMapVolumeSource{}, "DefaultMode"),
 	cmpopts.IgnoreFields(corev1.VolumeSource{}, "EmptyDir"),
 	cmp.Comparer(func(x, y resource.Quantity) bool {
 		return x.Cmp(y) == 0

--- a/templates/keycloak_provision
+++ b/templates/keycloak_provision
@@ -2,6 +2,7 @@ $script config credentials --server http://0.0.0.0:8080/auth \
                                         --realm master \
                                         --user $keycloakAdminUserName \
                                         --password $keycloakAdminPassword \
+&& $script config truststore --trustpass ${SSO_TRUSTSTORE_PASSWORD} ${SSO_TRUSTSTORE_DIR}/${SSO_TRUSTSTORE} \
 && $script get realms/$keycloakRealm; \
 if [ $? -eq 0 ]; then echo "Realm exists"; exit 0; fi \
 && $script create realms  -s realm='$keycloakRealm' \

--- a/templates/oauth_provision
+++ b/templates/oauth_provision
@@ -1,5 +1,6 @@
 connect_to_keycloak() {
   {{ .Script }} config credentials --server http://0.0.0.0:8080/auth --realm master --user {{ .KeycloakAdminUserName }} --password {{ .KeycloakAdminPassword }}
+  {{ .Script }} config truststore --trustpass ${SSO_TRUSTSTORE_PASSWORD} ${SSO_TRUSTSTORE_DIR}/${SSO_TRUSTSTORE}
 }
 
 create_identity_provider() {


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What this PR does
We have `serverTrustStoreConfigMapName` parameter in Che CR, which hold name of config map with custom CA certificates. They are added into Che server trust store only, but to fully support trusting to custom CA certificates we need to propagate them into Keycloak and user workspaces.
This PR adds functionality which propagates custom CA certificates into Keycloak trust store.

### Reference issue
https://issues.redhat.com/browse/CRW-336

### How to test
1. Create a configmap which has CA certificates only.
This could be done via `kubectl apply -f <yaml>` where the config map definition could be like:
```yaml
--- 
apiVersion: v1
kind: ConfigMap
metadata: 
  name: ca-certs
data: 
  demoCA.crt: |
    -----BEGIN CERTIFICATE-----
    MIIE9DCCAtygAwIBAgIULvsF/i5fe7k9lmHB5vVcYVzUu6IwDQYJKoZIhvcNAQEL
    ...
    yIxypcdoasYNfQA8pv4jaOaOo6ED61Wi
    -----END CERTIFICATE-----
  testCA.crt: |
    -----BEGIN CERTIFICATE-----
    MIIE9DCCAtygAwIBAgIUclWFCOb945tF50cWQOOIhrKHgOYwDQYJKoZIhvcNAQEL
   ...
    hl7GDIY6ql9YpHFsyUuNG4mNqq8NLt1X
    -----END CERTIFICATE-----
```
2. Modify Che custom resource by adding `serverTrustStoreConfigMapName` under `spec.server`. Or this could be done by providing `--che-operator-cr-patch-yaml` option to chectl. Pathc file content:
```yaml
spec:
  server:
    serverTrustStoreConfigMapName: "ca-certs"
```
3. Exec into Keycloak container and query trust store for certificates.
