### PR TITLE
Match quay login vars to the ones used by...

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 ## 1. Release files
 
 Export environment variables:
-1. `QUAY_USERNAME` and `QUAY_PASSWORD` to access https://quay.io/organization/eclipse
+1. `QUAY_ECLIPSE_CHE_USERNAME` and `QUAY_ECLIPSE_CHE_PASSWORD` to access https://quay.io/organization/eclipse
 
 ```bash
 ./make-release.sh <RELEASE_VERSION> --release --push-olm-files --push-git-changes --pull-requests

--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -62,11 +62,9 @@ function build_and_push() {
   REGISTRY="quay.io"
   ORGANIZATION="eclipse"
   IMAGE="che-operator"
-  QUAY_USERNAME=${QUAY_ECLIPSE_CHE_USERNAME}
-  QUAY_PASSWORD=${QUAY_ECLIPSE_CHE_PASSWORD}
 
-  if [ -n "${QUAY_USERNAME}" ] && [ -n "${QUAY_PASSWORD}" ]; then
-    docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" "${REGISTRY}"
+  if [ -n "${QUAY_ECLIPSE_CHE_USERNAME}" ] && [ -n "${QUAY_ECLIPSE_CHE_PASSWORD}" ]; then
+    docker login -u "${QUAY_ECLIPSE_CHE_USERNAME}" -p "${QUAY_ECLIPSE_CHE_PASSWORD}" "${REGISTRY}"
   else
     echo "Could not login, missing credentials for pushing to the '${ORGANIZATION}' organization"
   fi

--- a/make-release.sh
+++ b/make-release.sh
@@ -37,8 +37,8 @@ init() {
     shift 1
   done
 
-  [ -z "$QUAY_USERNAME" ] && echo "[ERROR] QUAY_USERNAME is not set" && exit 1
-  [ -z "$QUAY_PASSWORD" ] && echo "[ERROR] QUAY_PASSWORD is not set" && exit 1
+  [ -z "$QUAY_ECLIPSE_CHE_USERNAME" ] && echo "[ERROR] QUAY_ECLIPSE_CHE_USERNAME is not set" && exit 1
+  [ -z "$QUAY_ECLIPSE_CHE_PASSWORD" ] && echo "[ERROR] QUAY_ECLIPSE_CHE_PASSWORD is not set" && exit 1
   command -v operator-courier >/dev/null 2>&1 || { echo "[ERROR] operator-courier is not installed. Aborting."; exit 1; }
   command -v operator-sdk >/dev/null 2>&1 || { echo "[ERROR] operator-sdk is not installed. Aborting."; exit 1; }
   command -v skopeo >/dev/null 2>&1 || { echo "[ERROR] skopeo is not installed. Aborting."; exit 1; }
@@ -163,7 +163,7 @@ releaseOperatorCode() {
   docker build -t "quay.io/eclipse/che-operator:${RELEASE}" .
 
   echo "[INFO] Pushing image to quay.io"
-  docker login quay.io -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}"
+  docker login quay.io -u "${QUAY_ECLIPSE_CHE_USERNAME}" -p "${QUAY_ECLIPSE_CHE_PASSWORD}"
   docker push quay.io/eclipse/che-operator:$RELEASE
 }
 

--- a/olm/README.md
+++ b/olm/README.md
@@ -52,8 +52,8 @@ Olm bundle packages will be generated in the folders `olm/eclipse-che-preview-${
 Push che-operator bundles to your application registry:
 
 ```shell
-$ export QUAY_USERNAME=${username} && \
-export QUAY_PASSWORD=${password} && \
+$ export QUAY_ECLIPSE_CHE_USERNAME=${username} && \
+export QUAY_ECLIPSE_CHE_PASSWORD=${password} && \
 export APPLICATION_REGISTRY=${application_registry_namespace} && \
 ./push-olm-files-to-quay.sh
 ```

--- a/olm/push-olm-files-to-quay.sh
+++ b/olm/push-olm-files-to-quay.sh
@@ -47,29 +47,29 @@ do
   "kubernetes")
     QUAY_USERNAME_PLATFORM_VAR="QUAY_USERNAME_K8S"
     QUAY_PASSWORD_PLATFORM_VAR="QUAY_PASSWORD_K8S"
-    QUAY_USERNAME=${QUAY_USERNAME_K8S:-$QUAY_USERNAME}
-    QUAY_PASSWORD=${QUAY_PASSWORD_K8S:-$QUAY_PASSWORD}
+    QUAY_ECLIPSE_CHE_USERNAME=${QUAY_USERNAME_K8S:-$QUAY_ECLIPSE_CHE_USERNAME}
+    QUAY_ECLIPSE_CHE_PASSWORD=${QUAY_PASSWORD_K8S:-$QUAY_ECLIPSE_CHE_PASSWORD}
     ;;
   "openshift")
     QUAY_USERNAME_PLATFORM_VAR="QUAY_USERNAME_OS"
     QUAY_PASSWORD_PLATFORM_VAR="QUAY_PASSWORD_OS"
-    QUAY_USERNAME=${QUAY_USERNAME_OS:-$QUAY_USERNAME}
-    QUAY_PASSWORD=${QUAY_PASSWORD_OS:-$QUAY_PASSWORD}
+    QUAY_ECLIPSE_CHE_USERNAME=${QUAY_USERNAME_OS:-$QUAY_ECLIPSE_CHE_USERNAME}
+    QUAY_ECLIPSE_CHE_PASSWORD=${QUAY_PASSWORD_OS:-$QUAY_ECLIPSE_CHE_PASSWORD}
     ;;
   esac
-  if [ -z "${QUAY_USERNAME}" ] || [ -z "${QUAY_PASSWORD}" ]
+  if [ -z "${QUAY_ECLIPSE_CHE_USERNAME}" ] || [ -z "${QUAY_ECLIPSE_CHE_PASSWORD}" ]
   then
     echo "#### ERROR: "
     echo "You should have set ${QUAY_USERNAME_PLATFORM_VAR} and ${QUAY_PASSWORD_PLATFORM_VAR} environment variables"
     echo "with a user that has write access to the following Quay.io namespace: ${quayNamespace}"
-    echo "or QUAY_USERNAME and QUAY_PASSWORD if the same user can access both namespaces 'eclipse-che-operator-kubernetes' and 'eclipse-che-operator-openshift'"
+    echo "or QUAY_ECLIPSE_CHE_USERNAME and QUAY_ECLIPSE_CHE_PASSWORD if the same user can access both namespaces 'eclipse-che-operator-kubernetes' and 'eclipse-che-operator-openshift'"
     exit 1
   fi
   AUTH_TOKEN=$(curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '
 {
     "user": {
-        "username": "'"${QUAY_USERNAME}"'",
-        "password": "'"${QUAY_PASSWORD}"'"
+        "username": "'"${QUAY_ECLIPSE_CHE_USERNAME}"'",
+        "password": "'"${QUAY_ECLIPSE_CHE_PASSWORD}"'"
     }
 }' | jq -r '.token')
 


### PR DESCRIPTION
Match quay login vars to the ones used by cico che-release script

Global vars are defined here:

https://github.com/eclipse/che-release/blob/release/cico_release.sh#L14

Change-Id: I12d95b48b0600d805f107958c099838d4a263659
Signed-off-by: nickboldt <nboldt@redhat.com>