### PR TITLE
Some release improvements

### DIFF
--- a/olm/release-olm-files.sh
+++ b/olm/release-olm-files.sh
@@ -11,6 +11,7 @@
 #   Red Hat, Inc. - initial API and implementation
 
 set -e
+set -x
 
 REGEX="^([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
 
@@ -30,8 +31,7 @@ fi
 for platform in 'kubernetes' 'openshift'
 do
   packageName="eclipse-che-preview-${platform}"
-  echo
-  echo "## Creating release '${RELEASE}' of the OperatorHub package '${packageName}' for platform '${platform}'"
+  echo "[INFO] Creating release '${RELEASE}' of the OperatorHub package '${packageName}' for platform '${platform}'"
 
   packageBaseFolderPath="${BASE_DIR}/${packageName}"
   cd "${packageBaseFolderPath}"
@@ -40,16 +40,24 @@ do
   packageFilePath="${packageFolderPath}/${packageName}.package.yaml"
   lastPackageNightlyVersion=$(yq -r '.channels[] | select(.name == "nightly") | .currentCSV' "${packageFilePath}" | sed -e "s/${packageName}.v//")
   lastPackagePreReleaseVersion=$(yq -r '.channels[] | select(.name == "stable") | .currentCSV' "${packageFilePath}" | sed -e "s/${packageName}.v//")
-  echo "   - Last package nightly version: ${lastPackageNightlyVersion}"
-  echo "   - Last package pre-release version: ${lastPackagePreReleaseVersion}"
+  echo "[INFO] Last package nightly version: ${lastPackageNightlyVersion}"
+  echo "[INFO] Last package pre-release version: ${lastPackagePreReleaseVersion}"
+
   if [ "${lastPackagePreReleaseVersion}" == "${RELEASE}" ]
   then
-    echo "Release ${RELEASE} already exists in the package !"
-    echo "You should first remove it"
+    echo "[ERROR] Release ${RELEASE} already exists in the package !"
+    echo "[ERROR] You should first remove it"
     exit 1
   fi
 
-  echo "     => will create release '${RELEASE}' from nightly version '${lastPackageNightlyVersion}' that will replace previous release '${lastPackagePreReleaseVersion}'"
+  echo "[INFO] Will create release '${RELEASE}' from nightly version '${lastPackageNightlyVersion}' that will replace previous release '${lastPackagePreReleaseVersion}'"
+
+  LAST_NIGHTLY_CSV="${packageFolderPath}/${lastPackageNightlyVersion}/${packageName}.v${lastPackageNightlyVersion}.clusterserviceversion.yaml"
+  PRE_RELEASE_CSV="${packageFolderPath}/${lastPackagePreReleaseVersion}/${packageName}.v${lastPackagePreReleaseVersion}.clusterserviceversion.yaml"
+  RELEASE_CSV="${packageFolderPath}/${RELEASE}/${packageName}.v${RELEASE}.clusterserviceversion.yaml"
+  LAST_NIGHTLY_CRD="${packageFolderPath}/${lastPackageNightlyVersion}/${packageName}.crd.yaml"
+  PRE_RELEASE_CRD="${packageFolderPath}/${lastPackagePreReleaseVersion}/${packageName}.crd.yaml"
+  RELEASE_CRD="${packageFolderPath}/${RELEASE}/${packageName}.crd.yaml"
 
   mkdir -p "${packageFolderPath}/${RELEASE}"
   sed \
@@ -64,23 +72,19 @@ do
   -e "s/: nightly/: ${RELEASE}/" \
   -e "s/:nightly/:${RELEASE}/" \
   -e "s/${lastPackageNightlyVersion}/${RELEASE}/" \
-  -e "s/createdAt:.*$/createdAt: \"$(date -u +%FT%TZ)\"/" \
-  "${packageFolderPath}/${lastPackageNightlyVersion}/${packageName}.v${lastPackageNightlyVersion}.clusterserviceversion.yaml" \
-  > "${packageFolderPath}/${RELEASE}/${packageName}.v${RELEASE}.clusterserviceversion.yaml"
+  -e "s/createdAt:.*$/createdAt: \"$(date -u +%FT%TZ)\"/" ${LAST_NIGHTLY_CSV} > ${RELEASE_CSV}
 
-  echo "   - Copying the CRD file"
-  cp "${packageFolderPath}/${lastPackageNightlyVersion}/${packageName}.crd.yaml" \
-  "${packageFolderPath}/${RELEASE}/${packageName}.crd.yaml"
-  echo "   - Updating the 'stable' channel with new release in the package descriptor: ${packageFilePath}"
+  cp ${LAST_NIGHTLY_CRD} ${RELEASE_CRD}
+  if [[ $platform == "openshift" ]]; then
+    yq -riSY  '.spec.preserveUnknownFields = false' ${RELEASE_CRD}
+    yq -riSY  '.spec.validation.openAPIV3Schema.type = "object"' ${RELEASE_CRD}
+    eval head -10 ${LAST_NIGHTLY_CRD} | cat - ${RELEASE_CRD} > tmp && mv tmp ${RELEASE_CRD}
+  fi
+
   sed -e "s/${lastPackagePreReleaseVersion}/${RELEASE}/" "${packageFilePath}" > "${packageFilePath}.new"
   mv "${packageFilePath}.new" "${packageFilePath}"
 
