### PR TITLE
Add scripts to run che updates against OCP4.X

### DIFF
--- a/.ci/cico_updates_openshift.sh
+++ b/.ci/cico_updates_openshift.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+set -ex
+
+init() {
+  export SCRIPT=$(readlink -f "$0")
+  export SCRIPT_DIR=$(dirname "$SCRIPT")
+
+  if [[ ${WORKSPACE} ]] && [[ -d ${WORKSPACE} ]]; then
+    export OPERATOR_REPO=${WORKSPACE};
+  else
+    export OPERATOR_REPO=$(dirname "$SCRIPT_DIR");
+  fi
+
+  export RAM_MEMORY=8192
+  export PLATFORM="openshift"
+  export NAMESPACE="che"
+  export CHANNEL="stable"
+}
+
+waitCheUpdateInstall() {
+  export packageName=eclipse-che-preview-${PLATFORM}
+  export platformPath=${OPERATOR_REPO}/olm/${packageName}
+  export packageFolderPath="${platformPath}/deploy/olm-catalog/${packageName}"
+  export packageFilePath="${packageFolderPath}/${packageName}.package.yaml"
+
+  export lastCSV=$(yq -r ".channels[] | select(.name == \"${CHANNEL}\") | .currentCSV" "${packageFilePath}")
+  export lastPackageVersion=$(echo "${lastCSV}" | sed -e "s/${packageName}.v//")
+
+  echo -e "\u001b[34m Check installation last version che-operator...$lastPackageVersion \u001b[0m"
+
+  export n=0
+
+  while [ $n -le 360 ]
+  do
+    cheVersion=$(kubectl get checluster/eclipse-che -n "${NAMESPACE}" -o jsonpath={.status.cheVersion})
+    if [ "${cheVersion}" == $lastPackageVersion ]
+    then
+      echo -e "\u001b[32m Installed latest version che-operator: ${lastCSV} \u001b[0m"
+      break
+    fi
+    sleep 3
+    n=$(( n+1 ))
+  done
+
+  if [ $n -gt 360 ]
+  then
+    echo "Latest version install for Eclipse che failed."
+    exit 1
+  fi
+}
+
+testUpdates() {
+  "${OPERATOR_REPO}"/olm/testUpdate.sh ${PLATFORM} ${CHANNEL} ${NAMESPACE}
+
+  getCheAcessToken
+  chectl workspace:create --devfile=$OPERATOR_REPO/.ci/util/devfile-test.yaml
+
+  waitCheUpdateInstall
+  getCheAcessToken
+
+  local cheVersion=$(kubectl get checluster/eclipse-che -n "${NAMESPACE}" -o jsonpath={.status.cheVersion})
+
+  echo "[INFO] Successfully installed Eclipse Che: ${cheVersion}"
+  sleep 120
+
+  getCheAcessToken
+  workspaceList=$(chectl workspace:list)
+  workspaceID=$(echo "$workspaceList" | grep -oP '\bworkspace.*?\b')
+  chectl workspace:start $workspaceID
+  chectl workspace:list
+
+  waitWorkspaceStart
+  echo "[INFO] Successfully started an workspace on Eclipse Che: ${cheVersion}"
+}
+
+init
+source "${OPERATOR_REPO}"/.ci/util/ci_common.sh
+testUpdates

--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,0 +1,15 @@
+
+# Dockerfile to bootstrap build and test in openshift-ci
+
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12
+
+SHELL ["/bin/bash", "-c"]
+
+# Install yq, kubectl, chectl cli used by olm/olm.sh script.
+RUN yum install --assumeyes -d1 python3-pip && \
+    pip3 install --upgrade setuptools && \
+    pip3 install yq && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin && \
+    bash <(curl -sL https://www.eclipse.org/che/chectl/) --channel=next

--- a/.ci/util/ci_common.sh
+++ b/.ci/util/ci_common.sh
@@ -151,15 +151,16 @@ getCheAcessToken() {
 }
 
 waitWorkspaceStart() {
-  export x=0
   set +e
-  getCheAcessToken
+  export x=0
+  echo "Hello"
   while [ $x -le 180 ]
   do
+    getCheAcessToken
     workspaceList=$(chectl workspace:list --chenamespace=${NAMESPACE})
     workspaceStatus=$(echo "$workspaceList" | grep -oP '\bRUNNING.*?\b')
 
-    if [ "${workspaceStatus}" == "RUNNING" ]
+    if [ "${workspaceStatus:-NOT_RUNNING}" == "RUNNING" ]
     then
       printInfo "Workspace started started successfully"
       break

--- a/.ci/util/ci_common.sh
+++ b/.ci/util/ci_common.sh
@@ -153,7 +153,6 @@ getCheAcessToken() {
 waitWorkspaceStart() {
   set +e
   export x=0
-  echo "Hello"
   while [ $x -le 180 ]
   do
     getCheAcessToken


### PR DESCRIPTION
This PR includes:

- Bash script to run Che Operator Updates against OCP 4.X cluster installed in AWS
- DockerFile with dependencies used by PROW to build job container

Ref. Issue: https://github.com/eclipse/che/issues/17073