### PR TITLE
CRW-979 use strings.TrimPrefix instead of...

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -253,7 +253,7 @@ func GenerateProxyJavaOpts(proxyURL string, proxyPort string, nonProxyHosts stri
 		}
 	}
 
-	proxyHost := strings.TrimLeft(proxyURL, "https://")
+	proxyHost := strings.TrimPrefix(proxyURL, "https://")
 	proxyUserPassword := ""
 	if len(proxyUser) > 1 && len(proxyPassword) > 1 {
 		proxyUserPassword =


### PR DESCRIPTION
CRW-979 use strings.TrimPrefix instead of strings.TrimLeft

Change-Id: I7969e88c84ab211738fe071313ccc0fae4bac25c
Signed-off-by: nickboldt <nboldt@redhat.com>