### PR TITLE
CRW-1254 can we use the standard,...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH=
     export MOCK_API=true && go test -mod=vendor -v ./... && \
     GOOS=linux GOARCH=${ARCH} CGO_ENABLED=0 go build -mod=vendor -o /tmp/che-operator/che-operator cmd/manager/main.go
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.2-349
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.redhat.io/ubi8/ubi-minimal:8.2-349
 
 COPY --from=builder /tmp/che-operator/che-operator /usr/local/bin/che-operator
 COPY --from=builder /che-operator/templates/keycloak_provision /tmp/keycloak_provision

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH=
     GOOS=linux GOARCH=${ARCH} CGO_ENABLED=0 go build -mod=vendor -o /tmp/che-operator/che-operator cmd/manager/main.go
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/ubi-minimal
-FROM registry.redhat.io/ubi8/ubi-minimal:8.2-349
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.2-349
 
 COPY --from=builder /tmp/che-operator/che-operator /usr/local/bin/che-operator
 COPY --from=builder /che-operator/templates/keycloak_provision /tmp/keycloak_provision

--- a/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -52,13 +52,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2020-09-28T07:48:12Z"
+    createdAt: "2020-10-06T19:40:40Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.20.0-10.nightly
+  name: eclipse-che-preview-kubernetes.v7.20.0-11.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -402,4 +402,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.20.0-10.nightly
+  version: 7.20.0-11.nightly

--- a/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -52,13 +52,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2020-10-06T19:40:40Z"
+    createdAt: "2020-10-07T06:20:08Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.20.0-11.nightly
+  name: eclipse-che-preview-kubernetes.v7.20.0-12.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -260,7 +260,7 @@ spec:
                       - name: RELATED_IMAGE_che_tls_secrets_creation_job
                         value: quay.io/eclipse/che-tls-secret-creator:alpine-d1ed4ad
                       - name: RELATED_IMAGE_pvc_jobs
-                        value: registry.access.redhat.com/ubi8-minimal:8.2-349
+                        value: registry.access.redhat.com/ubi8/ubi-minimal:8.2-349
                       - name: RELATED_IMAGE_postgres
                         value: centos/postgresql-96-centos7:9.6
                       - name: RELATED_IMAGE_keycloak
@@ -402,4 +402,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.20.0-11.nightly
+  version: 7.20.0-12.nightly

--- a/deploy/olm-catalog/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -49,13 +49,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2020-09-28T07:48:12Z"
+    createdAt: "2020-10-06T19:40:40Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.20.0-10.nightly
+  name: eclipse-che-preview-openshift.v7.20.0-11.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -435,4 +435,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.20.0-10.nightly
+  version: 7.20.0-11.nightly

--- a/deploy/olm-catalog/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -49,13 +49,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2020-10-06T19:40:40Z"
+    createdAt: "2020-10-07T06:20:08Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.20.0-11.nightly
+  name: eclipse-che-preview-openshift.v7.20.0-12.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -287,7 +287,7 @@ spec:
                       - name: RELATED_IMAGE_devfile_registry
                         value: quay.io/eclipse/che-devfile-registry:nightly
                       - name: RELATED_IMAGE_pvc_jobs
-                        value: registry.access.redhat.com/ubi8-minimal:8.2-349
+                        value: registry.access.redhat.com/ubi8/ubi-minimal:8.2-349
                       - name: RELATED_IMAGE_postgres
                         value: centos/postgresql-96-centos7:9.6
                       - name: RELATED_IMAGE_keycloak
@@ -435,4 +435,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.20.0-11.nightly
+  version: 7.20.0-12.nightly

--- a/deploy/operator-local.yaml
+++ b/deploy/operator-local.yaml
@@ -54,7 +54,7 @@ spec:
             - name: RELATED_IMAGE_che_tls_secrets_creation_job
               value: quay.io/eclipse/che-tls-secret-creator:alpine-d1ed4ad
             - name: RELATED_IMAGE_pvc_jobs
-              value: registry.access.redhat.com/ubi8-minimal:8.2-349
+              value: registry.redhat.io/ubi8/ubi-minimal:8.2-349
             - name: RELATED_IMAGE_postgres
               value: centos/postgresql-96-centos7:9.6
             - name: RELATED_IMAGE_keycloak

