### PR TITLE
Implement ability to use default ingress TLS certificate

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -136,8 +136,9 @@ spec:
     # Can be multi-host (host is explicitly provided in ingress, <ingress-name>-<namespace>.<global-ingress-domain>),
     # single-host (host is provided, path based rules, <ingress-domain>/path) and default-host *(no host is provided, path based rules)
     ingressStrategy: ''
-    # secret name used for tls termination
-    tlsSecretName: ''
+    # Secret name used for tls termination.
+    # If the field is empty string, then default cluster certificate will be used.
+    tlsSecretName: 'che-tls'
     # FSGroup the Che POD and Workspace pod containers should run in
     securityContextFsGroup: ''
     # User the Che POD and Workspace pod containers should run as

--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -272,8 +272,8 @@ spec:
                 tlsSecretName:
                   description: Name of a secret that will be used to setup ingress
                     TLS termination if TLS is enabled. If the field is empty string,
-                    then default cluster certificate will be used.
-                    See also the `tlsSupport` field.
+                    then default cluster certificate will be used. See also the `tlsSupport`
+                    field.
                   type: string
               type: object
             metrics:

--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -271,7 +271,9 @@ spec:
                   type: string
                 tlsSecretName:
                   description: Name of a secret that will be used to setup ingress
-                    TLS termination if TLS is enabled. See also the `tlsSupport` field.
+                    TLS termination if TLS is enabled. If the field is empty string,
+                    then default cluster certificate will be used.
+                    See also the `tlsSupport` field.
                   type: string
               type: object
             metrics:

--- a/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -17,8 +17,8 @@ metadata:
               },
              "server": {
                 "cheImageTag": "nightly",
-                "devfileRegistryImage": "",
-                "pluginRegistryImage": "",
+                "devfileRegistryImage": "quay.io/eclipse/che-devfile-registry:nightly",
+                "pluginRegistryImage": "quay.io/eclipse/che-plugin-registry:nightly",
                 "tlsSupport": true,
                 "selfSignedCert": false
              },
