### PR TITLE
as of go 1.13 image, PATH already includes...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH=
     GOOS=linux GOARCH=${ARCH} CGO_ENABLED=0 go build -mod=vendor -o /tmp/che-operator/che-operator cmd/manager/main.go
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.1-409
+FROM registry.access.redhat.com/ubi8-minimal:8.2-267
 
 COPY --from=builder /tmp/che-operator/che-operator /usr/local/bin/che-operator
 COPY --from=builder /che-operator/templates/keycloak_provision /tmp/keycloak_provision


### PR DESCRIPTION
as of go 1.13 image, PATH already includes /opt/rh/go-toolset-1.13/root/usr/bin

Change-Id: Ibc30a188ee347adf4c0128b112d956b91e861ec2
Signed-off-by: nickboldt <nboldt@redhat.com>