### PR TITLE
Add catalog source dockerfile openshfit ci

### DIFF
--- a/.ci/openshift-ci/.dockerignore
+++ b/.ci/openshift-ci/.dockerignore
@@ -1,0 +1,3 @@
+**/*.diff
+**/*.sh
+**/*Dockerfile

--- a/.ci/openshift-ci/Dockerfile.catalog
+++ b/.ci/openshift-ci/Dockerfile.catalog
@@ -1,0 +1,15 @@
+FROM quay.io/operator-framework/upstream-registry-builder as builder
+# Docker build in ci needs the complete route of the che operator repo dir...
+COPY olm/eclipse-che-preview-openshift/deploy manifests/eclipse-che-preview-openshift
+RUN ./bin/initializer --permissive -o ./bundles.db
+
+FROM openshift/origin-base
+
+COPY --from=builder /build/bin/initializer /initializer
+COPY --from=builder /build/bin/configmap-server /bin/configmap-server
+COPY --from=builder /build/bundles.db /bundles.db
+COPY --from=builder /build/bin/registry-server /registry-server
+COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+EXPOSE 50051
+ENTRYPOINT ["/registry-server"]
+CMD ["--database", "bundles.db"]


### PR DESCRIPTION
In openshift CI we are not able to build the catalog source from `olm/eclipse-che-preview-openshift/Dockerfile`. I create a new catalog dockerfile in .ci/openshift-ci/ folder where Openshift CI will be able to read...
Signed-off-by: flacatus <flacatus@redhat.com>