### PR TITLE
Correctly convert wildcards in nonProxyHosts for JAVA_OPTS

### DIFF
--- a/pkg/deploy/deployment_keycloak.go
+++ b/pkg/deploy/deployment_keycloak.go
@@ -186,7 +186,17 @@ func getSpecKeycloakDeployment(
 			if len(quotedNoProxy) != 0 {
 				quotedNoProxy += ","
 			}
-			quotedNoProxy += "\"" + strings.ReplaceAll(regexp.QuoteMeta(noProxyHost), "\\", "\\\\\\") + ";NO_PROXY\""
+
+			var noProxyEntry string
+			if strings.HasPrefix(noProxyHost, ".") {
+				noProxyEntry = ".*" + strings.ReplaceAll(regexp.QuoteMeta(noProxyHost), "\\", "\\\\\\")
+			} else if strings.HasPrefix(noProxyHost, "*.") {
+				noProxyEntry = strings.TrimPrefix(noProxyHost, "*")
+				noProxyEntry = ".*" + strings.ReplaceAll(regexp.QuoteMeta(noProxyEntry), "\\", "\\\\\\")
+			} else {
+				noProxyEntry = strings.ReplaceAll(regexp.QuoteMeta(noProxyHost), "\\", "\\\\\\")
+			}
+			quotedNoProxy += "\"" + noProxyEntry + ";NO_PROXY\""
 		}
 
 		jbossCli := "/opt/jboss/keycloak/bin/jboss-cli.sh"


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do
Correctly converts wildcards from nonProxyHosts in Che CR for JAVA_OPTS.
For Java, wildcards should look like `*.domain.com` instead of just `.domain.com`

### What issue does it fix
https://github.com/eclipse/che/issues/17831