### PR TITLE
assign che-namespace-editor to che ServiceAccout

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -27,6 +27,8 @@ spec:
     # defaults to `che`. When set to `codeready`, CodeReady Workspaces is deployed
     # the difference is in images, labels, exec commands
     cheFlavor: ''
+    # Comma separated list of ClusterRoles, that will be bound to Che Server's ServiceAccount.
+    cheClusterRoles: ''
     # specifies a custom cluster role to user for the Che workspaces
     # Uses the default roles if left blank.
     cheWorkspaceClusterRole: ''

--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -364,6 +364,10 @@ spec:
                         to organize and categorize (scope and select) objects.
                       type: string
                   type: object
+                cheClusterRoles:
+                  description: Comma separated list of ClusterRoles, that will be bound to
+                    Che Server's ServiceAccount.
+                  type: string
                 cheWorkspaceClusterRole:
                   description: Custom cluster role bound to the user for the Che workspaces.
                     The default roles are used if this is omitted or left blank.

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -579,6 +579,18 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 		}
 	}
 
+	cheNamespaceEditorClusterRoleName := instance.Namespace + "-che-namespace-editor"
+	cheNamespaceEditorClusterRoleBinding, err := deploy.SyncClusterRoleBindingToCluster(deployContext, "che-namespace-editor", "che", cheNamespaceEditorClusterRoleName)
+	if cheNamespaceEditorClusterRoleBinding == nil {
+		logrus.Info("Waiting on cluster role binding 'che-namespace-editor' to be created")
+		if err != nil {
+			logrus.Error(err)
+		}
+		if !tests {
+			return reconcile.Result{RequeueAfter: time.Second}, err
+		}
+	}
+
 	cheWSExecRoleBinding, err := deploy.SyncRoleBindingToCluster(deployContext, "che-workspace-exec", "che-workspace", "exec", "Role")
 	if cheWSExecRoleBinding == nil {
 		logrus.Info("Waiting on role binding 'che-workspace-exec' to be created")


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

TODO: take ClusterRoles from `server.cheClusterRoles` and assign them to che ServiceAccout

default - `che-namespace-editor` or empty?

fixes: https://github.com/eclipse/che/issues/18399