### PR TITLE
Add quay.io/eclipse/che-sidecar-workspace-data-sync:latest to digestExcludeList

### DIFF
--- a/olm/digestExcludeList
+++ b/olm/digestExcludeList
@@ -1,3 +1,4 @@
 quay.io/eclipse/che-theia:next
 quay.io/eclipse/che-theia-dev:next
 quay.io/eclipse/che-theia-endpoint-runtime-binary:next
+quay.io/eclipse/che-sidecar-workspace-data-sync:latest


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

### Reference issue
https://github.com/eclipse/che/issues/17580

### What does this PR do
Exclude image `quay.io/eclipse/che-sidecar-workspace-data-sync:latest` from digest usage 