### PR TITLE
as of go 1.13 image, PATH already includes...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@
 # NOTE: since updateBaseImages.sh does not support other registries than RHCC, update to RHEL8
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/devtools/go-toolset-rhel7
 FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.13.4-18  as builder
-ENV PATH=/opt/rh/go-toolset-1.12/root/usr/bin:$PATH \
-    GOPATH=/go/
+ENV GOPATH=/go/
 
 USER root
 ADD . /che-operator


### PR DESCRIPTION
as of go 1.13 image, PATH already includes /opt/rh/go-toolset-1.13/root/usr/bin

Change-Id: I994d8aa4001e24162a2eb1d8b0a36ce269985f00
Signed-off-by: nickboldt <nboldt@redhat.com>