### PR TITLE
Add scripts to create a job in CENTOS CI to test operator updates

### DIFF
--- a/.ci/cico_updates_minikube.sh
+++ b/.ci/cico_updates_minikube.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+set -ex
+
+#Stop execution on any error
+trap "catchFinish" EXIT SIGINT
+
+# Catch_Finish is executed after finish script.
+catchFinish() {
+  result=$?
+  if [ "$result" != "0" ]; then
+    printInfo "Failed on running tests. Please check logs or contact QE team (e-mail:codereadyqe-workspaces-qe@redhat.com, Slack: #che-qe-internal, Eclipse mattermost: 'Eclipse Che QE'"
+    printInfo "Logs should be availabe on http://artifacts.ci.centos.org/devtools/che/che-eclipse-minikube-updates/${ghprbPullId}/"
+    exit 1
+    getCheClusterLogs
+    archiveArtifacts "minikube-updates"
+  fi
+  minikube delete && yes | kubeadm reset
+  rm -rf ~/.kube ~/.minikube
+  exit $result
+}
+
+init() {
+  SCRIPT=$(readlink -f "$0")
+  SCRIPT_DIR=$(dirname "$SCRIPT")
+
+  if [[ ${WORKSPACE} ]] && [[ -d ${WORKSPACE} ]]; then
+    OPERATOR_REPO=${WORKSPACE};
+  else
+    OPERATOR_REPO=$(dirname "$SCRIPT_DIR");
+  fi
+
+  RAM_MEMORY=8192
+  PLATFORM="kubernetes"
+  NAMESPACE="che"
+  CHANNEL="stable"
+}
+
+installDependencies() {
+  installYQ
+  installJQ
+  install_VirtPackages
+  installStartDocker
+  source ${OPERATOR_REPO}/.ci/start-minikube.sh
+}
+
+testUpdates() {
+  "${OPERATOR_REPO}"/olm/testUpdate.sh ${PLATFORM} ${CHANNEL} ${NAMESPACE}
+  printInfo "Successfully verified updates on kubernetes platform."
+  installChectl
+  getCheAcessToken
+  chectl workspace:create --start --devfile=$OPERATOR_REPO/.ci/util/devfile-test.yaml
+  chectl workspace:list
+}
+
+init
+source "${OPERATOR_REPO}"/.ci/util/ci_common.sh
+installDependencies
+testUpdates
+
+getCheClusterLogs() {
+  mkdir -p /root/payload/report/che-logs
+  cd /root/payload/report/che-logs
+  for POD in $(kubectl get pods -o name -n ${NAMESPACE}); do
+    for CONTAINER in $(kubectl get -n ${NAMESPACE} ${POD} -o jsonpath="{.spec.containers[*].name}"); do
+      echo ""
+      printInfo "Getting logs from $POD"
+      echo ""
+      kubectl logs ${POD} -c ${CONTAINER} -n ${NAMESPACE} |tee $(echo ${POD}-${CONTAINER}.log | sed 's|pod/||g')
+    done
+  done
+  printInfo "kubectl get events"
+  kubectl get events -n ${NAMESPACE}| tee get_events.log
+  printInfo "kubectl get all"
+  kubectl get all | tee get_all.log
+}
+
+## $1 = name of subdirectory into which the artifacts will be archived. Commonly it's job name.
+archiveArtifacts() {
+  JOB_NAME=$1
+  DATE=$(date +"%m-%d-%Y-%H-%M")
+  echo "Archiving artifacts from ${DATE} for ${JOB_NAME}/${BUILD_NUMBER}"
+  cd /root/payload
+  ls -la ./artifacts.key
+  chmod 600 ./artifacts.key
+  chown $(whoami) ./artifacts.key
+  mkdir -p ./che/${JOB_NAME}/${BUILD_NUMBER}
+  cp -R ./report ./che/${JOB_NAME}/${BUILD_NUMBER}/ | true
+  rsync --password-file=./artifacts.key -Hva --partial --relative ./che/${JOB_NAME}/${BUILD_NUMBER} devtools@artifacts.ci.centos.org::devtools/
+}

