### PR TITLE
Add property to allow use authenticator for proxies;

### DIFF
--- a/pkg/deploy/proxy.go
+++ b/pkg/deploy/proxy.go
@@ -130,7 +130,8 @@ func GenerateProxyJavaOpts(proxy *Proxy, noProxy string) (javaOpts string, err e
 	proxyUserPassword := ""
 	if len(proxy.HttpUser) > 1 && len(proxy.HttpPassword) > 1 {
 		proxyUserPassword = " -Dhttp.proxyUser=" + proxy.HttpUser + " -Dhttp.proxyPassword=" + proxy.HttpPassword +
-			" -Dhttps.proxyUser=" + proxy.HttpsUser + " -Dhttps.proxyPassword=" + proxy.HttpsPassword
+			" -Dhttps.proxyUser=" + proxy.HttpsUser + " -Dhttps.proxyPassword=" + proxy.HttpsPassword + 
+			" -Djdk.http.auth.tunneling.disabledSchemes= -Djdk.http.auth.proxying.disabledSchemes="
 	}
 
 	javaOpts =

--- a/pkg/deploy/proxy_test.go
+++ b/pkg/deploy/proxy_test.go
@@ -51,7 +51,8 @@ func TestGenerateProxyJavaOpts(t *testing.T) {
 	javaOpts, _ := GenerateProxyJavaOpts(proxy, "")
 	expectedJavaOpts := " -Dhttp.proxyHost=myproxy.com -Dhttp.proxyPort=1234 -Dhttps.proxyHost=myproxy.com " +
 		"-Dhttps.proxyPort=1234 -Dhttp.nonProxyHosts='localhost|myhost.com' -Dhttp.proxyUser=user " +
-		"-Dhttp.proxyPassword=password -Dhttps.proxyUser=user -Dhttps.proxyPassword=password"
+		"-Dhttp.proxyPassword=password -Dhttps.proxyUser=user -Dhttps.proxyPassword=password " +
+		"-Djdk.http.auth.tunneling.disabledSchemes= -Djdk.http.auth.proxying.disabledSchemes="
 	if !reflect.DeepEqual(javaOpts, expectedJavaOpts) {
 		t.Errorf("Test failed. Expected '%s' but got '%s'", expectedJavaOpts, javaOpts)
 


### PR DESCRIPTION
To be able to work with authenticated proxies, special Java authenticator should be used. Besides that, using custom authenticator requires special properties to be set.
```
jdk.http.auth.proxying.disabledSchemes=
jdk.http.auth.tunneling.disabledSchemes=
```

More info:
https://www.oracle.com/java/technologies/javase/8u111-relnotes.html
https://stackoverflow.com/questions/41806422/java-web-start-unable-to-tunnel-through-proxy-since-java-8-update-111
(yes java 11 requires it too)