### PR TITLE
Do not push nightly OLM files during release in 7.15.x branch

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -10,9 +10,6 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
-set -e
-set -x
-
 init() {
   RELEASE="$1"
   BRANCH=$(echo $RELEASE | sed 's/.$/x/')
@@ -245,7 +242,6 @@ createPRToMasterBranch() {
 run() {
   checkoutToReleaseBranch
   releaseOperatorCode
-  updateNightlyOlmFiles
   if [[ $RELEASE_OLM_FILES == "true" ]]; then
     releaseOlmFiles
   fi
@@ -268,5 +264,4 @@ fi
 
 if [[ $CREATE_PULL_REQUESTS == "true" ]]; then
   createPRToXBranch
-  createPRToMasterBranch
 fi

--- a/make-release.sh
+++ b/make-release.sh
@@ -264,4 +264,5 @@ fi
 
 if [[ $CREATE_PULL_REQUESTS == "true" ]]; then
   createPRToXBranch
+  createPRToMasterBranch
 fi

--- a/olm/prepare-community-operators-update.sh
+++ b/olm/prepare-community-operators-update.sh
@@ -109,7 +109,7 @@ do
     echo "####"
     echo "#################"
   else
-    git push "https://${GIT_USER}:${GIT_PASSWORD}@github.com/che-incubator/community-operators.git" "${branch}"
+    git push "git@github.com:che-incubator/community-operators.git" "${branch}"
   fi
 done
 cd "${CURRENT_DIR}"

--- a/olm/release-olm-files.sh
+++ b/olm/release-olm-files.sh
@@ -11,7 +11,6 @@
 #   Red Hat, Inc. - initial API and implementation
 
 set -e
-set -x
 
 REGEX="^([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
 

--- a/olm/update-nightly-olm-files.sh
+++ b/olm/update-nightly-olm-files.sh
@@ -11,7 +11,6 @@
 #   Red Hat, Inc. - initial API and implementation
 
 set -e
-set -x
 
 CURRENT_DIR=$(pwd)
 BASE_DIR=$(cd "$(dirname "$0")"; pwd)


### PR DESCRIPTION
- Do not push nightly OLM files during release in 7.15.x branch
- Do not create PR to master branch during release
- Remove certain `-x` flags

Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>