### PR TITLE
Add tls support to che operator updates

### DIFF
--- a/.ci/cico_updates_minikube.sh
+++ b/.ci/cico_updates_minikube.sh
@@ -86,7 +86,21 @@ waitCheUpdateInstall() {
   fi
 }
 
+self_signed_minikube() {
+  export DOMAIN=*.$(minikube ip).nip.io
+
+  source ${OPERATOR_REPO}/.ci/util/che-cert-generation.sh
+
+  kubectl create namespace che
+  kubectl create secret tls che-tls --key=domain.key --cert=domain.crt -n che
+  cp rootCA.crt ca.crt
+  kubectl create secret generic self-signed-certificate --from-file=ca.crt -n che
+}
+
 testUpdates() {
+  # Create certificates for tests purpose
+  self_signed_minikube
+
   "${OPERATOR_REPO}"/olm/testUpdate.sh ${PLATFORM} ${CHANNEL} ${NAMESPACE}
   printInfo "Successfully installed Eclipse Che previous version."
 

--- a/.ci/cico_updates_minikube.sh
+++ b/.ci/cico_updates_minikube.sh
@@ -86,21 +86,7 @@ waitCheUpdateInstall() {
   fi
 }
 
-self_signed_minikube() {
-  export DOMAIN=*.$(minikube ip).nip.io
-
-  source ${OPERATOR_REPO}/.ci/util/che-cert-generation.sh
-
-  kubectl create namespace che
-  kubectl create secret tls che-tls --key=domain.key --cert=domain.crt -n che
-  cp rootCA.crt ca.crt
-  kubectl create secret generic self-signed-certificate --from-file=ca.crt -n che
-}
-
 testUpdates() {
-  # Create certificates for tests purpose
-  self_signed_minikube
-
   "${OPERATOR_REPO}"/olm/testUpdate.sh ${PLATFORM} ${CHANNEL} ${NAMESPACE}
   printInfo "Successfully installed Eclipse Che previous version."
 

--- a/.ci/util/che-cert-generation.sh
+++ b/.ci/util/che-cert-generation.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+#
+# Copyright (c) 2012-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+#Declare CN
+export CA_CN=eclipse-che-signer
+
+#Create Root Key
+openssl genrsa -out rootCA.key 4096
+
+#Create and self sign the Root Certificate
+openssl req -x509 -new -nodes -key rootCA.key -subj /CN=${CA_CN} -sha256 -days 1024 -out rootCA.crt
+
+#Create the certificate key
+openssl genrsa -out domain.key 2048
+
+#Create the signing (csr)
+openssl req -new -sha256 -key domain.key -subj "/C=US/ST=CK/O=RedHat/CN=${DOMAIN}" -out domain.csr
+
+#Verify Csr
+openssl req -in domain.csr -noout -text
+
+#Generate the certificate using the domain csr and key along with the CA Root key
+openssl x509 -req -in domain.csr -CA rootCA.crt -CAkey rootCA.key -CAcreateserial -out domain.crt -days 500 -sha256
+
+#Verify the certificate's content
+openssl x509 -in domain.crt -text -noout

--- a/.ci/util/ci_common.sh
+++ b/.ci/util/ci_common.sh
@@ -151,7 +151,7 @@ getCheAcessToken() {
   if [[ ${PLATFORM} == "openshift" ]]
   then
     KEYCLOAK_HOSTNAME=$(oc get route -n ${NAMESPACE} keycloak --template={{.spec.host}})
-    TOKEN_ENDPOINT="http://${KEYCLOAK_HOSTNAME}/auth/realms/che/protocol/openid-connect/token"
+    TOKEN_ENDPOINT="https://${KEYCLOAK_HOSTNAME}/auth/realms/che/protocol/openid-connect/token"
     export CHE_ACCESS_TOKEN=$(curl --data "grant_type=password&client_id=che-public&username=admin&password=admin" -k ${TOKEN_ENDPOINT} | jq -r .access_token)
   else
     KEYCLOAK_HOSTNAME=keycloak-che.$(minikube ip).nip.io

--- a/olm/olm.sh
+++ b/olm/olm.sh
@@ -202,7 +202,6 @@ applyCRCheCluster() {
 
   CRs=$(yq -r '.metadata.annotations["alm-examples"]' "${packageFolderPath}/${PACKAGE_VERSION}/${packageName}.v${PACKAGE_VERSION}.clusterserviceversion.yaml")
   CR=$(echo "$CRs" | yq -r ".[0]")
-  CR=$(echo "$CR" | yq -r ".spec.server.tlsSupport = false")
   if [ "${platform}" == "kubernetes" ]
   then
     CR=$(echo "$CR" | yq -r ".spec.k8s.ingressDomain = \"$(minikube ip).nip.io\"")


### PR DESCRIPTION
This PR add the ability to use tls support in CI.

Reference issue: https://github.com/eclipse/che/issues/17337
Signed-off-by: flacatus <flacatus@redhat.com>