### PR TITLE
Build nightly images of operator in github actions

### DIFF
--- a/.github/workflows/operator-build-nightly.yaml
+++ b/.github/workflows/operator-build-nightly.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2012-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+name: Nightly Dockerimage Build
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout che-machine-exec source code
+      uses: actions/checkout@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to quay.io
+      uses: docker/login-action@v1 
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        registry: quay.io
+    - name: Build and push nightly
+      uses: docker/build-push-action@v2
+      with:
+        file: build/dockerfiles/Dockerfile
+        platforms: linux/amd64,linux/ppc64le,linux/s390x
+        push: true
+        tags: quay.io/eclipse/che-operator:nightly


### PR DESCRIPTION
After migrating normal jobs in PR from centos ci to GH actions is time to migrate nightly build from centos ci to GH actions.

Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>