### PR TITLE
Automatically propagate ca-certs configmap content into server and identity provider

### DIFF
--- a/pkg/controller/che/get.go
+++ b/pkg/controller/che/get.go
@@ -18,7 +18,6 @@ import (
 	oauth "github.com/openshift/api/oauth/v1"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -27,17 +26,6 @@ func (r *ReconcileChe) GetEffectiveDeployment(instance *orgv1.CheCluster, name s
 	deployment = &appsv1.Deployment{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: instance.Namespace}, deployment)
 	return deployment, err
-}
-
-func (r *ReconcileChe) GetEffectiveConfigMap(instance *orgv1.CheCluster, name string) (configMap *corev1.ConfigMap) {
-	configMap = &corev1.ConfigMap{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: instance.Namespace}, configMap)
-	if err != nil {
-		logrus.Errorf("Failed to get %s config map: %s", name, err)
-		return nil
-	}
-	return configMap
-
 }
 
 func (r *ReconcileChe) GetCR(request reconcile.Request) (instance *orgv1.CheCluster, err error) {

--- a/pkg/deploy/identity-provider/deployment_keycloak.go
+++ b/pkg/deploy/identity-provider/deployment_keycloak.go
@@ -12,12 +12,14 @@
 package identity_provider
 
 import (
+	"github.com/eclipse/che-operator/pkg/deploy/server"
 	"context"
-	"github.com/eclipse/che-operator/pkg/deploy"
-	"github.com/eclipse/che-operator/pkg/deploy/postgres"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/eclipse/che-operator/pkg/deploy"
+	"github.com/eclipse/che-operator/pkg/deploy/postgres"
 
 	orgv1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
 	"github.com/eclipse/che-operator/pkg/util"
@@ -101,6 +103,7 @@ func getSpecKeycloakDeployment(
 		}
 	}
 
+	cmResourceVersions := server.GetTrustStoreConfigMapVersion(deployContext)
 	terminationGracePeriodSeconds := int64(30)
 	cheCertSecretVersion := getSecretResourceVersion("self-signed-certificate", deployContext.CheCluster.Namespace, deployContext.ClusterAPI)
 	openshiftApiCertSecretVersion := getSecretResourceVersion("openshift-api-crt", deployContext.CheCluster.Namespace, deployContext.ClusterAPI)
@@ -221,6 +224,10 @@ func getSpecKeycloakDeployment(
 	}
 
 	keycloakEnv := []corev1.EnvVar{
+		{
+			Name:  "CM_REVISION",
+			Value: cmResourceVersions,
+		},
 		{
 			Name:  "PROXY_ADDRESS_FORWARDING",
 			Value: "true",
@@ -348,6 +355,10 @@ func getSpecKeycloakDeployment(
 
 	if cheFlavor == "codeready" {
 		keycloakEnv = []corev1.EnvVar{
+			{
+				Name:  "CM_REVISION",
+				Value: cmResourceVersions,
+			},
 			{
 				Name:  "PROXY_ADDRESS_FORWARDING",
 				Value: "true",

--- a/pkg/deploy/identity-provider/identity_provider.go
+++ b/pkg/deploy/identity-provider/identity_provider.go
@@ -31,8 +31,14 @@ const (
 
 // SyncIdentityProviderToCluster instantiates the identity provider (Keycloak) in the cluster. Returns true if
 // the provisioning is complete, false if requeue of the reconcile request is needed.
-func SyncIdentityProviderToCluster(deployContext *deploy.DeployContext, cheHost string, protocol string, cheFlavor string) (bool, error) {
+func SyncIdentityProviderToCluster(deployContext *deploy.DeployContext) (bool, error) {
 	instance := deployContext.CheCluster
+	cheHost := instance.Spec.Server.CheHost
+	protocol := "http"
+	if instance.Spec.Server.TlsSupport {
+		protocol = "https"
+	}
+	cheFlavor := deploy.DefaultCheFlavor(instance)
 	cheMultiUser := deploy.GetCheMultiUser(instance)
 	tests := util.IsTestMode()
 	isOpenShift := util.IsOpenShift

--- a/pkg/deploy/server/che_configmap.go
+++ b/pkg/deploy/server/che_configmap.go
@@ -271,3 +271,11 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 	addMap(cheEnv, deployContext.CheCluster.Spec.Server.CustomCheProperties)
 	return cheEnv, nil
 }
+
+func GetCheConfigMapVersion(deployContext *deploy.DeployContext) string {
+	cheConfigMap, _ := deploy.GetClusterConfigMap("che", deployContext.CheCluster.Namespace, deployContext.ClusterAPI.Client)
+	if cheConfigMap != nil {
+		return cheConfigMap.ResourceVersion
+	}
+	return ""
+}

--- a/pkg/deploy/server/configmap_cert.go
+++ b/pkg/deploy/server/configmap_cert.go
@@ -13,6 +13,7 @@ package server
 
 import (
 	"context"
+
 	"github.com/eclipse/che-operator/pkg/deploy"
 
 	"github.com/sirupsen/logrus"
@@ -52,4 +53,15 @@ func SyncTrustStoreConfigMapToCluster(deployContext *deploy.DeployContext) (*cor
 	}
 
 	return clusterConfigMap, nil
+}
+
+func GetTrustStoreConfigMapVersion(deployContext *deploy.DeployContext) string {
+	if deployContext.CheCluster.Spec.Server.ServerTrustStoreConfigMapName != "" {
+		trustStoreConfigMap, _ := deploy.GetClusterConfigMap(deployContext.CheCluster.Spec.Server.ServerTrustStoreConfigMapName, deployContext.CheCluster.Namespace, deployContext.ClusterAPI.Client)
+		if trustStoreConfigMap != nil {
+			return trustStoreConfigMap.ResourceVersion
+		}
+	}
+
+	return ""
 }

--- a/pkg/deploy/server/deployment_che.go
+++ b/pkg/deploy/server/deployment_che.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func SyncCheDeploymentToCluster(deployContext *deploy.DeployContext, cmResourceVersion string) deploy.DeploymentProvisioningStatus {
+func SyncCheDeploymentToCluster(deployContext *deploy.DeployContext) deploy.DeploymentProvisioningStatus {
 	clusterDeployment, err := deploy.GetClusterDeployment(deploy.DefaultCheFlavor(deployContext.CheCluster), deployContext.CheCluster.Namespace, deployContext.ClusterAPI.Client)
 	if err != nil {
 		return deploy.DeploymentProvisioningStatus{
@@ -35,7 +35,7 @@ func SyncCheDeploymentToCluster(deployContext *deploy.DeployContext, cmResourceV
 		}
 	}
 
-	specDeployment, err := getSpecCheDeployment(deployContext, cmResourceVersion)
+	specDeployment, err := getSpecCheDeployment(deployContext)
 	if err != nil {
 		return deploy.DeploymentProvisioningStatus{
 			ProvisioningStatus: deploy.ProvisioningStatus{Err: err},
@@ -45,7 +45,7 @@ func SyncCheDeploymentToCluster(deployContext *deploy.DeployContext, cmResourceV
 	return deploy.SyncDeploymentToCluster(deployContext, specDeployment, clusterDeployment, nil, nil)
 }
 
-func getSpecCheDeployment(deployContext *deploy.DeployContext, cmResourceVersion string) (*appsv1.Deployment, error) {
+func getSpecCheDeployment(deployContext *deploy.DeployContext) (*appsv1.Deployment, error) {
 	isOpenShift, _, err := util.DetectOpenShift()
 	if err != nil {
 		return nil, err
@@ -55,6 +55,9 @@ func getSpecCheDeployment(deployContext *deploy.DeployContext, cmResourceVersion
 	if err != nil {
 		return nil, err
 	}
+
+	cmResourceVersions := GetCheConfigMapVersion(deployContext)
+	cmResourceVersions += "," + GetTrustStoreConfigMapVersion(deployContext)
 
 	terminationGracePeriodSeconds := int64(30)
 	cheFlavor := deploy.DefaultCheFlavor(deployContext.CheCluster)
@@ -175,7 +178,7 @@ func getSpecCheDeployment(deployContext *deploy.DeployContext, cmResourceVersion
 	cheEnv = append(cheEnv,
 		corev1.EnvVar{
 			Name:  "CM_REVISION",
-			Value: cmResourceVersion,
+			Value: cmResourceVersions,
 		},
 		corev1.EnvVar{
 			Name: "KUBERNETES_NAMESPACE",


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

Back port: https://github.com/eclipse/che-operator/pull/487