### PR TITLE
Update the configmap property name

### DIFF
--- a/pkg/deploy/che_configmap.go
+++ b/pkg/deploy/che_configmap.go
@@ -74,7 +74,7 @@ type CheConfigMap struct {
 	CheWorkspacePluginBrokerArtifactsImage string `json:"CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE,omitempty"`
 	CheServerSecureExposerJwtProxyImage    string `json:"CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE,omitempty"`
 	CheJGroupsKubernetesLabels             string `json:"KUBERNETES_LABELS,omitempty"`
-	TruststoreConfigMapName                string `json:"CHE_TRUSTSTORE__CONFIGMAP__NAME,omitempty"`
+	CheTrustedCABundlesConfigMap           string `json:"CHE_TRUSTED__CA__BUNDLES__CONFIGMAP,omitempty"`
 }
 
 func SyncCheConfigMapToCluster(checluster *orgv1.CheCluster, proxy *Proxy, clusterAPI ClusterAPI) (*corev1.ConfigMap, error) {
@@ -206,7 +206,7 @@ func GetCheConfigMapData(cr *orgv1.CheCluster, proxy *Proxy) (cheEnv map[string]
 		CheServerSecureExposerJwtProxyImage:    DefaultCheServerSecureExposerJwtProxyImage(cr),
 		CheJGroupsKubernetesLabels:             cheLabels,
 		CheMetricsEnabled:                      cheMetrics,
-		TruststoreConfigMapName:                cr.Spec.Server.ServerTrustStoreConfigMapName,
+		CheTrustedCABundlesConfigMap:           cr.Spec.Server.ServerTrustStoreConfigMapName,
 	}
 
 	if cheMultiUser == "true" {


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>


### Reference issue
https://github.com/eclipse/che/issues/17407

### What does this PR do
Updates the property name in che configmap:

`CHE_TRUSTSTORE__CONFIGMAP__NAME` -> `CHE_TRUSTED__CA__BUNDLES__CONFIGMAP`