### PR TITLE
[WIP] Properly update console links

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,6 @@
       "env": {
         "WATCH_NAMESPACE": "che",
         "CHE_FLAVOR": "che",
-        "CONSOLE_LINK_NAME": "che",
         "CONSOLE_LINK_DISPLAY_NAME": "Eclipse Che",
         "CONSOLE_LINK_SECTION": "Red Hat Applications",
         "CONSOLE_LINK_IMAGE": "/dashboard/assets/branding/loader.svg",

--- a/deploy/operator-local.yaml
+++ b/deploy/operator-local.yaml
@@ -67,8 +67,6 @@ spec:
               value: quay.io/eclipse/che-jwtproxy:fd94e60
             - name: CHE_FLAVOR
               value: che
-            - name: CONSOLE_LINK_NAME
-              value: che
             - name: CONSOLE_LINK_DISPLAY_NAME
               value: Eclipse Che
             - name: CONSOLE_LINK_SECTION

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -66,8 +66,6 @@ spec:
               value: quay.io/eclipse/che-jwtproxy:fd94e60
             - name: CHE_FLAVOR
               value: che
-            - name: CONSOLE_LINK_NAME
-              value: che
             - name: CONSOLE_LINK_DISPLAY_NAME
               value: Eclipse Che
             - name: CONSOLE_LINK_SECTION

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -94,7 +94,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		if err := oauthv1.AddToScheme(mgr.GetScheme()); err != nil {
 			logrus.Errorf("Failed to add OpenShift OAuth to scheme: %s", err)
 		}
-		if deploy.HasConsolelinkObject() {
+		if deploy.HasConsoleLinkObject() {
 			if err := consolev1.AddToScheme(mgr.GetScheme()); err != nil {
 				logrus.Errorf("Failed to add OpenShift ConsoleLink to scheme: %s", err)
 			}

--- a/pkg/deploy/consolelink.go
+++ b/pkg/deploy/consolelink.go
@@ -67,7 +67,7 @@ func SyncConsoleLinkToCluster(checluster *orgv1.CheCluster, clusterAPI ClusterAP
 	if len(clusterConsoleLinks) != 1 {
 		for _, clusterConsoleLink := range clusterConsoleLinks {
 			logrus.Infof("Deleting existed object: %s, name %s", clusterConsoleLink.Kind, clusterConsoleLink.Name)
-			if err := clusterAPI.Client.Delete(context.TODO(), &clusterConsoleLink); err != nil {
+			if err := clusterAPI.Client.Delete(context.TODO(), clusterConsoleLink); err != nil {
 				return err
 			}
 		}
@@ -83,7 +83,7 @@ func SyncConsoleLinkToCluster(checluster *orgv1.CheCluster, clusterAPI ClusterAP
 		logrus.Infof("Updating existed object: %s, name: %s", clusterConsoleLinks[0].Kind, clusterConsoleLinks[0].Name)
 		fmt.Printf("Difference:\n%s", diff)
 
-		if err := clusterAPI.Client.Delete(context.TODO(), &clusterConsoleLinks[0]); err != nil {
+		if err := clusterAPI.Client.Delete(context.TODO(), clusterConsoleLinks[0]); err != nil {
 			return err
 		}
 		return clusterAPI.Client.Create(context.TODO(), specConsoleLink)
@@ -95,8 +95,8 @@ func SyncConsoleLinkToCluster(checluster *orgv1.CheCluster, clusterAPI ClusterAP
 /**
  * Returns all console links for the same host name or for the target console link name
  */
-func getClusterConsoleLinks(checluster *orgv1.CheCluster, client runtimeClient.Client) ([]consolev1.ConsoleLink, error) {
-	var clusterConsoleLinks []consolev1.ConsoleLink
+func getClusterConsoleLinks(checluster *orgv1.CheCluster, client runtimeClient.Client) ([]*consolev1.ConsoleLink, error) {
+	var clusterConsoleLinks []*consolev1.ConsoleLink
 	defaultConsoleLinkName := DefaultConsoleLinkName(checluster)
 
 	consoleLinks := &consolev1.ConsoleLinkList{}
@@ -105,9 +105,9 @@ func getClusterConsoleLinks(checluster *orgv1.CheCluster, client runtimeClient.C
 		return nil, err
 	}
 
-	for _, consoleLink := range consoleLinks.Items {
+	for i, consoleLink := range consoleLinks.Items {
 		if strings.Contains(consoleLink.Spec.Link.Href, checluster.Spec.Server.CheHost) || consoleLink.Name == defaultConsoleLinkName {
-			clusterConsoleLinks = append(clusterConsoleLinks, consoleLink)
+			clusterConsoleLinks = append(clusterConsoleLinks, &consoleLinks.Items[i])
 		}
 	}
 

--- a/pkg/deploy/consolelink.go
+++ b/pkg/deploy/consolelink.go
@@ -55,7 +55,7 @@ func SyncConsoleLinkToCluster(checluster *orgv1.CheCluster, clusterAPI ClusterAP
 	if !checluster.ObjectMeta.DeletionTimestamp.IsZero() {
 		for _, clusterConsoleLink := range clusterConsoleLinks {
 			logrus.Infof("Deleting existed object: %s, name %s", clusterConsoleLink.Kind, clusterConsoleLink.Name)
-			if err := clusterAPI.Client.Delete(context.TODO(), clusterConsoleLink); err != nil {
+			if err := clusterAPI.Client.Delete(context.TODO(), &clusterConsoleLink); err != nil {
 				return err
 			}
 		}
@@ -67,7 +67,7 @@ func SyncConsoleLinkToCluster(checluster *orgv1.CheCluster, clusterAPI ClusterAP
 	if len(clusterConsoleLinks) != 1 {
 		for _, clusterConsoleLink := range clusterConsoleLinks {
 			logrus.Infof("Deleting existed object: %s, name %s", clusterConsoleLink.Kind, clusterConsoleLink.Name)
-			if err := clusterAPI.Client.Delete(context.TODO(), clusterConsoleLink); err != nil {
+			if err := clusterAPI.Client.Delete(context.TODO(), &clusterConsoleLink); err != nil {
 				return err
 			}
 		}
@@ -83,7 +83,7 @@ func SyncConsoleLinkToCluster(checluster *orgv1.CheCluster, clusterAPI ClusterAP
 		logrus.Infof("Updating existed object: %s, name: %s", clusterConsoleLinks[0].Kind, clusterConsoleLinks[0].Name)
 		fmt.Printf("Difference:\n%s", diff)
 
-		if err := clusterAPI.Client.Delete(context.TODO(), clusterConsoleLinks[0]); err != nil {
+		if err := clusterAPI.Client.Delete(context.TODO(), &clusterConsoleLinks[0]); err != nil {
 			return err
 		}
 		return clusterAPI.Client.Create(context.TODO(), specConsoleLink)
@@ -95,8 +95,8 @@ func SyncConsoleLinkToCluster(checluster *orgv1.CheCluster, clusterAPI ClusterAP
 /**
  * Returns all console links for the same host name or for the target console link name
  */
-func getClusterConsoleLinks(checluster *orgv1.CheCluster, client runtimeClient.Client) ([]*consolev1.ConsoleLink, error) {
-	var clusterConsoleLinks []*consolev1.ConsoleLink
+func getClusterConsoleLinks(checluster *orgv1.CheCluster, client runtimeClient.Client) ([]consolev1.ConsoleLink, error) {
+	var clusterConsoleLinks []consolev1.ConsoleLink
 	defaultConsoleLinkName := DefaultConsoleLinkName(checluster)
 
 	consoleLinks := &consolev1.ConsoleLinkList{}
@@ -107,7 +107,7 @@ func getClusterConsoleLinks(checluster *orgv1.CheCluster, client runtimeClient.C
 
 	for _, consoleLink := range consoleLinks.Items {
 		if strings.Contains(consoleLink.Spec.Link.Href, checluster.Spec.Server.CheHost) || consoleLink.Name == defaultConsoleLinkName {
-			clusterConsoleLinks = append(clusterConsoleLinks, &consoleLink)
+			clusterConsoleLinks = append(clusterConsoleLinks, consoleLink)
 		}
 	}
 

--- a/pkg/deploy/consolelink.go
+++ b/pkg/deploy/consolelink.go
@@ -1,0 +1,145 @@
+//
+// Copyright (c) 2012-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	orgv1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
+	"github.com/eclipse/che-operator/pkg/util"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	consolev1 "github.com/openshift/api/console/v1"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var consoleLinkDiffOpts = cmp.Options{
+	cmpopts.IgnoreFields(consolev1.ConsoleLink{}, "TypeMeta"),
+	cmp.Comparer(func(x, y metav1.ObjectMeta) bool {
+		return x.Name == y.Name
+	}),
+}
+
+func SyncConsoleLinkToCluster(checluster *orgv1.CheCluster, clusterAPI ClusterAPI) error {
+	if !util.IsOpenShift4 || !HasConsolelinkObject() {
+		logrus.Debug("Console link won't be created. It's not supported by cluster")
+		// console link is supported only on OpenShift >= 4.2
+		return nil
+	}
+
+	if !checluster.Spec.Server.TlsSupport {
+		logrus.Debug("Console link won't be created. It's not supported when http connection is used")
+		// console link is supported only with https
+		return nil
+	}
+
+	specConsoleLink := getSpecConsoleLink(checluster)
+	clusterConsoleLinks, err := getClusterConsoleLinks(checluster, clusterAPI.Client)
+	if err != nil {
+		return err
+	}
+
+	if !checluster.ObjectMeta.DeletionTimestamp.IsZero() {
+		for _, clusterConsoleLink := range clusterConsoleLinks {
+			logrus.Infof("Deleting existed object: %s, name %s", clusterConsoleLink.Kind, clusterConsoleLink.Name)
+			return clusterAPI.Client.Delete(context.TODO(), clusterConsoleLink)
+		}
+		return nil
+	}
+
+	if len(clusterConsoleLinks) != 1 {
+		for _, clusterConsoleLink := range clusterConsoleLinks {
+			logrus.Infof("Deleting existed object: %s, name %s", clusterConsoleLink.Kind, clusterConsoleLink.Name)
+			return clusterAPI.Client.Delete(context.TODO(), clusterConsoleLink)
+		}
+
+		logrus.Infof("Creating a new object: %s, name %s", specConsoleLink.Kind, specConsoleLink.Name)
+		return clusterAPI.Client.Create(context.TODO(), specConsoleLink)
+	}
+
+	diff := cmp.Diff(clusterConsoleLinks[0], specConsoleLink, consoleLinkDiffOpts)
+	if len(diff) > 0 {
+		logrus.Infof("Updating existed object: %s, name: %s", clusterConsoleLinks[0].Kind, clusterConsoleLinks[0].Name)
+		fmt.Printf("Difference:\n%s", diff)
+
+		err := clusterAPI.Client.Delete(context.TODO(), clusterConsoleLinks[0])
+		if err != nil {
+			return err
+		}
+
+		return clusterAPI.Client.Create(context.TODO(), specConsoleLink)
+	}
+
+	return nil
+}
+
+/**
+ * Returns all console links for the same host name.
+ */
+func getClusterConsoleLinks(checluster *orgv1.CheCluster, client runtimeClient.Client) ([]*consolev1.ConsoleLink, error) {
+	var clusterConsoleLinks []*consolev1.ConsoleLink
+
+	consoleLinks := &consolev1.ConsoleLinkList{}
+	listOptions := &runtimeClient.ListOptions{}
+	if err := client.List(context.TODO(), listOptions, consoleLinks); err != nil {
+		return nil, err
+	}
+
+	for _, consoleLink := range consoleLinks.Items {
+		if strings.Contains(consoleLink.Spec.Link.Href, checluster.Spec.Server.CheHost) {
+			clusterConsoleLinks = append(clusterConsoleLinks, &consoleLink)
+		}
+	}
+
+	return clusterConsoleLinks, nil
+}
+
+func getSpecConsoleLink(checluster *orgv1.CheCluster) *consolev1.ConsoleLink {
+	cheHost := checluster.Spec.Server.CheHost
+	return &consolev1.ConsoleLink{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ConsoleLink",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: DefaultConsoleLinkName(),
+		},
+		Spec: consolev1.ConsoleLinkSpec{
+			Link: consolev1.Link{
+				Href: "https://" + cheHost,
+				Text: DefaultConsoleLinkDisplayName()},
+			Location: consolev1.ApplicationMenu,
+			ApplicationMenu: &consolev1.ApplicationMenuSpec{
+				Section:  DefaultConsoleLinkSection(),
+				ImageURL: fmt.Sprintf("https://%s%s", cheHost, DefaultConsoleLinkImage()),
+			},
+		},
+	}
+}
+
+func HasConsolelinkObject() bool {
+	resourceList, err := util.GetServerResources()
+	if err != nil {
+		return false
+	}
+	for _, res := range resourceList {
+		for _, r := range res.APIResources {
+			if r.Name == "consolelinks" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/deploy/consolelink.go
+++ b/pkg/deploy/consolelink.go
@@ -34,7 +34,7 @@ var consoleLinkDiffOpts = cmp.Options{
 }
 
 func SyncConsoleLinkToCluster(checluster *orgv1.CheCluster, clusterAPI ClusterAPI) error {
-	if !util.IsOpenShift4 || !HasConsolelinkObject() {
+	if !util.IsOpenShift4 || !HasConsoleLinkObject() {
 		// console link is supported only on OpenShift >= 4.2
 		logrus.Debug("Console link won't be created. It's not supported by cluster")
 		return nil
@@ -52,15 +52,15 @@ func SyncConsoleLinkToCluster(checluster *orgv1.CheCluster, clusterAPI ClusterAP
 		return err
 	}
 
-	if !checluster.ObjectMeta.DeletionTimestamp.IsZero() {
-		for _, clusterConsoleLink := range clusterConsoleLinks {
-			logrus.Infof("Deleting existed object: %s, name %s", clusterConsoleLink.Kind, clusterConsoleLink.Name)
-			if err := clusterAPI.Client.Delete(context.TODO(), &clusterConsoleLink); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
+	// if !checluster.ObjectMeta.DeletionTimestamp.IsZero() {
+	// 	for _, clusterConsoleLink := range clusterConsoleLinks {
+	// 		logrus.Infof("Deleting existed object: %s, name %s", clusterConsoleLink.Kind, clusterConsoleLink.Name)
+	// 		if err := clusterAPI.Client.Delete(context.TODO(), &clusterConsoleLink); err != nil {
+	// 			return err
+	// 		}
+	// 	}
+	// 	return nil
+	// }
 
 	// Found console links from previous deployments with different names
 	// Let's delete them all and create a proper one
@@ -136,7 +136,7 @@ func getSpecConsoleLink(checluster *orgv1.CheCluster) *consolev1.ConsoleLink {
 	}
 }
 
-func HasConsolelinkObject() bool {
+func HasConsoleLinkObject() bool {
 	resourceList, err := util.GetServerResources()
 	if err != nil {
 		return false

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -181,8 +181,8 @@ func DefaultCheFlavor(cr *orgv1.CheCluster) string {
 	return util.GetValue(cr.Spec.Server.CheFlavor, getDefaultFromEnv("CHE_FLAVOR"))
 }
 
-func DefaultConsoleLinkName() string {
-	return getDefaultFromEnv("CONSOLE_LINK_NAME")
+func DefaultConsoleLinkName(checluster *orgv1.CheCluster) string {
+	return DefaultCheFlavor(checluster) + "-" + checluster.Namespace
 }
 
 func DefaultConsoleLinkDisplayName() string {


### PR DESCRIPTION
### What does this PR do
- removes ability to change console link name
- set console link name to `<che_flavor>-<namespace>`

As a result every deployment will have its own console link. User can update display name to distinguish one deployment from another.

### Reference issue
https://github.com/eclipse/che/issues/17185

### TODO
- [ ] remove consolelink when che-operator is uninstalled
- [ ] check https://issues.redhat.com/browse/CRW-1078