### PR TITLE
Build a catalog source image only if there is a new nightly bundle image

### DIFF
--- a/.github/action_scripts/build_olm_bundle_images.sh
+++ b/.github/action_scripts/build_olm_bundle_images.sh
@@ -21,7 +21,7 @@ export PATH=$HOME/.local/bin:$PATH
 
 export IMAGE_REGISTRY_USERNAME=eclipse
 export IMAGE_REGISTRY=quay.io
-export ROOT_PROJECT_DIR="${PWD}"
+export ROOT_PROJECT_DIR="${GITHUB_WORKSPACE}"
 export BASE_DIR="${ROOT_PROJECT_DIR}/olm"
 
 for platform in 'kubernetes' 'openshift'

--- a/.github/action_scripts/build_olm_bundle_images.sh
+++ b/.github/action_scripts/build_olm_bundle_images.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
-
-IMAGE_REGISTRY_USERNAME=eclipse
-IMAGE_REGISTRY=quay.io
-ROOT_PROJECT_DIR="${GITHUB_WORKSPACE}"
-export BASE_DIR="${ROOT_PROJECT_DIR}/olm"
+#
+# Copyright (c) 2012-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+set -ex
 
 # install yq
 pip3 install wheel
@@ -12,32 +18,44 @@ pip3 install yq
 # Make python3 installed modules "visible"
 export PATH=$HOME/.local/bin:$PATH
 
+
+export IMAGE_REGISTRY_USERNAME=eclipse
+export IMAGE_REGISTRY=quay.io
+export ROOT_PROJECT_DIR="${PWD}"
+export BASE_DIR="${ROOT_PROJECT_DIR}/olm"
+
 for platform in 'kubernetes' 'openshift'
 do
-  OPM_BUNDLE_DIR="${ROOT_PROJECT_DIR}/deploy/olm-catalog/eclipse-che-preview-${platform}"
-  OPM_BUNDLE_MANIFESTS_DIR="${OPM_BUNDLE_DIR}/manifests"
-  CSV="${OPM_BUNDLE_MANIFESTS_DIR}/che-operator.clusterserviceversion.yaml"
+  export OPM_BUNDLE_DIR="${ROOT_PROJECT_DIR}/deploy/olm-catalog/eclipse-che-preview-${platform}"
+  export OPM_BUNDLE_MANIFESTS_DIR="${OPM_BUNDLE_DIR}/manifests"
+  export CSV="${OPM_BUNDLE_MANIFESTS_DIR}/che-operator.clusterserviceversion.yaml"
 
-  nightlyVersion=$(yq -r ".spec.version" "${CSV}")
-  CATALOG_BUNDLE_IMAGE_NAME_LOCAL="${IMAGE_REGISTRY}/${IMAGE_REGISTRY_USERNAME}/eclipse-che-${platform}-opm-bundles:${nightlyVersion}"
-  CATALOG_IMAGENAME="${IMAGE_REGISTRY}/${IMAGE_REGISTRY_USERNAME}/eclipse-che-${platform}-opm-catalog:preview"
+  export nightlyVersion=$(yq -r ".spec.version" "${CSV}")
+  export CATALOG_BUNDLE_IMAGE_NAME_LOCAL="${IMAGE_REGISTRY}/${IMAGE_REGISTRY_USERNAME}/eclipse-che-${platform}-opm-bundles:${nightlyVersion}"
+  export CATALOG_IMAGENAME="${IMAGE_REGISTRY}/${IMAGE_REGISTRY_USERNAME}/eclipse-che-${platform}-opm-catalog:preview"
 
   source "${ROOT_PROJECT_DIR}/olm/olm.sh" "${platform}" "${nightlyVersion}" "che"
   source "${ROOT_PROJECT_DIR}/olm/incrementNightlyBundles.sh"
-
   installOPM
 
   ${OPM_BINARY} version
 
-  incrementPart=$(getNightlyVersionIncrementPart "${nightlyVersion}")
-  echo "Nightly increment version ${incrementPart}"
+  export incrementPart=$(getNightlyVersionIncrementPart "${nightlyVersion}")
+  echo "[INFO] Nightly increment version ${incrementPart}"
 
-  buildBundleImage "${CATALOG_BUNDLE_IMAGE_NAME_LOCAL}"
+  export CHECK_NIGHTLY_TAG=$(skopeo inspect docker://quay.io/eclipse/eclipse-che-kubernetes-opm-bundles:${nightlyVersion} 2>/dev/null | jq -r '.RepoTags[]|select(. == "${nightlyVersion}")')
+  if [ -z "$CHECK_NIGHTLY_TAG" ]
+  then
+    buildBundleImage "${CATALOG_BUNDLE_IMAGE_NAME_LOCAL}"
 
-  if [ "${incrementPart}" == 0 ]; then
-    echo "Build very first bundle."
-    buildCatalogImage "${CATALOG_IMAGENAME}" "${CATALOG_BUNDLE_IMAGE_NAME_LOCAL}"
+    if [ "${incrementPart}" == 0 ]; then
+      echo "[INFO] Build very first bundle."
+      buildCatalogImage "${CATALOG_IMAGENAME}" "${CATALOG_BUNDLE_IMAGE_NAME_LOCAL}"
+    else
+      buildCatalogImage "${CATALOG_IMAGENAME}" "${CATALOG_BUNDLE_IMAGE_NAME_LOCAL}" "docker" "${CATALOG_IMAGENAME}"
+    fi
+
   else
-    buildCatalogImage "${CATALOG_IMAGENAME}" "${CATALOG_BUNDLE_IMAGE_NAME_LOCAL}" "docker" "${CATALOG_IMAGENAME}"
+      echo "[INFO] Bundle already present in the catalog source"
   fi
 done


### PR DESCRIPTION
Check if the bundle was already pushed to the catalog source. In case if the bundle was not pushed, build the bundles container and push to quay.io

Refference issue: https://github.com/eclipse/che/issues/17907
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>