### PR TITLE
Make additional requiest for test route certs if first one fails without proxy

### DIFF
--- a/pkg/deploy/tls.go
+++ b/pkg/deploy/tls.go
@@ -149,11 +149,27 @@ func GetEndpointTLSCrtChain(deployContext *DeployContext, endpointURL string) ([
 		requestURL = endpointURL
 	}
 
+	certificates, err := doRequestForTLSCrtChain(deployContext, requestURL, isTestRoute)
+	if err != nil {
+		if deployContext.Proxy.HttpProxy != "" && isTestRoute {
+			// Fetching certificates from the test route without proxy failed. Probably non-proxy connections are blocked.
+			// Retrying with proxy configuration, however it might cause retreiving of wrong certificate in case of TLS interception by proxy.
+			logrus.Warn("Failed to get certificate chain of trust of the OpenShift Ingress bypassing the proxy")
+
+			return doRequestForTLSCrtChain(deployContext, requestURL, false)
+		}
+
+		return nil, err
+	}
+	return certificates, nil
+}
+
+func doRequestForTLSCrtChain(deployContext *DeployContext, requestURL string, skipProxy bool) ([]*x509.Certificate, error) {
 	transport := &http.Transport{}
 	// Adding the proxy settings to the Transport object.
 	// However, in case of test route we need to reach cluter directly in order to get the right certificate.
-	if deployContext.Proxy.HttpProxy != "" && !isTestRoute {
-		logrus.Infof("Configuring proxy with %s to extract crt from the following URL: %s", deployContext.Proxy.HttpProxy, requestURL)
+	if deployContext.Proxy.HttpProxy != "" && !skipProxy {
+		logrus.Infof("Configuring proxy with %s to extract certificate chain from the following URL: %s", deployContext.Proxy.HttpProxy, requestURL)
 		ConfigureProxy(deployContext, transport)
 	}
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do
Adds second attempt to retrieve cluster CA certificate in case if Openshift cluster uses proxy and first request without the proxy failed. The second request uses proxy, but adds warning that this could be not accurate.