### PR TITLE
Check Operator SDK version in update nightly script

### DIFF
--- a/olm/update-nightly-olm-files.sh
+++ b/olm/update-nightly-olm-files.sh
@@ -17,6 +17,18 @@ BASE_DIR=$(cd "$(dirname "$0")"; pwd)
 TAG=$1
 source ${BASE_DIR}/check-yq.sh
 
+# Check for compatible version of operator-sdk:
+OPERATOR_SDK_VERSION=$(operator-sdk version | sed -E 's|.*version: (v[0-9]+.[0-9]+\.[0-9]+).*|\1|')
+case $OPERATOR_SDK_VERSION in
+  v0.10.*)
+    echo "Operator SDK $OPERATOR_SDK_VERSION installed"
+    ;;
+  *)
+    echo "This script requires Operator SDK v0.10.x. Please install the correct version to continue"
+    exit 1
+    ;;
+esac
+
 for platform in 'kubernetes' 'openshift'
 do
   packageName=eclipse-che-preview-${platform}


### PR DESCRIPTION
Add a check in olm/update-nightly-olm-files.sh to check that the correct version of operator-sdk is installed. Otherwise, if a newer version is installed, the command will fail with a cryptic error message.

I've tested changes with `operator-sdk v0.14.0`, `operator-sdk v0.10.1` and no operator-sdk in the `$PATH`.