--- a/deploy/operator-local.yaml
+++ b/deploy/operator-local.yaml
@@ -54,7 +54,7 @@ spec:
             - name: RELATED_IMAGE_che_tls_secrets_creation_job
               value: quay.io/eclipse/che-tls-secret-creator:alpine-d1ed4ad
             - name: RELATED_IMAGE_pvc_jobs
-              value: registry.redhat.io/ubi8/ubi-minimal:8.2-349
+              value: registry.access.redhat.com/ubi8/ubi-minimal:8.2-349
             - name: RELATED_IMAGE_postgres
               value: centos/postgresql-96-centos7:9.6
             - name: RELATED_IMAGE_keycloak

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -53,7 +53,7 @@ spec:
             - name: RELATED_IMAGE_che_tls_secrets_creation_job
               value: quay.io/eclipse/che-tls-secret-creator:alpine-d1ed4ad
             - name: RELATED_IMAGE_pvc_jobs
-              value: registry.redhat.io/ubi8/ubi-minimal:8.2-349
+              value: registry.access.redhat.com/ubi8/ubi-minimal:8.2-349
             - name: RELATED_IMAGE_postgres
               value: centos/postgresql-96-centos7:9.6
             - name: RELATED_IMAGE_keycloak

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -53,7 +53,7 @@ spec:
             - name: RELATED_IMAGE_che_tls_secrets_creation_job
               value: quay.io/eclipse/che-tls-secret-creator:alpine-d1ed4ad
             - name: RELATED_IMAGE_pvc_jobs
-              value: registry.access.redhat.com/ubi8-minimal:8.2-349
+              value: registry.redhat.io/ubi8/ubi-minimal:8.2-349
             - name: RELATED_IMAGE_postgres
               value: centos/postgresql-96-centos7:9.6
             - name: RELATED_IMAGE_keycloak

--- a/olm/update-nightly-bundle.sh
+++ b/olm/update-nightly-bundle.sh
@@ -49,9 +49,9 @@ ROOT_PROJECT_DIR=$(dirname "${BASE_DIR}")
 TAG=$1
 source ${BASE_DIR}/check-yq.sh
 
