### PR TITLE
Fix certs paths to import into truststore

### DIFF
--- a/pkg/deploy/deployment_keycloak.go
+++ b/pkg/deploy/deployment_keycloak.go
@@ -113,7 +113,7 @@ func getSpecKeycloakDeployment(checluster *orgv1.CheCluster, clusterDeployment *
 		"keytool -importcert -alias MOUNTEDSERVICECRT" +
 		" -keystore " + jbossDir + "/openshift.jks" +
 		" -file /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt -storepass " + trustpass + " -noprompt; fi"
-	importJavaCacerts := "keytool -importkeystore -srckeystore $JAVA_HOME/jre/lib/security/cacerts" +
+	importJavaCacerts := "keytool -importkeystore -srckeystore /etc/pki/ca-trust/extracted/java/cacerts" +
 		" -destkeystore " + jbossDir + "/openshift.jks" +
 		" -srcstorepass changeit -deststorepass " + trustpass
 


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

### Reference issue
https://github.com/eclipse/che/issues/17058

It is enough to import `/etc/pki/ca-trust/extracted/java/cacerts`
```bash
sh-4.4$ ls -l ./etc/java/java-11-openjdk/java-11-openjdk-11.0.7.10-1.el8_1.x86_64/lib/security/cacerts
lrwxrwxrwx. 1 root root 21 Apr 15 12:51 ./etc/java/java-11-openjdk/java-11-openjdk-11.0.7.10-1.el8_1.x86_64/lib/security/cacerts -> /etc/pki/java/cacerts
sh-4.4$ ls -l ./etc/pki/java/cacerts
lrwxrwxrwx. 1 root root 40 Oct 18  2019 ./etc/pki/java/cacerts -> /etc/pki/ca-trust/extracted/java/cacerts
sh-4.4$ ls -l ./etc/pki/ca-trust/extracted/java/cacerts
-r--r--r--. 1 root root 161905 Mar  2 17:42 ./etc/pki/ca-trust/extracted/java/cacerts
```