### PR TITLE
Fix minishift install

### DIFF
--- a/.ci/cico_updates_minishift.sh
+++ b/.ci/cico_updates_minishift.sh
@@ -44,6 +44,7 @@ installDependencies() {
   install_VirtPackages
   installStartDocker
   start_libvirt
+  setup_kvm_machine_driver
   minishift_installation
   installChectl
   load_jenkins_vars

--- a/.ci/util/ci_common.sh
+++ b/.ci/util/ci_common.sh
@@ -97,7 +97,7 @@ minishift_installation() {
   printInfo "Downloading Minishift binaries"
   if [ ! -d "$OPERATOR_REPO/tmp" ]; then mkdir -p "$OPERATOR_REPO/tmp" && chmod 777 "$OPERATOR_REPO/tmp"; fi
   curl -L https://github.com/minishift/minishift/releases/download/v$MSFT_RELEASE/minishift-$MSFT_RELEASE-linux-amd64.tgz \
-    -o ${OPERATOR_REPO}/tmp/minishift-$MSFT_RELEASE-linux-amd64.tar && tar -xvf ${OPERATOR_REPO}/tmp/minishift-$MSFT_RELEASE-linux-amd64.tar -C /usr/bin --strip-components=1
+    -o ${OPERATOR_REPO}/tmp/minishift-$MSFT_RELEASE-linux-amd64.tar && tar -xvf ${OPERATOR_REPO}/tmp/minishift-$MSFT_RELEASE-linux-amd64.tar -C /usr/local/bin --strip-components=1
   
   printInfo "Setting github token and start a new minishift VM."
   github_token_set


### PR DESCRIPTION
Copy minishift bin to `/usr/local/bin` instead of `/usr/bin`.

Signed-off-by: flacatus <flacatus@redhat.com>