@@ -31,7 +31,7 @@ metadata:
                 "chePostgresDb": ""
              },
              "auth": {
-                "identityProviderImage": "",
+                "identityProviderImage": "quay.io/eclipse/che-keycloak:nightly",
                 "externalIdentityProvider": false,
                 "identityProviderURL": "",
                 "identityProviderRealm": "",

--- a/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -13,12 +13,12 @@ metadata:
           "spec": {
             "k8s": {
                 "ingressDomain": "",
-                "tlsSecretName": ""
+                "tlsSecretName": "che-tls"
               },
              "server": {
                 "cheImageTag": "nightly",
-                "devfileRegistryImage": "quay.io/eclipse/che-devfile-registry:nightly",
-                "pluginRegistryImage": "quay.io/eclipse/che-plugin-registry:nightly",
+                "devfileRegistryImage": "",
+                "pluginRegistryImage": "",
                 "tlsSupport": true,
                 "selfSignedCert": false
              },
@@ -31,7 +31,7 @@ metadata:
                 "chePostgresDb": ""
              },
              "auth": {
-                "identityProviderImage": "quay.io/eclipse/che-keycloak:nightly",
+                "identityProviderImage": "",
                 "externalIdentityProvider": false,
                 "identityProviderURL": "",
                 "identityProviderRealm": "",

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -480,6 +480,7 @@ type CheClusterSpecK8SOnly struct {
 	// +optional
 	IngressClass string `json:"ingressClass,omitempty"`
 	// Name of a secret that will be used to setup ingress TLS termination if TLS is enabled.
+	// If the field is empty string, then default cluster certificate will be used.
 	// See also the `tlsSupport` field.
 	// +optional
 	TlsSecretName string `json:"tlsSecretName,omitempty"`

--- a/pkg/apis/org/v1/zz_generated.openapi.go
+++ b/pkg/apis/org/v1/zz_generated.openapi.go
@@ -352,7 +352,7 @@ func schema_pkg_apis_org_v1_CheClusterSpecK8SOnly(ref common.ReferenceCallback) 
 					},
 					"tlsSecretName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name of a secret that will be used to setup ingress TLS termination if TLS is enabled. See also the `tlsSupport` field.",
+							Description: "Name of a secret that will be used to setup ingress TLS termination if TLS is enabled. If the field is empty string, then default cluster certificate will be used. See also the `tlsSupport` field.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/deploy/ingress.go
+++ b/pkg/deploy/ingress.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/eclipse/che-operator/pkg/util"
 	"github.com/google/go-cmp/cmp"
@@ -44,12 +45,12 @@ func SyncIngressToCluster(
 	servicePort int,
 	additionalLabels string) (*v1beta1.Ingress, error) {
 
-	specIngress, err := getSpecIngress(deployContext, name, host, serviceName, servicePort, additionalLabels)
+	specIngress, err := GetSpecIngress(deployContext, name, host, serviceName, servicePort, additionalLabels)
 	if err != nil {
 		return nil, err
 	}
 
-	clusterIngress, err := getClusterIngress(specIngress.Name, specIngress.Namespace, deployContext.ClusterAPI.Client)
+	clusterIngress, err := GetClusterIngress(specIngress.Name, specIngress.Namespace, deployContext.ClusterAPI.Client)
 	if err != nil {
 		return nil, err
 	}
@@ -77,8 +78,9 @@ func SyncIngressToCluster(
 	return clusterIngress, nil
 }
 
+// DeleteIngressIfExists removes specified ingress if any
 func DeleteIngressIfExists(name string, deployContext *DeployContext) error {
-	ingress, err := getClusterIngress(name, deployContext.CheCluster.Namespace, deployContext.ClusterAPI.Client)
+	ingress, err := GetClusterIngress(name, deployContext.CheCluster.Namespace, deployContext.ClusterAPI.Client)
 	if err != nil {
 		return err
 	}
@@ -93,7 +95,8 @@ func DeleteIngressIfExists(name string, deployContext *DeployContext) error {
 	return nil
 }
 
-func getClusterIngress(name string, namespace string, client runtimeClient.Client) (*v1beta1.Ingress, error) {
+// GetClusterIngress return actual ingress config by provided name and namespace
+func GetClusterIngress(name string, namespace string, client runtimeClient.Client) (*v1beta1.Ingress, error) {
 	ingress := &v1beta1.Ingress{}
 	namespacedName := types.NamespacedName{
 		Namespace: namespace,
@@ -109,7 +112,8 @@ func getClusterIngress(name string, namespace string, client runtimeClient.Clien
 	return ingress, nil
 }
 
-func getSpecIngress(
+// GetSpecIngress returns expected ingress config for given parameters
+func GetSpecIngress(
 	deployContext *DeployContext,
 	name string,
 	host string,
@@ -132,10 +136,8 @@ func getSpecIngress(
 		}
 	}
 
-	tls := "false"
-	tlsSecretName := util.GetValue(deployContext.CheCluster.Spec.K8s.TlsSecretName, "che-tls")
+	tlsSecretName := util.GetValue(deployContext.CheCluster.Spec.K8s.TlsSecretName, "")
 	if tlsSupport {
-		tls = "true"
 		if name == DefaultCheFlavor(deployContext.CheCluster) && deployContext.CheCluster.Spec.Server.CheHostTLSSecret != "" {
 			tlsSecretName = deployContext.CheCluster.Spec.Server.CheHostTLSSecret
 		}
@@ -157,7 +159,7 @@ func getSpecIngress(
 		"kubernetes.io/ingress.class":                       ingressClass,
 		"nginx.ingress.kubernetes.io/proxy-read-timeout":    "3600",
 		"nginx.ingress.kubernetes.io/proxy-connect-timeout": "3600",
-		"nginx.ingress.kubernetes.io/ssl-redirect":          tls,
+		"nginx.ingress.kubernetes.io/ssl-redirect":          strconv.FormatBool(tlsSupport),
 	}
 	if ingressStrategy != "multi-host" && (name == DevfileRegistry || name == PluginRegistry) {
 		annotations["nginx.ingress.kubernetes.io/rewrite-target"] = "/$1"
@@ -180,7 +182,6 @@ func getSpecIngress(
 					Host: host,
 					IngressRuleValue: v1beta1.IngressRuleValue{
 						HTTP: &v1beta1.HTTPIngressRuleValue{
-
 							Paths: []v1beta1.HTTPIngressPath{
 								{
 									Backend: v1beta1.IngressBackend{

--- a/pkg/deploy/ingress.go
+++ b/pkg/deploy/ingress.go
@@ -95,7 +95,7 @@ func DeleteIngressIfExists(name string, deployContext *DeployContext) error {
 	return nil
 }
 
-// GetClusterIngress return actual ingress config by provided name and namespace
+// GetClusterIngress returns actual ingress config by provided name and namespace
 func GetClusterIngress(name string, namespace string, client runtimeClient.Client) (*v1beta1.Ingress, error) {
 	ingress := &v1beta1.Ingress{}
 	namespacedName := types.NamespacedName{

--- a/pkg/deploy/secret.go
+++ b/pkg/deploy/secret.go
@@ -112,7 +112,7 @@ func GetSpecSecret(deployContext *DeployContext, name string, data map[string][]
 	return secret, nil
 }
 
-// CreateTLSSecretFromEndpoint creates TLS secret with given name which contains certificates obtained from give url.
+// CreateTLSSecretFromEndpoint creates TLS secret with given name which contains certificates obtained from the given url.
 // If the url is empty string, then cluster default certificate will be obtained.
 // Does nothing if secret with given name already exists.
 func CreateTLSSecretFromEndpoint(deployContext *DeployContext, url string, name string) (err error) {

--- a/pkg/deploy/secret.go
+++ b/pkg/deploy/secret.go
@@ -112,10 +112,10 @@ func GetSpecSecret(deployContext *DeployContext, name string, data map[string][]
 	return secret, nil
 }
 
-// CreateTLSSecretFromRoute creates TLS secret with given name which contains certificates obtained from give url.
-// If the url is empty string, then router certificate will be obtained.
-// Works only on Openshift family infrastructures.
-func CreateTLSSecretFromRoute(deployContext *DeployContext, url string, name string) (err error) {
+// CreateTLSSecretFromEndpoint creates TLS secret with given name which contains certificates obtained from give url.
+// If the url is empty string, then cluster default certificate will be obtained.
+// Does nothing if secret with given name already exists.
+func CreateTLSSecretFromEndpoint(deployContext *DeployContext, url string, name string) (err error) {
 	secret := &corev1.Secret{}
 	if err := deployContext.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: deployContext.CheCluster.Namespace}, secret); err != nil && errors.IsNotFound(err) {
 		crtBytes, err := GetEndpointTLSCrtBytes(deployContext, url)

--- a/pkg/deploy/server/che_configmap.go
+++ b/pkg/deploy/server/che_configmap.go
@@ -149,9 +149,6 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 
 	ingressDomain := deployContext.CheCluster.Spec.K8s.IngressDomain
 	tlsSecretName := deployContext.CheCluster.Spec.K8s.TlsSecretName
-	if tlsSupport && tlsSecretName == "" {
-		tlsSecretName = "che-tls"
-	}
 	securityContextFsGroup := util.GetValue(deployContext.CheCluster.Spec.K8s.SecurityContextFsGroup, deploy.DefaultSecurityContextFsGroup)
 	securityContextRunAsUser := util.GetValue(deployContext.CheCluster.Spec.K8s.SecurityContextRunAsUser, deploy.DefaultSecurityContextRunAsUser)
 	pvcStrategy := util.GetValue(deployContext.CheCluster.Spec.Storage.PvcStrategy, deploy.DefaultPvcStrategy)

--- a/pkg/deploy/tls.go
+++ b/pkg/deploy/tls.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -60,99 +61,141 @@ func IsSelfSignedCertificateUsed(deployContext *DeployContext) (bool, error) {
 		return false, err
 	}
 
-	if util.IsOpenShift {
-		// Get router TLS certificates chain
-		peerCertificates, err := GetEndpointTLSCrtChain(deployContext, "")
-		if err != nil {
-			return false, err
-		}
+	if !util.IsOpenShift {
+		// Handle custom tls secret for Che ingresses
+		cheTLSSecretName := deployContext.CheCluster.Spec.K8s.TlsSecretName
+		if cheTLSSecretName != "" {
+			// The secret is specified in CR
+			cheTLSSecret := &corev1.Secret{}
+			err = deployContext.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Namespace: deployContext.CheCluster.Namespace, Name: cheTLSSecretName}, cheTLSSecret)
+			if err != nil {
+				if !errors.IsNotFound(err) {
+					// Failed to get secret, return error to restart reconcile loop.
+					return false, err
+				}
 
-		// Check the chain if ti contains self-signed CA certificate
-		for _, cert := range peerCertificates {
-			if cert.Subject.String() == cert.Issuer.String() {
-				// Self-signed CA certificate is found in the chain
+				// Both secrets (che-tls and self-signed-certificate) are missing which means that we should generate them (i.e. use self-signed certificate).
 				return true, nil
 			}
+			// TLS secret found, consider it as commonly trusted.
+			return false, nil
 		}
-		// The chain doesn't contain self-signed certificate
-		return false, nil
+
+		// Empty secret name means using of default ingress certificate.
+		// Retrieve the info about certificate chain from test ingress below.
 	}
 
-	// For Kubernetes, check che-tls secret.
-
-	cheTLSSecretName := deployContext.CheCluster.Spec.K8s.TlsSecretName
-	if len(cheTLSSecretName) < 1 {
-		cheTLSSecretName = DefaultCheTLSSecretName
-	}
-
-	cheTLSSecret := &corev1.Secret{}
-	err = deployContext.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Namespace: deployContext.CheCluster.Namespace, Name: cheTLSSecretName}, cheTLSSecret)
+	// Get route/ingress TLS certificates chain
+	peerCertificates, err := GetEndpointTLSCrtChain(deployContext, "")
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			// Failed to get secret, return error to restart reconcile loop.
-			return false, err
-		}
-
-		// Both secrets (che-tls and self-signed-certificate) are missing which means that we should generate them (i.e. use self-signed certificate).
-		return true, nil
+		return false, err
 	}
-	// TLS secret found, consider it as commonly trusted.
+
+	// Check the chain if it contains self-signed CA certificate
+	for _, cert := range peerCertificates {
+		if cert.Subject.String() == cert.Issuer.String() {
+			// Self-signed CA certificate is found in the chain
+			return true, nil
+		}
+	}
+	// The chain doesn't contain self-signed certificate
 	return false, nil
 }
 
 // GetEndpointTLSCrtChain retrieves TLS certificates chain from given endpoint.
-// If endpoint is not specified, then a test route will be created and used to get router certificates.
+// If endpoint is not specified, then a test route/ingress will be created and used to get router certificates.
 func GetEndpointTLSCrtChain(deployContext *DeployContext, endpointURL string) ([]*x509.Certificate, error) {
 	if util.IsTestMode() {
 		return nil, stderrors.New("Not allowed for tests")
 	}
 
-	var isTestRoute bool = len(endpointURL) < 1
+	var useTestEndpoint bool = len(endpointURL) < 1
 	var requestURL string
-	if isTestRoute {
-		// Create test route to get certificates chain.
-		// Note, it is not possible to use SyncRouteToCluster here as it may cause infinite reconcile loop.
-		additionalLabels := deployContext.CheCluster.Spec.Server.CheServerRoute.Labels
-		routeSpec, err := GetSpecRoute(deployContext, "test", "", "test", 8080, additionalLabels)
-		if err != nil {
-			return nil, err
-		}
-		// Remove controller reference to prevent queueing new reconcile loop
-		routeSpec.SetOwnerReferences(nil)
-		// Create route manually
-		if err := deployContext.ClusterAPI.Client.Create(context.TODO(), routeSpec); err != nil {
-			if !errors.IsAlreadyExists(err) {
-				logrus.Errorf("Failed to create test route 'test': %s", err)
-				return nil, err
-			}
-		}
-
-		// Schedule test route cleanup after the job done.
-		defer func() {
-			if err := deployContext.ClusterAPI.Client.Delete(context.TODO(), routeSpec); err != nil {
-				logrus.Errorf("Failed to delete test route %s: %s", routeSpec.Name, err)
-			}
-		}()
-
-		// Wait till route is ready
-		var route *routev1.Route
-		for wait := true; wait; {
-			time.Sleep(time.Duration(1) * time.Second)
-			route, err = GetClusterRoute(routeSpec.Name, routeSpec.Namespace, deployContext.ClusterAPI.Client)
+	if useTestEndpoint {
+		if util.IsOpenShift {
+			// Create test route to get certificates chain.
+			// Note, it is not possible to use SyncRouteToCluster here as it may cause infinite reconcile loop.
+			additionalLabels := deployContext.CheCluster.Spec.Server.CheServerRoute.Labels
+			routeSpec, err := GetSpecRoute(deployContext, "test", "", "test", 8080, additionalLabels)
 			if err != nil {
 				return nil, err
 			}
-			wait = len(route.Spec.Host) == 0
-		}
+			// Remove controller reference to prevent queueing new reconcile loop
+			routeSpec.SetOwnerReferences(nil)
+			// Create route manually
+			if err := deployContext.ClusterAPI.Client.Create(context.TODO(), routeSpec); err != nil {
+				if !errors.IsAlreadyExists(err) {
+					logrus.Errorf("Failed to create test route 'test': %s", err)
+					return nil, err
+				}
+			}
 
-		requestURL = "https://" + route.Spec.Host
+			// Schedule test route cleanup after the job done.
+			defer func() {
+				if err := deployContext.ClusterAPI.Client.Delete(context.TODO(), routeSpec); err != nil {
+					logrus.Errorf("Failed to delete test route %s: %s", routeSpec.Name, err)
+				}
+			}()
+
+			// Wait till the route is ready
+			var route *routev1.Route
+			for wait := true; wait; {
+				time.Sleep(time.Duration(1) * time.Second)
+				route, err = GetClusterRoute(routeSpec.Name, routeSpec.Namespace, deployContext.ClusterAPI.Client)
+				if err != nil {
+					return nil, err
+				}
+				wait = len(route.Spec.Host) == 0
+			}
+
+			requestURL = "https://" + route.Spec.Host
+		} else {
+			// Kubernetes
+
+			// Create test ingress to get certificates chain.
+			// Note, it is not possible to use SyncIngressToCluster here as it may cause infinite reconcile loop.
+			additionalLabels := deployContext.CheCluster.Spec.Server.CheServerIngress.Labels
+			ingressSpec, err := GetSpecIngress(deployContext, "test", "", "test", 8080, additionalLabels)
+			if err != nil {
+				return nil, err
+			}
+			// Remove controller reference to prevent queueing new reconcile loop
+			ingressSpec.SetOwnerReferences(nil)
+			// Create ingress manually
+			if err := deployContext.ClusterAPI.Client.Create(context.TODO(), ingressSpec); err != nil {
+				if !errors.IsAlreadyExists(err) {
+					logrus.Errorf("Failed to create test ingress 'test': %s", err)
+					return nil, err
+				}
+			}
+
+			// Schedule test ingress cleanup after the job done.
+			defer func() {
+				if err := deployContext.ClusterAPI.Client.Delete(context.TODO(), ingressSpec); err != nil {
+					logrus.Errorf("Failed to delete test ingress %s: %s", ingressSpec.Name, err)
+				}
+			}()
+
+			// Wait till the ingress is ready
+			var ingress *v1beta1.Ingress
+			for wait := true; wait; {
+				time.Sleep(time.Duration(1) * time.Second)
+				ingress, err = GetClusterIngress(ingressSpec.Name, ingressSpec.Namespace, deployContext.ClusterAPI.Client)
+				if err != nil {
+					return nil, err
+				}
+				wait = len(ingress.Spec.Rules[0].Host) == 0
+			}
+
+			requestURL = "https://" + ingress.Spec.Rules[0].Host
+		}
 	} else {
 		requestURL = endpointURL
 	}
 
-	certificates, err := doRequestForTLSCrtChain(deployContext, requestURL, isTestRoute)
+	certificates, err := doRequestForTLSCrtChain(deployContext, requestURL, useTestEndpoint)
 	if err != nil {
-		if deployContext.Proxy.HttpProxy != "" && isTestRoute {
+		if deployContext.Proxy.HttpProxy != "" && useTestEndpoint {
 			// Fetching certificates from the test route without proxy failed. Probably non-proxy connections are blocked.
 			// Retrying with proxy configuration, however it might cause retreiving of wrong certificate in case of TLS interception by proxy.
 			logrus.Warn("Failed to get certificate chain of trust of the OpenShift Ingress bypassing the proxy")
@@ -188,7 +231,8 @@ func doRequestForTLSCrtChain(deployContext *DeployContext, requestURL string, sk
 	return resp.TLS.PeerCertificates, nil
 }
 
-// GetEndpointTLSCrtBytes creates a test TLS route and gets it to extract certificate chain
+// GetEndpointTLSCrtBytes extracts certificate chain from given endpoint.
+// Creates a test TLS route/ingress if enpoint url is empty.
 // There's an easier way which is to read tls secret in default (3.11) or openshift-ingress (4.0) namespace
 // which however requires extra privileges for operator service account
 func GetEndpointTLSCrtBytes(deployContext *DeployContext, endpointURL string) (certificates []byte, err error) {
@@ -380,19 +424,6 @@ func K8sHandleCheTLSSecrets(deployContext *DeployContext) (reconcile.Result, err
 
 	// TLS configuration is ok, go further in reconcile loop
 	return reconcile.Result{}, nil
-}
-
-// CheckAndUpdateK8sTLSConfiguration validates Che TLS configuration on Kubernetes infra.
-// If configuration is wrong it will guess most common use cases and will make changes in Che CR accordingly to the assumption.
-func CheckAndUpdateK8sTLSConfiguration(deployContext *DeployContext) error {
-	if deployContext.CheCluster.Spec.K8s.TlsSecretName == "" {
-		deployContext.CheCluster.Spec.K8s.TlsSecretName = DefaultCheTLSSecretName
-		if err := UpdateCheCRSpec(deployContext, "TlsSecretName", deployContext.CheCluster.Spec.K8s.TlsSecretName); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func isCheTLSSecretValid(cheTLSSecret *corev1.Secret) bool {

--- a/pkg/deploy/tls.go
+++ b/pkg/deploy/tls.go
@@ -232,7 +232,7 @@ func doRequestForTLSCrtChain(deployContext *DeployContext, requestURL string, sk
 }
 
 // GetEndpointTLSCrtBytes extracts certificate chain from given endpoint.
-// Creates a test TLS route/ingress if enpoint url is empty.
+// Creates a test TLS route/ingress if endpoint url is empty.
 // There's an easier way which is to read tls secret in default (3.11) or openshift-ingress (4.0) namespace
 // which however requires extra privileges for operator service account
 func GetEndpointTLSCrtBytes(deployContext *DeployContext, endpointURL string) (certificates []byte, err error) {


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do
Adds ability to tell Che operator to use default ingress TLS certificate to secure Che endpoints.
To use default ingress certificate, field `k8s.tlsSecretName` should be empty string or absent.

### Which isseus this PR fixes
https://github.com/eclipse/che/issues/18079

### How to test

1. Create a new Minikube instance.
2. Enable ingress addon: `minikube addons enable ingress`
3. Change the default ingress certificate

<details>
<summary>Automation script</summary>

```sh
#!/bin/bash

MINIKUBE_DOMAIN=$(minikube ip).nip.io

CA_CN='Custom Minikube CA'
CA_KEY_FILE='ca.key'
CA_CERT_FILE='ca.crt'

CN_SERVER='Minikube Ingress'
SERVER_KEY_FILE='domain.key'
SERVER_CERT_REQUEST_FILE='domain.csr'
SERVER_CERT_FILE='domain.crt'

CHAIN_FILE='chain.pem'

# Detect openssl configuration file
OPENSSL_CNF='/etc/pki/tls/openssl.cnf'
if [ ! -f $OPENSSL_CNF ]; then
    OPENSSL_CNF='/etc/ssl/openssl.cnf'
fi

DIR=/tmp/minikube-cert
rm -rf $DIR && mkdir $DIR && cd $DIR

# Generate private key for root CA
openssl genrsa -out $CA_KEY_FILE 4096

# Generate root CA certificate and sign it with previously generated key.
openssl req -batch -new -x509 -nodes -key $CA_KEY_FILE -sha256 -subj /CN="${CA_CN}" -days 1024 -reqexts SAN -extensions SAN -config <(cat ${OPENSSL_CNF} <(printf '[SAN]\nbasicConstraints=critical, CA:TRUE\nkeyUsage=keyCertSign, cRLSign, digitalSignature')) -outform PEM -out $CA_CERT_FILE

# Generate server prvate key
openssl genrsa -out $SERVER_KEY_FILE 2048

# Create certificate request for the ingress
openssl req --batch -new -sha256 -key $SERVER_KEY_FILE -subj "/CN=${CN_SERVER}" -reqexts SAN -config <(cat $OPENSSL_CNF <(printf "\n[SAN]\nsubjectAltName=DNS:${MINIKUBE_DOMAIN},DNS:*.${MINIKUBE_DOMAIN}\nbasicConstraints=critical, CA:FALSE\nkeyUsage=digitalSignature, keyEncipherment, keyAgreement, dataEncipherment\nextendedKeyUsage=serverAuth")) -outform PEM -out $SERVER_CERT_REQUEST_FILE

# Create certificate for ingress domain based on given certificate request.
openssl x509 -req -in $SERVER_CERT_REQUEST_FILE -CA $CA_CERT_FILE -CAkey $CA_KEY_FILE -CAcreateserial -days 365 -sha256 -extfile <(printf "subjectAltName=DNS:${MINIKUBE_DOMAIN},DNS:*.${MINIKUBE_DOMAIN}\nbasicConstraints=critical, CA:FALSE\nkeyUsage=digitalSignature, keyEncipherment, keyAgreement, dataEncipherment\nextendedKeyUsage=serverAuth") -outform PEM -out $SERVER_CERT_FILE

# Create certificate chain file
cat $SERVER_CERT_FILE $CA_CERT_FILE > $CHAIN_FILE

# Create secret
SECRET_NAME='new-ingress-tls'
kubectl create secret tls ${SECRET_NAME} --key ${SERVER_KEY_FILE} --cert ${CHAIN_FILE} --namespace kube-system

# Patch nginix ingress controller
kubectl patch deployment ingress-nginx-controller --namespace kube-system --type=json -p="[{\"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/args/-\", \"value\": \"--default-ssl-certificate=kube-system/${SECRET_NAME}\"}]"

echo "Minikube TLS certificate has been changed. New CA: ${DIR}/${CA_CERT_FILE}"

```

</details>

4. Deploy Eclipse Che with command: 
```
./run server:start --platform=minikube --installer=operator --che-operator-image=<image-built-from-this-PR> --che-operator-cr-patch-yaml default-secret-patch.yaml 
```

where `default-secret-patch.yaml` is:
```yaml
spec:
  k8s:
    tlsSecretName: ''
```
5. Check that everything works