-  diff -u "${packageFolderPath}/${lastPackagePreReleaseVersion}/${packageName}.v${lastPackagePreReleaseVersion}.clusterserviceversion.yaml" \
-  "${packageFolderPath}/${RELEASE}/${packageName}.v${RELEASE}.clusterserviceversion.yaml" \
-  > "${packageFolderPath}/${RELEASE}/${packageName}.v${RELEASE}.clusterserviceversion.yaml.diff" || true
-
-  diff -u "${packageFolderPath}/${lastPackagePreReleaseVersion}/${packageName}.crd.yaml" \
-  "${packageFolderPath}/${RELEASE}/${packageName}.crd.yaml" \
-  > "${packageFolderPath}/${RELEASE}/${packageName}.crd.yaml.diff" || true
+  diff -u ${PRE_RELEASE_CSV} ${RELEASE_CSV} > ${RELEASE_CSV}".diff" || true
+  diff -u ${PRE_RELEASE_CRD} ${RELEASE_CRD} > ${RELEASE_CRD}".diff" || true
 done
 cd "${CURRENT_DIR}"

--- a/olm/update-nightly-olm-files.sh
+++ b/olm/update-nightly-olm-files.sh
@@ -11,6 +11,7 @@
 #   Red Hat, Inc. - initial API and implementation
 
 set -e
+set -x
 
 CURRENT_DIR=$(pwd)
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)
@@ -23,6 +24,7 @@ do
 
   echo "[INFO] Updating OperatorHub package '${packageName}' for platform '${platform}'"
   packageBaseFolderPath=${BASE_DIR}/${packageName}
+
   cd "${packageBaseFolderPath}"
   packageFolderPath="${packageBaseFolderPath}/deploy/olm-catalog/${packageName}"
   packageFilePath="${packageFolderPath}/${packageName}.package.yaml"
@@ -31,12 +33,17 @@ do
   echo "[INFO] Last package version: ${lastPackageVersion}"
   newNightlyPackageVersion="9.9.9-nightly.$(date +%s)"
 
+  PREV_CRD="${packageFolderPath}/${lastPackageVersion}/eclipse-che-preview-${platform}.crd.yaml"
+  PREV_CSV="${packageFolderPath}/${lastPackageVersion}/${packageName}.v${lastPackageVersion}.clusterserviceversion.yaml"
+  NEW_CSV="${packageFolderPath}/${newNightlyPackageVersion}/${packageName}.v${newNightlyPackageVersion}.clusterserviceversion.yaml"
+  NEW_CRD="${packageFolderPath}/${newNightlyPackageVersion}/eclipse-che-preview-${platform}.crd.yaml"
+
   echo "[INFO] will create a new version: ${newNightlyPackageVersion}"
   ./build-roles.sh
 
   echo "[INFO] Updating new package version with roles defined in: ${role}"
   operator-sdk olm-catalog gen-csv --csv-version "${newNightlyPackageVersion}" --from-version="${lastPackageVersion}" 2>&1 | sed -e 's/^/      /'
-  containerImage=$(sed -n 's|^ *image: *\([^ ]*/che-operator:[^ ]*\) *|\1|p' "${packageFolderPath}/${newNightlyPackageVersion}/${packageName}.v${newNightlyPackageVersion}.clusterserviceversion.yaml")
+  containerImage=$(sed -n 's|^ *image: *\([^ ]*/che-operator:[^ ]*\) *|\1|p' ${NEW_CSV})
   createdAt=$(date -u +%FT%TZ)
 
   echo "[INFO] Updating new package version fields:"
@@ -44,31 +51,35 @@ do
   echo "[INFO]        - createdAt => ${createdAt}"
   sed \
   -e "s|containerImage:.*$|containerImage: ${containerImage}|" \
-  -e "s/createdAt:.*$/createdAt: \"${createdAt}\"/" \
-  "${packageFolderPath}/${newNightlyPackageVersion}/${packageName}.v${newNightlyPackageVersion}.clusterserviceversion.yaml" \
-  > "${packageFolderPath}/${newNightlyPackageVersion}/${packageName}.v${newNightlyPackageVersion}.clusterserviceversion.yaml.new"
-  mv "${packageFolderPath}/${newNightlyPackageVersion}/${packageName}.v${newNightlyPackageVersion}.clusterserviceversion.yaml.new" \
-  "${packageFolderPath}/${newNightlyPackageVersion}/${packageName}.v${newNightlyPackageVersion}.clusterserviceversion.yaml"
+  -e "s/createdAt:.*$/createdAt: \"${createdAt}\"/" ${NEW_CSV} > ${NEW_CSV}".new"
+  mv ${NEW_CSV}".new" ${NEW_CSV}
 
