### PR TITLE
Set default value to {} for singleHostGatewayConfigMapLabels

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -72,8 +72,8 @@ spec:
     # Omit it or leave it empty to use the defaut container image provided by the operator.
     singleHostGatewayConfigSidecarImage: ''
     # The labels that need to be present (and are put) on the configmaps representing the gateway configuration.
-    singleHostGatewayConfigMapLabels: ''
-        
+    singleHostGatewayConfigMapLabels: {}
+
   database:
     # when set to true, the operator skips deploying Postgres, and passes connection details of existing DB to Che server
     # otherwise a Postgres deployment is created


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

### Reference issue
https://github.com/eclipse/che/issues/17888

### What does this PR do
Since `spec.server.singleHostGatewayConfigMapLabel` is type of `labels.Set` the default value should be set to `{}` instead of `""`