### PR TITLE
Add truststore config map name to che config map

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -74,6 +74,7 @@ type CheConfigMap struct {
 	CheWorkspacePluginBrokerArtifactsImage string `json:"CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE,omitempty"`
 	CheServerSecureExposerJwtProxyImage    string `json:"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE,omitempty"`
 	CheJGroupsKubernetesLabels             string `json:"KUBERNETES_LABELS,omitempty"`
+	TruststoreConfigMapName                string `json:"CHE_TRUSTSTORE__CONFIGMAP__NAME,omitempty"`
 }
 
 func SyncCheConfigMapToCluster(checluster *orgv1.CheCluster, proxy *Proxy, clusterAPI ClusterAPI) (*corev1.ConfigMap, error) {
@@ -205,6 +206,7 @@ func GetCheConfigMapData(cr *orgv1.CheCluster, proxy *Proxy) (cheEnv map[string]
 		CheServerSecureExposerJwtProxyImage:    DefaultCheServerSecureExposerJwtProxyImage(cr),
 		CheJGroupsKubernetesLabels:             cheLabels,
 		CheMetricsEnabled:                      cheMetrics,
+		TruststoreConfigMapName:                cr.Spec.Server.ServerTrustStoreConfigMapName,
 	}
 
 	if cheMultiUser == "true" {


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>


### Reference issue
https://github.com/eclipse/che/issues/17407

### What does this PR do
It simply adds truststore config map name to che config map.
Che server will use this config map name to mount certificates into workspace pod containers