### PR TITLE
Implement addition CA config maps merge and propagation to Che server

### DIFF
--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -1060,6 +1060,14 @@ func isTrustedBundleConfigMap(mgr manager.Manager, obj handler.MapObject) (bool,
 	if checlusters.Items[0].Spec.Server.ServerTrustStoreConfigMapName != obj.Meta.GetName() {
 		// No, it is not form CR
 		// Check for labels
+
+		// Check for part of Che label
+		if value, exists := obj.Meta.GetLabels()[deploy.PartOfCheLabelKey]; !exists || value != deploy.PartOfCheLabelValue {
+			// Labels do not match
+			return false, reconcile.Request{}
+		}
+
+		// Check for CA bundle label
 		if value, exists := obj.Meta.GetLabels()[deploy.CheCACertsConfigMapLabelKey]; !exists || value != deploy.CheCACertsConfigMapLabelValue {
 			// Labels do not match
 			return false, reconcile.Request{}

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -458,9 +458,14 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 	}
 
 	// Make sure that CA certificates from all marked config maps are merged into single config map to be propageted to Che components
-	_, err = deploy.SyncAdditionalCACertsConfigMapToCluster(instance, deployContext)
+	cm, err := deploy.SyncAdditionalCACertsConfigMapToCluster(instance, deployContext)
 	if err != nil {
 		logrus.Errorf("Error updating additional CA config map: %v", err)
+		return reconcile.Result{}, err
+	}
+	if cm == nil && !tests {
+		// Config map update is in progress
+		// Return and do not force reconcile. When update finishes it will trigger reconcile loop.
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/che/proxy.go
+++ b/pkg/controller/che/proxy.go
@@ -13,10 +13,10 @@ package che
 
 import (
 	"context"
-	"github.com/eclipse/che-operator/pkg/deploy/server"
 
 	orgv1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
 	"github.com/eclipse/che-operator/pkg/deploy"
+	"github.com/eclipse/che-operator/pkg/deploy/server"
 	"github.com/eclipse/che-operator/pkg/util"
 	configv1 "github.com/openshift/api/config/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -36,7 +36,7 @@ func (r *ReconcileChe) getProxyConfiguration(checluster *orgv1.CheCluster) (*dep
 
 		// If proxy configuration exists in CR then cluster wide proxy configuration is ignored
 		// otherwise cluster wide proxy configuration is used and non proxy hosts
-		// are merted with defined ones in CR
+		// are merged with defined ones in CR
 		if proxy.HttpProxy == "" && clusterProxy.Status.HTTPProxy != "" {
 			proxy, err = deploy.ReadClusterWideProxyConfiguration(clusterProxy, proxy.NoProxy)
 			if err != nil {

--- a/pkg/deploy/configmap.go
+++ b/pkg/deploy/configmap.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+// SyncConfigMapToCluster makes sure that given config map spec is actual
 func SyncConfigMapToCluster(deployContext *DeployContext, specConfigMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 	clusterConfigMap, err := GetClusterConfigMap(specConfigMap.Name, specConfigMap.Namespace, deployContext.ClusterAPI.Client)
 	if err != nil {
@@ -50,6 +51,7 @@ func SyncConfigMapToCluster(deployContext *DeployContext, specConfigMap *corev1.
 	return clusterConfigMap, nil
 }
 
+// GetSpecConfigMap returns config map spec template
 func GetSpecConfigMap(
 	deployContext *DeployContext,
 	name string,
@@ -79,6 +81,7 @@ func GetSpecConfigMap(
 	return configMap, nil
 }
 
+// GetClusterConfigMap reads config map from cluster
 func GetClusterConfigMap(name string, namespace string, client runtimeClient.Client) (*corev1.ConfigMap, error) {
 	configMap := &corev1.ConfigMap{}
 	namespacedName := types.NamespacedName{

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -14,10 +14,11 @@ package deploy
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/eclipse/che-operator/pkg/util"
 	"github.com/sirupsen/logrus"
@@ -97,6 +98,9 @@ const (
 	OldDefaultCodeReadyServerImageRepo = "registry.redhat.io/codeready-workspaces/server-rhel8"
 	OldDefaultCodeReadyServerImageTag  = "1.2"
 	OldCrwPluginRegistryUrl            = "https://che-plugin-registry.openshift.io"
+
+	PartOfCheLabelKey   = "app.kubernetes.io/part-of"
+	PartOfCheLabelValue = "che.eclipse.org"
 )
 
 func InitDefaults(defaultsPath string) {

--- a/pkg/deploy/identity-provider/deployment_keycloak.go
+++ b/pkg/deploy/identity-provider/deployment_keycloak.go
@@ -104,7 +104,7 @@ func getSpecKeycloakDeployment(
 		}
 	}
 
-	cmResourceVersions := server.GetTrustStoreConfigMapVersion(deployContext)
+	cmResourceVersions := deploy.GetAdditionalCACertsConfigMapVersion(deployContext)
 	terminationGracePeriodSeconds := int64(30)
 	cheCertSecretVersion := getSecretResourceVersion("self-signed-certificate", deployContext.CheCluster.Namespace, deployContext.ClusterAPI)
 	openshiftApiCertSecretVersion := getSecretResourceVersion("openshift-api-crt", deployContext.CheCluster.Namespace, deployContext.ClusterAPI)
@@ -134,14 +134,12 @@ func getSpecKeycloakDeployment(
 
 	customPublicCertsDir := "/public-certs"
 	customPublicCertsVolumeSource := corev1.VolumeSource{}
-	if deployContext.CheCluster.Spec.Server.ServerTrustStoreConfigMapName != "" {
-		customPublicCertsVolumeSource = corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: deployContext.CheCluster.Spec.Server.ServerTrustStoreConfigMapName,
-				},
+	customPublicCertsVolumeSource = corev1.VolumeSource{
+		ConfigMap: &corev1.ConfigMapVolumeSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: deploy.CheAllCACertsConfigMapName,
 			},
-		}
+		},
 	}
 	customPublicCertsVolume := corev1.Volume{
 		Name:         "che-public-certs",

--- a/pkg/deploy/identity-provider/deployment_keycloak.go
+++ b/pkg/deploy/identity-provider/deployment_keycloak.go
@@ -17,12 +17,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/eclipse/che-operator/pkg/deploy/server"
-
+	orgv1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
 	"github.com/eclipse/che-operator/pkg/deploy"
 	"github.com/eclipse/che-operator/pkg/deploy/postgres"
-
-	orgv1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
 	"github.com/eclipse/che-operator/pkg/util"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"

--- a/pkg/deploy/server/che_configmap.go
+++ b/pkg/deploy/server/che_configmap.go
@@ -213,7 +213,7 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 		CheServerSecureExposerJwtProxyImage:    deploy.DefaultCheServerSecureExposerJwtProxyImage(deployContext.CheCluster),
 		CheJGroupsKubernetesLabels:             cheLabels,
 		CheMetricsEnabled:                      cheMetrics,
-		CheTrustedCABundlesConfigMap:           deployContext.CheCluster.Spec.Server.ServerTrustStoreConfigMapName,
+		CheTrustedCABundlesConfigMap:           deploy.CheAllCACertsConfigMapName,
 		ServerStrategy:                         ingressStrategy,
 		WorkspaceExposure:                      workspaceExposure,
 		SingleHostGatewayConfigMapLabels:       singleHostGatewayConfigMapLabels,

--- a/pkg/deploy/server/configmap_cert.go
+++ b/pkg/deploy/server/configmap_cert.go
@@ -54,14 +54,3 @@ func SyncTrustStoreConfigMapToCluster(deployContext *deploy.DeployContext) (*cor
 
 	return clusterConfigMap, nil
 }
-
-func GetTrustStoreConfigMapVersion(deployContext *deploy.DeployContext) string {
-	if deployContext.CheCluster.Spec.Server.ServerTrustStoreConfigMapName != "" {
-		trustStoreConfigMap, _ := deploy.GetClusterConfigMap(deployContext.CheCluster.Spec.Server.ServerTrustStoreConfigMapName, deployContext.CheCluster.Namespace, deployContext.ClusterAPI.Client)
-		if trustStoreConfigMap != nil {
-			return trustStoreConfigMap.ResourceVersion
-		}
-	}
-
-	return ""
-}

--- a/pkg/deploy/server/deployment_che.go
+++ b/pkg/deploy/server/deployment_che.go
@@ -57,7 +57,7 @@ func getSpecCheDeployment(deployContext *deploy.DeployContext) (*appsv1.Deployme
 	}
 
 	cmResourceVersions := GetCheConfigMapVersion(deployContext)
-	cmResourceVersions += "," + GetTrustStoreConfigMapVersion(deployContext)
+	cmResourceVersions += "," + deploy.GetAdditionalCACertsConfigMapVersion(deployContext)
 
 	terminationGracePeriodSeconds := int64(30)
 	cheFlavor := deploy.DefaultCheFlavor(deployContext.CheCluster)
@@ -69,14 +69,12 @@ func getSpecCheDeployment(deployContext *deploy.DeployContext) (*appsv1.Deployme
 		Value: "",
 	}
 	customPublicCertsVolumeSource := corev1.VolumeSource{}
-	if deployContext.CheCluster.Spec.Server.ServerTrustStoreConfigMapName != "" {
-		customPublicCertsVolumeSource = corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: deployContext.CheCluster.Spec.Server.ServerTrustStoreConfigMapName,
-				},
+	customPublicCertsVolumeSource = corev1.VolumeSource{
+		ConfigMap: &corev1.ConfigMapVolumeSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: deploy.CheAllCACertsConfigMapName,
 			},
-		}
+		},
 	}
 	customPublicCertsVolume := corev1.Volume{
 		Name:         "che-public-certs",

--- a/pkg/deploy/tls.go
+++ b/pkg/deploy/tls.go
@@ -48,12 +48,12 @@ const (
 	CheTLSSelfSignedCertificateSecretName = "self-signed-certificate"
 	DefaultCheTLSSecretName               = "che-tls"
 
+	// CheCACertsConfigMapLabelKey is the label key which marks config map with additional CA certificates
+	CheCACertsConfigMapLabelKey = "app.kubernetes.io/component"
+	// CheCACertsConfigMapLabelKey is the label value which marks config map with additional CA certificates
+	CheCACertsConfigMapLabelValue = "ca-bundle"
 	// CheAllCACertsConfigMapName is the name of config map which contains all additional trusted by Che TLS CA certificates
 	CheAllCACertsConfigMapName = "che-ca-certs-merged"
-	// CheCACertsConfigMapLabelKey is the label key which marks config map with additional CA certificates
-	CheCACertsConfigMapLabelKey = "che-ca-certs"
-	// CheCACertsConfigMapLabelKey is the label value which marks config map with additional CA certificates
-	CheCACertsConfigMapLabelValue = "true"
 	// CheMergedCAConfigMapRevisionsLabelKey is label name which holds versions of included config maps in format: cm-name1=ver1,cm-name2=ver2
 	CheMergedCAConfigMapRevisionsLabelKey = "included-cm"
 
@@ -564,9 +564,10 @@ func SyncAdditionalCACertsConfigMapToCluster(cr *orgv1.CheCluster, deployContext
 func getCACertsConfigMaps(deployContext *DeployContext) ([]corev1.ConfigMap, error) {
 	CACertsConfigMapList := &corev1.ConfigMapList{}
 
-	labelSelectorRequirement, _ := labels.NewRequirement(CheCACertsConfigMapLabelKey, selection.Equals, []string{CheCACertsConfigMapLabelValue})
+	caBundleLabelSelectorRequirement, _ := labels.NewRequirement(CheCACertsConfigMapLabelKey, selection.Equals, []string{CheCACertsConfigMapLabelValue})
+	cheComponetLabelSelectorRequirement, _ := labels.NewRequirement("app.kubernetes.io/part-of", selection.Equals, []string{"che.eclipse.org"})
 	listOptions := &client.ListOptions{
-		LabelSelector: labels.NewSelector().Add(*labelSelectorRequirement),
+		LabelSelector: labels.NewSelector().Add(*cheComponetLabelSelectorRequirement).Add(*caBundleLabelSelectorRequirement),
 	}
 	if err := deployContext.ClusterAPI.Client.List(context.TODO(), CACertsConfigMapList, listOptions); err != nil {
 		return nil, err

--- a/pkg/deploy/tls.go
+++ b/pkg/deploy/tls.go
@@ -55,10 +55,12 @@ const (
 	// CheAllCACertsConfigMapName is the name of config map which contains all additional trusted by Che TLS CA certificates
 	CheAllCACertsConfigMapName = "che-ca-certs-merged"
 	// CheMergedCAConfigMapRevisionsLabelKey is label name which holds versions of included config maps in format: cm-name1=ver1,cm-name2=ver2
-	CheMergedCAConfigMapRevisionsLabelKey = "included-cm"
+	CheMergedCAConfigMapRevisionsLabelKey = "cm_revision"
 
 	// Local constants
+	// labelEqualSign consyant is used as a replacement for '=' symbol in labels because '=' is not allowed there
 	labelEqualSign = "-"
+	// labelCommaSign consyant is used as a replacement for ',' symbol in labels because ',' is not allowed there
 	labelCommaSign = "."
 )
 
@@ -549,7 +551,7 @@ func SyncAdditionalCACertsConfigMapToCluster(cr *orgv1.CheCluster, deployContext
 		return nil, err
 	}
 	mergedCAConfigMapSpec.ObjectMeta.Labels[CheMergedCAConfigMapRevisionsLabelKey] = revisions
-	mergedCAConfigMapSpec.ObjectMeta.Labels["warning"] = "do-not-edit-manually"
+	mergedCAConfigMapSpec.ObjectMeta.Labels[PartOfCheLabelKey] = PartOfCheLabelValue
 
 	logrus.Infof("Updating additional CA certs config map: %s", CheAllCACertsConfigMapName)
 	mergedCAConfigMap, err = SyncConfigMapToCluster(deployContext, mergedCAConfigMapSpec)
@@ -565,7 +567,7 @@ func getCACertsConfigMaps(deployContext *DeployContext) ([]corev1.ConfigMap, err
 	CACertsConfigMapList := &corev1.ConfigMapList{}
 
 	caBundleLabelSelectorRequirement, _ := labels.NewRequirement(CheCACertsConfigMapLabelKey, selection.Equals, []string{CheCACertsConfigMapLabelValue})
-	cheComponetLabelSelectorRequirement, _ := labels.NewRequirement("app.kubernetes.io/part-of", selection.Equals, []string{"che.eclipse.org"})
+	cheComponetLabelSelectorRequirement, _ := labels.NewRequirement(PartOfCheLabelKey, selection.Equals, []string{PartOfCheLabelValue})
 	listOptions := &client.ListOptions{
 		LabelSelector: labels.NewSelector().Add(*cheComponetLabelSelectorRequirement).Add(*caBundleLabelSelectorRequirement),
 	}


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
This PR merged all config maps with CA certificates that marked with `che-ca-certs:true` label into single config and then pass resulting config map to Che server.
`spec.server.serverTrustStoreConfigMapName` CR field is supported too and the config map, if any, added into resulting one as well.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17634

### How to test
1. Deploy Eclipse Che
2. Create a few config maps in `che` namespace with CA certs
3. Mark some of them with `che-ca-certs:true` label
4. Start a workspace, check `/public-certs` folder

To generate CA certs, one may use the following script:
```bash
#!/bin/bash

# CA certs generator

OPENSSL_CNF='/etc/pki/tls/openssl.cnf'
if [ ! -f $OPENSSL_CNF ]; then
    OPENSSL_CNF='/etc/ssl/openssl.cnf'
fi

for ((i=1;i<=5;i++)); do
  openssl genrsa -out ${i}.key 4096
  openssl req -batch -new -x509 -nodes -key ${i}.key -sha256 -subj /CN="TestCA${i}" -days 1024 -reqexts SAN -extensions SAN -config <(cat ${OPENSSL_CNF} <(printf '[SAN]\nbasicConstraints=critical, CA:TRUE\nkeyUsage=keyCertSign, cRLSign, digitalSignature')) -outform PEM -out ${i}.crt
done
```
Then create config maps:
```bash
kubectl create configmap ca1 --from-file=1.crt -n che
kubectl create configmap ca23 --from-file=2.crt --from-file=3.crt -n che
kubectl create configmap ca4 --from-file=4.crt -n che
kubectl create configmap ca5 --from-file=5.crt -n che
```
Finally, add the label:
```bash
kubectl label configmap ca1 app.kubernetes.io/part-of=che.eclipse.org -n che && kubectl label configmap ca1 app.kubernetes.io/component=ca-bundle -n che
kubectl label configmap ca23 app.kubernetes.io/part-of=che.eclipse.org -n che && kubectl label configmap ca23 app.kubernetes.io/component=ca-bundle -n che
```
and/or patch CR:
```yaml
spec:
  server:
    serverTrustStoreConfigMapName: ca5
```
It is expected, then certs from `ca1`, `ca23` and `ca5` will be propagated into a workspace under `/public-certs` directory. `ca4` should not be propagated.