-  echo "[INFO]    - Copying the CRD file"
-  cp "${BASE_DIR}/../deploy/crds/org_v1_che_crd.yaml" "${packageFolderPath}/${newNightlyPackageVersion}/eclipse-che-preview-${platform}.crd.yaml"
-  diff -u "${packageFolderPath}/${lastPackageVersion}/eclipse-che-preview-${platform}.crd.yaml" \
-  "${packageFolderPath}/${newNightlyPackageVersion}/eclipse-che-preview-${platform}.crd.yaml" \
-  > "${packageFolderPath}/${newNightlyPackageVersion}/eclipse-che-preview-${platform}.crd.yaml.diff" || true
+  echo "[INFO] Copying the CRD file"
+  cp "${BASE_DIR}/../deploy/crds/org_v1_che_crd.yaml" ${NEW_CRD}
 
-  echo "[INFO]    - Updating the 'nightly' channel with new version in the package descriptor: ${packageFilePath}"
+  echo "[INFO] Updating the 'nightly' channel with new version in the package descriptor: ${packageFilePath}"
   sed -e "s/${lastPackageVersion}/${newNightlyPackageVersion}/" "${packageFilePath}" > "${packageFilePath}.new"
   mv "${packageFilePath}.new" "${packageFilePath}"
 
   if [[ ! -z "$TAG" ]]; then
     echo "[INFO] Set tags in nighlty OLM files"
-    csvFile="${packageFolderPath}/${newNightlyPackageVersion}/${packageName}.v${newNightlyPackageVersion}.clusterserviceversion.yaml"
-    sed -i 's/'$RELEASE'/'$TAG'/g' $csvFile
+    sed -i 's/'$RELEASE'/'$TAG'/g' ${NEW_CSV}
   fi
 
-  diff -u "${packageFolderPath}/${lastPackageVersion}/${packageName}.v${lastPackageVersion}.clusterserviceversion.yaml" \
-  "${packageFolderPath}/${newNightlyPackageVersion}/${packageName}.v${newNightlyPackageVersion}.clusterserviceversion.yaml" \
-  > "${packageFolderPath}/${newNightlyPackageVersion}/${packageName}.v${newNightlyPackageVersion}.clusterserviceversion.yaml.diff" || true
+  if [[ $platform == "openshift" ]]; then
+    # Removes che-tls-secret-creator
+    index=0
+    while [[ $index -le 30 ]]
+    do
+      if [[ $(cat ${NEW_CSV} | yq -r '.spec.install.spec.deployments[0].spec.template.spec.containers[0].env['$index'].name') == "IMAGE_default_che_tls_secrets_creation_job" ]]; then
+        yq -rYSi 'del(.spec.install.spec.deployments[0].spec.template.spec.containers[0].env['$index'])' ${NEW_CSV}
+        break
+      fi
+      index=$((index+1))
+    done
+  fi
 
+  diff -u ${PREV_CRD} ${NEW_CRD} > ${NEW_CRD}".diff" || true
+  diff -u ${PREV_CSV} ${NEW_CSV} > ${NEW_CSV}".diff" || true
 done
 cd "${CURRENT_DIR}"

--- a/replace-images-tags.sh
+++ b/replace-images-tags.sh
@@ -88,6 +88,9 @@ replaceImagesTags() {
   yq -ryY "( .spec.template.spec.containers[] | select(.name == \"che-operator\").env[] | select(.name == \"IMAGE_default_che_server_secure_exposer_jwt_proxy_image\") | .value ) = \"${JWT_PROXY_IMAGE_RELEASE}\"" \
   >> "${NEW_OPERATOR_LOCAL_YAML}"
   mv "${NEW_OPERATOR_LOCAL_YAML}" "${OPERATOR_LOCAL_YAML}"
+
+  DOCKERFILE=${BASE_DIR}/Dockerfile
+  sed -i 's|registry.access.redhat.com/ubi8-minimal:.*|'${UBI8_MINIMAL_IMAGE}'|g' $DOCKERFILE
 }
 
 init "$@"


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

### Reference issue
https://github.com/eclipse/che/issues/17048

### What does this pr do
- [x] Remove che-tls-secret-creator from openshift olm CSV files (if it's only needed for k8s)
- [x] Set the latest `registry.access.redhat.com/ubi8-minimal` image in the [Dockerfile](https://github.com/eclipse/che-operator/blob/master/Dockerfile#L29)
- [x] Make sure openshift lm CSV files contains [these changes](https://github.com/redhat-developer/codeready-workspaces-operator/pull/19/files) in every release