### PR TITLE
Fix release scripts for CI integration

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,6 @@
 
 Export environment variables:
 1. `QUAY_USERNAME` and `QUAY_PASSWORD` to access https://quay.io/organization/eclipse
-2. `GIT_USER` and `GIT_PASSWORD` to create PR into https://github.com/operator-framework/community-operators
 
 ```bash
 ./make-release.sh <RELEASE_VERSION> --release --push-olm-files --push-git-changes --pull-requests

--- a/make-release.sh
+++ b/make-release.sh
@@ -163,7 +163,7 @@ releaseOperatorCode() {
   docker build -t "quay.io/eclipse/che-operator:${RELEASE}" .
 
   echo "[INFO] Pushing image to quay.io"
-  docker login quay.io -u $QUAY_USERNAME
+  docker login quay.io -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}"
   docker push quay.io/eclipse/che-operator:$RELEASE
 }
 
@@ -225,7 +225,7 @@ pushGitChanges() {
 
 createPRToXBranch() {
   echo "[INFO] Creating pull request into ${BRANCH} branch"
-  hub pull-request --base ${BRANCH} --head ${RELEASE} --browse -m "Release version ${RELEASE}"
+  hub pull-request --base ${BRANCH} --head ${RELEASE} -m "Release version ${RELEASE}"
 }
 
 createPRToMasterBranch() {
@@ -238,7 +238,7 @@ createPRToMasterBranch() {
   git add -A
   git commit -m "Copy "$RELEASE" csv to master" --signoff
   git push origin $tmpBranch -f
-  hub pull-request --base master --head ${tmpBranch} --browse -m "Copy "$RELEASE" csv to master"
+  hub pull-request --base master --head ${tmpBranch} -m "Copy "$RELEASE" csv to master"
 }
 
 run() {

--- a/olm/prepare-community-operators-update.sh
+++ b/olm/prepare-community-operators-update.sh
@@ -96,20 +96,6 @@ do
   git commit -s -m "Update eclipse-che operator for ${platform} to release ${lastPackagePreReleaseVersion}"
   echo
   echo "   - Pushing branch ${branch} to the 'che-incubator/community-operators' GitHub repository"
-  if [ -z "${GIT_USER}" ] || [ -z "${GIT_PASSWORD}" ]
-  then
-    echo
-    echo "#### WARNING ####"
-    echo "####"
-    echo "#### You shoud define GIT_USER and GIT_PASSWORD environment variable"
-    echo "#### to be able to push release branches to the 'che-incubator/community-operators' repository"
-    echo "####"
-    echo "#### As soon as you have set them, you can push by running the following command:"
-    echo "####    cd \"${communityOperatorsLocalGitFolder}\" && git push \"https://\${GIT_USER}:\${GIT_PASSWORD}@github.com/che-incubator/community-operators.git\" \"${branch}\""
-    echo "####"
-    echo "#################"
-  else
-    git push "https://${GIT_USER}:${GIT_PASSWORD}@github.com/che-incubator/community-operators.git" "${branch}"
-  fi
+  git push "git@github.com:che-incubator/community-operators.git" "${branch}"
 done
 cd "${CURRENT_DIR}"


### PR DESCRIPTION
- remove interactive bits that couldn't run on a non-interactive CI
- also remove GIT_USER and GIT_PASSWORD and use ssh links instead to push community operator updates