-ubiMinimal8Version=$(skopeo inspect docker://registry.access.redhat.com/ubi8-minimal:latest | jq -r '.Labels.version')
-ubiMinimal8Release=$(skopeo inspect docker://registry.access.redhat.com/ubi8-minimal:latest | jq -r '.Labels.release')
-UBI8_MINIMAL_IMAGE="registry.access.redhat.com/ubi8-minimal:"$ubiMinimal8Version"-"$ubiMinimal8Release
+ubiMinimal8Version=$(skopeo inspect docker://registry.redhat.io/ubi8/ubi-minimal:latest | jq -r '.Labels.version')
+ubiMinimal8Release=$(skopeo inspect docker://registry.redhat.io/ubi8/ubi-minimal:latest | jq -r '.Labels.release')
+UBI8_MINIMAL_IMAGE="registry.redhat.io/ubi8/ubi-minimal:"$ubiMinimal8Version"-"$ubiMinimal8Release
 skopeo inspect docker://$UBI8_MINIMAL_IMAGE > /dev/null
 wget https://raw.githubusercontent.com/eclipse/che/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties -q -O /tmp/che.properties
 PLUGIN_BROKER_METADATA_IMAGE_RELEASE=$(cat /tmp/che.properties| grep "che.workspace.plugin_broker.metadata.image" | cut -d = -f2)
@@ -75,7 +75,7 @@ yq -ryY "( .spec.template.spec.containers[] | select(.name == \"che-operator\").
 mv "${NEW_OPERATOR_LOCAL_YAML}" "${OPERATOR_LOCAL_YAML}"
 
 DOCKERFILE=${BASE_DIR}/../Dockerfile
-sed -i 's|registry.access.redhat.com/ubi8-minimal:.*|'${UBI8_MINIMAL_IMAGE}'|g' $DOCKERFILE
+sed -i 's|registry.redhat.io/ubi8/ubi-minimal:.*|'${UBI8_MINIMAL_IMAGE}'|g' $DOCKERFILE
 
 if [ -z "${NO_INCREMENT}" ]; then
   source "${BASE_DIR}/incrementNightlyBundles.sh"

--- a/olm/update-nightly-bundle.sh
+++ b/olm/update-nightly-bundle.sh
@@ -49,9 +49,9 @@ ROOT_PROJECT_DIR=$(dirname "${BASE_DIR}")
 TAG=$1
 source ${BASE_DIR}/check-yq.sh
 
-ubiMinimal8Version=$(skopeo inspect docker://registry.redhat.io/ubi8/ubi-minimal:latest | jq -r '.Labels.version')
-ubiMinimal8Release=$(skopeo inspect docker://registry.redhat.io/ubi8/ubi-minimal:latest | jq -r '.Labels.release')
-UBI8_MINIMAL_IMAGE="registry.redhat.io/ubi8/ubi-minimal:"$ubiMinimal8Version"-"$ubiMinimal8Release
+ubiMinimal8Version=$(skopeo inspect docker://registry.access.redhat.com/ubi8/ubi-minimal:latest | jq -r '.Labels.version')
+ubiMinimal8Release=$(skopeo inspect docker://registry.access.redhat.com/ubi8/ubi-minimal:latest | jq -r '.Labels.release')
+UBI8_MINIMAL_IMAGE="registry.access.redhat.com/ubi8/ubi-minimal:"$ubiMinimal8Version"-"$ubiMinimal8Release
 skopeo inspect docker://$UBI8_MINIMAL_IMAGE > /dev/null
 wget https://raw.githubusercontent.com/eclipse/che/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties -q -O /tmp/che.properties
 PLUGIN_BROKER_METADATA_IMAGE_RELEASE=$(cat /tmp/che.properties| grep "che.workspace.plugin_broker.metadata.image" | cut -d = -f2)
@@ -75,7 +75,7 @@ yq -ryY "( .spec.template.spec.containers[] | select(.name == \"che-operator\").
 mv "${NEW_OPERATOR_LOCAL_YAML}" "${OPERATOR_LOCAL_YAML}"
 
 DOCKERFILE=${BASE_DIR}/../Dockerfile
-sed -i 's|registry.redhat.io/ubi8/ubi-minimal:.*|'${UBI8_MINIMAL_IMAGE}'|g' $DOCKERFILE
+sed -i 's|registry.access.redhat.com/ubi8/ubi-minimal:.*|'${UBI8_MINIMAL_IMAGE}'|g' $DOCKERFILE
 
 if [ -z "${NO_INCREMENT}" ]; then
   source "${BASE_DIR}/incrementNightlyBundles.sh"

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -89,7 +89,7 @@ const (
 	// from Upstream 7.0.0 GA to the next version
 	// That fixed bug https://github.com/eclipse/che/issues/13714
 	OldDefaultKeycloakUpstreamImageToDetect = "eclipse/che-keycloak:7.0.0"
-	OldDefaultPvcJobsUpstreamImageToDetect  = "registry.access.redhat.com/ubi8-minimal:8.0-127"
+	OldDefaultPvcJobsUpstreamImageToDetect  = "registry.redhat.io/ubi8/ubi-minimal:8.0-127"
 	OldDefaultPostgresUpstreamImageToDetect = "centos/postgresql-96-centos7:9.6"
 
 	OldDefaultCodeReadyServerImageRepo = "registry.redhat.io/codeready-workspaces/server-rhel8"

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -89,7 +89,7 @@ const (
 	// from Upstream 7.0.0 GA to the next version
 	// That fixed bug https://github.com/eclipse/che/issues/13714
 	OldDefaultKeycloakUpstreamImageToDetect = "eclipse/che-keycloak:7.0.0"
-	OldDefaultPvcJobsUpstreamImageToDetect  = "registry.redhat.io/ubi8/ubi-minimal:8.0-127"
+	OldDefaultPvcJobsUpstreamImageToDetect  = "registry.access.redhat.com/ubi8/ubi-minimal:8.0-127"
 	OldDefaultPostgresUpstreamImageToDetect = "centos/postgresql-96-centos7:9.6"
 
 	OldDefaultCodeReadyServerImageRepo = "registry.redhat.io/codeready-workspaces/server-rhel8"


### PR DESCRIPTION
CRW-1254 can we use the standard, non-deprecated registry registry.redhat.io instead of registry.access.redhat.com for ubi minimal images? turns out NO, because no one wants to set up authentication from GH actions.

But we should use the safer path /ubi8/ubi-minimal vs. /ubi8-minimal so that OCP 4.x airgap mirroring works

Change-Id: I04112ce8cf9a3311872e7fb295fd742d75055d06
Signed-off-by: nickboldt <nboldt@redhat.com>