### PR TITLE
Fix reconciling of single user Che

### DIFF
--- a/pkg/deploy/deployment_che.go
+++ b/pkg/deploy/deployment_che.go
@@ -251,6 +251,7 @@ func getSpecCheDeployment(deployContext *DeployContext, cmResourceVersion string
 				})
 		}
 	} else {
+		deployment.Spec.Strategy.Type = appsv1.RecreateDeploymentStrategyType
 		deployment.Spec.Template.Spec.Volumes = []corev1.Volume{
 			{
 				Name: DefaultCheVolumeClaimName,


### PR DESCRIPTION
Single user Che is not compatible with rolling update, so after any change in CheCluster CR Che deployment is failed to start with the following error
```
20) Error injecting constructor, org.eclipse.che.core.db.schema.SchemaInitializationException: Cannot create PoolableConnectionFactory (Database may be already in use: null. Possible solutions: close all other connection(s); use the server mode [90020-196])
```

This PR is supposed to fix that issue but I haven't tested it.