### PR TITLE
Add server TLS key and cert into Che configmap if a separate namespace for Che workspaces is configured

### DIFF
--- a/pkg/deploy/che_configmap_test.go
+++ b/pkg/deploy/che_configmap_test.go
@@ -30,10 +30,10 @@ func TestNewCheConfigMap(t *testing.T) {
 	cr.Spec.Auth.OpenShiftoAuth = true
 	deployContext := &DeployContext{
 		CheCluster: cr,
-		Proxy: &Proxy{},
+		Proxy:      &Proxy{},
 		ClusterAPI: ClusterAPI{},
 	}
-	cheEnv := GetCheConfigMapData(deployContext)
+	cheEnv, _ := GetCheConfigMapData(deployContext)
 	testCm, _ := GetSpecConfigMap(deployContext, CheConfigMapName, cheEnv)
 	identityProvider := testCm.Data["CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER"]
 	_, isOpenshiftv4, _ := util.DetectOpenShift()
@@ -60,10 +60,10 @@ func TestConfigMapOverride(t *testing.T) {
 	cr.Spec.Auth.OpenShiftoAuth = true
 	deployContext := &DeployContext{
 		CheCluster: cr,
-		Proxy: &Proxy{},
+		Proxy:      &Proxy{},
 		ClusterAPI: ClusterAPI{},
 	}
-	cheEnv := GetCheConfigMapData(deployContext)
+	cheEnv, _ := GetCheConfigMapData(deployContext)
 	testCm, _ := GetSpecConfigMap(deployContext, CheConfigMapName, cheEnv)
 	if testCm.Data["CHE_WORKSPACE_NO_PROXY"] != "myproxy.myhostname.com" {
 		t.Errorf("Test failed. Expected myproxy.myhostname.com but was %s", testCm.Data["CHE_WORKSPACE_NO_PROXY"])


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do
If Eclipse Che is configured to use a separate namespace for Che workspaces via `CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT` Che property, then add into Che config map Che server TLS secret (key and certificate) in order for Che server to be able to configure workspace components with right TLS key and certificate (as it is not possible to access Che server TLS secret from a separate namespace) .

### Which issues this PR resolves
https://github.com/eclipse/che/issues/17631