### PR TITLE
Fix api limitation minishift

### DIFF
--- a/.github/workflows/che-nightly.yaml
+++ b/.github/workflows/che-nightly.yaml
@@ -24,6 +24,10 @@ jobs:
         # coreutils provides a readlink that supports `-f`
 
         brew install coreutils docker docker-machine
+
+        mkdir -p ~/.docker/machine/cache/
+        sudo curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
+
         docker-machine --github-api-token="${{ secrets.GITHUB_TOKEN }}" create --driver virtualbox default
         eval "$(docker-machine env default)"
         export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
@@ -49,7 +53,9 @@ jobs:
         eval $(minishift docker-env) && docker load -i operator.tar && rm operator.tar
 
         /bin/bash .ci/cico_minishift_nightly.sh
+    # Run this step even the previous step fail
     - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
       with:
         name: minishift-che-nightly-artifacts
         path: /tmp/artifacts-che

--- a/.github/workflows/che-operator-updates.yaml
+++ b/.github/workflows/che-operator-updates.yaml
@@ -26,7 +26,9 @@ jobs:
       run: bash <(curl -sL  https://www.eclipse.org/che/chectl/) --channel=next
     - name: Run che operator updates minikube
       run: /bin/bash .ci/cico_updates_minikube.sh
+    # Run this step even the previous step fail
     - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
       with:
         name: minikube-updates-artifacts
         path: /tmp/artifacts-che
@@ -50,7 +52,9 @@ jobs:
         eval $(minishift oc-env)
         pip install yq
         /bin/bash .ci/cico_updates_minishift.sh
+    # Run this step even the previous step fail
     - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
       with:
         name: minishift-updates-artifacts
         path: /tmp/artifacts-che

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,6 +22,10 @@ jobs:
         # coreutils provides a readlink that supports `-f`
 
         brew install coreutils docker docker-machine
+
+        mkdir -p ~/.docker/machine/cache/
+        sudo curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
+
         docker-machine --github-api-token="${{ secrets.GITHUB_TOKEN }}" create --driver virtualbox default
         eval "$(docker-machine env default)"
         export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"

--- a/.github/workflows/olm_checks_platforms.yaml
+++ b/.github/workflows/olm_checks_platforms.yaml
@@ -27,6 +27,7 @@ jobs:
     - name: Run che operator updates minikube
       run: /bin/bash .ci/cico_olm_minikube.sh
     # Run this step even the previous step fail
+    - uses: actions/upload-artifact@v2
       if: ${{ always() }}
       with:
         name: minikube-olm-artifacts

--- a/.github/workflows/olm_checks_platforms.yaml
+++ b/.github/workflows/olm_checks_platforms.yaml
@@ -26,7 +26,8 @@ jobs:
       run: bash <(curl -sL  https://www.eclipse.org/che/chectl/) --channel=next
     - name: Run che operator updates minikube
       run: /bin/bash .ci/cico_olm_minikube.sh
-    - uses: actions/upload-artifact@v2
+    # Run this step even the previous step fail
+      if: ${{ always() }}
       with:
         name: minikube-olm-artifacts
         path: /tmp/artifacts-che


### PR DESCRIPTION
This PR fix GH api response in PR.
Example of fails:https://github.com/eclipse/che-operator/pull/474/checks?check_run_id=1166233363

LOG: `Running pre-create checks...
(default) Image cache directory does not exist, creating it at /Users/runner/.docker/machine/cache...
(default) No default Boot2Docker ISO found locally, downloading the latest release...
Error with pre-create check: "failure getting a version tag from the Github API response (are you getting rate limited by Github?)"
`
Also I add to artifacts load to execute always in jobs even if previous steps of actions fails.
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>