--- a/.ci/cico_updates_minikube.sh
+++ b/.ci/cico_updates_minikube.sh
@@ -23,7 +23,7 @@ catchFinish() {
     printInfo "Logs should be availabe on http://artifacts.ci.centos.org/devtools/che/che-eclipse-minikube-updates/${ghprbPullId}/"
     exit 1
     getCheClusterLogs
-    archiveArtifacts "minikube-updates"
+    archiveArtifacts "che-eclipse-minikube-updates"
   fi
   minikube delete && yes | kubeadm reset
   rm -rf ~/.kube ~/.minikube

--- a/.ci/util/ci_common.sh
+++ b/.ci/util/ci_common.sh
@@ -138,6 +138,18 @@ installJQ() {
   yum install --assumeyes -d1 jq
 }
 
+installChectl() {
+  printInfo "Installing chectl"
+  bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next
+
+}
+
+getCheAcessToken() {
+  KEYCLOAK_HOSTNAME=keycloak-che.$(minikube ip).nip.io
+  TOKEN_ENDPOINT="https://${KEYCLOAK_HOSTNAME}/auth/realms/che/protocol/openid-connect/token"
+  export CHE_ACCESS_TOKEN=$(curl --data "grant_type=password&client_id=che-public&username=admin&password=admin" -k ${TOKEN_ENDPOINT} | jq -r .access_token)
+}
+
 load_jenkins_vars() {
     set +x
     eval "$(./env-toolkit load -f jenkins-env.json \

--- a/.ci/util/ci_common.sh
+++ b/.ci/util/ci_common.sh
@@ -150,6 +150,37 @@ getCheAcessToken() {
   export CHE_ACCESS_TOKEN=$(curl --data "grant_type=password&client_id=che-public&username=admin&password=admin" -k ${TOKEN_ENDPOINT} | jq -r .access_token)
 }
 
+getCheClusterLogs() {
+  mkdir -p /root/payload/report/che-logs
+  cd /root/payload/report/che-logs
+  for POD in $(kubectl get pods -o name -n ${NAMESPACE}); do
+    for CONTAINER in $(kubectl get -n ${NAMESPACE} ${POD} -o jsonpath="{.spec.containers[*].name}"); do
+      echo ""
+      printInfo "Getting logs from $POD"
+      echo ""
+      kubectl logs ${POD} -c ${CONTAINER} -n ${NAMESPACE} |tee $(echo ${POD}-${CONTAINER}.log | sed 's|pod/||g')
+    done
+  done
+  printInfo "kubectl get events"
+  kubectl get events -n ${NAMESPACE}| tee get_events.log
+  printInfo "kubectl get all"
+  kubectl get all | tee get_all.log
+}
+
+## $1 = name of subdirectory into which the artifacts will be archived. Commonly it's job name.
+archiveArtifacts() {
+  JOB_NAME=$1
+  DATE=$(date +"%m-%d-%Y-%H-%M")
+  echo "Archiving artifacts from ${DATE} for ${JOB_NAME}/${BUILD_NUMBER}"
+  cd /root/payload
+  ls -la ./artifacts.key
+  chmod 600 ./artifacts.key
+  chown $(whoami) ./artifacts.key
+  mkdir -p ./che/${JOB_NAME}/${BUILD_NUMBER}
+  cp -R ./report ./che/${JOB_NAME}/${BUILD_NUMBER}/ | true
+  rsync --password-file=./artifacts.key -Hva --partial --relative ./che/${JOB_NAME}/${BUILD_NUMBER} devtools@artifacts.ci.centos.org::devtools/
+}
+
 load_jenkins_vars() {
     set +x
     eval "$(./env-toolkit load -f jenkins-env.json \

--- a/.ci/util/devfile-test.yaml
+++ b/.ci/util/devfile-test.yaml
@@ -1,0 +1,3 @@
+metadata:
+ name: e2e-tests
+apiVersion: 1.0.0

--- a/olm/testCatalogSource.sh
+++ b/olm/testCatalogSource.sh
@@ -10,7 +10,6 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
-
 platform=$1
 if [ "${platform}" == "" ]; then
   echo "Please specify platform ('openshift' or 'kubernetes') as the first argument."

--- a/olm/testUpdate.sh
+++ b/olm/testUpdate.sh
@@ -46,8 +46,31 @@ applyCRCheCluster
 waitCheServerDeploy
 
 echo -e "\u001b[32m Installation of the previous che-operator version: ${previousCSV} succesfully completed \u001b[0m"
-echo -e "\u001b[34m Check installation last version che-operator... \u001b[0m"
 
 installPackage
 
-echo -e "\u001b[32m Installed latest version che-operator: ${lastCSV} \u001b[0m"
+waitCheUpdateInstall() {
+  set +x
+  echo -e "\u001b[34m Check installation last version che-operator...$lastPackageVersion \u001b[0m"
+
+  i=0
+  while [ $i -le 360 ]
+  do
+    cheVersion=$(kubectl get checluster/eclipse-che -n "${namespace}" -o jsonpath={.status.cheVersion})
+    if [ "${cheVersion}" == $lastPackageVersion ]
+    then
+      echo -e "\u001b[32m Installed latest version che-operator: ${lastCSV} \u001b[0m"
+      break
+    fi
+    sleep 3
+    ((i++))
+  done
+
+  if [ $i -gt 360 ]
+  then
+    echo "Che server did't start after 6 minutes"
+    exit 1
+  fi
+}
+
+waitCheUpdateInstall


### PR DESCRIPTION
This PR add scripts to check updates on minikube platform. This script have next tasks:

- Install minikube
- Install eclipse che previous stable version and then update to last stable version
- Create workspace using chectl 

Ref. issue: https://github.com/eclipse/che/issues/15814