### PR TITLE
18292 - switch to use quay copies of...

### DIFF
--- a/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml
@@ -82,13 +82,13 @@ metadata:
     categories: Developer Tools
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2020-11-16T13:57:54Z"
+    createdAt: "2020-11-18T22:39:05Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-kubernetes.v7.22.0-31.nightly
+  name: eclipse-che-preview-kubernetes.v7.22.0-33.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -321,7 +321,7 @@ spec:
                       - name: RELATED_IMAGE_pvc_jobs
                         value: registry.access.redhat.com/ubi8-minimal:8.3-201
                       - name: RELATED_IMAGE_postgres
-                        value: centos/postgresql-96-centos7:9.6
+                        value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
                       - name: RELATED_IMAGE_keycloak
                         value: quay.io/eclipse/che-keycloak:nightly
                       - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
@@ -331,7 +331,7 @@ spec:
                       - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
                         value: quay.io/eclipse/che-jwtproxy:0.10.0
                       - name: RELATED_IMAGE_single_host_gateway
-                        value: docker.io/traefik:v2.2.8
+                        value: quay.io/eclipse/che--traefik:v2.2.8-f5af5a5ce17fc3e353b507e8acce65d7f28126408a8c92dc3cac246d023dc9e8
                       - name: RELATED_IMAGE_single_host_gateway_config_sidecar
                         value: quay.io/che-incubator/configbump:0.1.4
                       - name: CHE_FLAVOR
@@ -461,4 +461,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.22.0-31.nightly
+  version: 7.22.0-33.nightly

--- a/deploy/olm-catalog/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/eclipse-che-preview-openshift/manifests/che-operator.clusterserviceversion.yaml
@@ -74,13 +74,13 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "false"
     containerImage: quay.io/eclipse/che-operator:nightly
-    createdAt: "2020-11-16T13:58:00Z"
+    createdAt: "2020-11-18T22:39:07Z"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: eclipse-che
     repository: https://github.com/eclipse/che-operator
     support: Eclipse Foundation
-  name: eclipse-che-preview-openshift.v7.22.0-31.nightly
+  name: eclipse-che-preview-openshift.v7.22.0-33.nightly
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -335,7 +335,7 @@ spec:
                       - name: RELATED_IMAGE_pvc_jobs
                         value: registry.access.redhat.com/ubi8-minimal:8.3-201
                       - name: RELATED_IMAGE_postgres
-                        value: centos/postgresql-96-centos7:9.6
+                        value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
                       - name: RELATED_IMAGE_keycloak
                         value: quay.io/eclipse/che-keycloak:nightly
                       - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
@@ -345,7 +345,7 @@ spec:
                       - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
                         value: quay.io/eclipse/che-jwtproxy:0.10.0
                       - name: RELATED_IMAGE_single_host_gateway
-                        value: docker.io/traefik:v2.2.8
+                        value: quay.io/eclipse/che--traefik:v2.2.8-f5af5a5ce17fc3e353b507e8acce65d7f28126408a8c92dc3cac246d023dc9e8
                       - name: RELATED_IMAGE_single_host_gateway_config_sidecar
                         value: quay.io/che-incubator/configbump:0.1.4
                       - name: CHE_FLAVOR
@@ -481,4 +481,4 @@ spec:
   maturity: stable
   provider:
     name: Eclipse Foundation
-  version: 7.22.0-31.nightly
+  version: 7.22.0-33.nightly

--- a/deploy/operator-local.yaml
+++ b/deploy/operator-local.yaml
@@ -56,7 +56,7 @@ spec:
             - name: RELATED_IMAGE_pvc_jobs
               value: registry.access.redhat.com/ubi8-minimal:8.3-201
             - name: RELATED_IMAGE_postgres
-              value: centos/postgresql-96-centos7:9.6
+              value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
             - name: RELATED_IMAGE_keycloak
               value: quay.io/eclipse/che-keycloak:nightly
             - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
@@ -66,7 +66,7 @@ spec:
             - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
               value: quay.io/eclipse/che-jwtproxy:0.10.0
             - name: RELATED_IMAGE_single_host_gateway
-              value: docker.io/traefik:v2.2.8
+              value: quay.io/eclipse/che--traefik:v2.2.8-f5af5a5ce17fc3e353b507e8acce65d7f28126408a8c92dc3cac246d023dc9e8
             - name: RELATED_IMAGE_single_host_gateway_config_sidecar
               value: quay.io/che-incubator/configbump:0.1.4
             - name: CHE_FLAVOR

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -55,7 +55,7 @@ spec:
             - name: RELATED_IMAGE_pvc_jobs
               value: registry.access.redhat.com/ubi8-minimal:8.3-201
             - name: RELATED_IMAGE_postgres
-              value: centos/postgresql-96-centos7:9.6
+              value: quay.io/eclipse/che--centos--postgresql-96-centos7:9.6-b681d78125361519180a6ac05242c296f8906c11eab7e207b5ca9a89b6344392
             - name: RELATED_IMAGE_keycloak
               value: quay.io/eclipse/che-keycloak:nightly
             - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
@@ -65,7 +65,7 @@ spec:
             - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
               value: quay.io/eclipse/che-jwtproxy:0.10.0
             - name: RELATED_IMAGE_single_host_gateway
-              value: docker.io/traefik:v2.2.8
+              value: quay.io/eclipse/che--traefik:v2.2.8-f5af5a5ce17fc3e353b507e8acce65d7f28126408a8c92dc3cac246d023dc9e8
             - name: RELATED_IMAGE_single_host_gateway_config_sidecar
               value: quay.io/che-incubator/configbump:0.1.4
             - name: CHE_FLAVOR

--- a/olm/update-nightly-bundle.sh
+++ b/olm/update-nightly-bundle.sh
@@ -31,7 +31,7 @@ case $OPERATOR_SDK_VERSION in
     echo "Operator SDK ${OPERATOR_SDK_VERSION} installed"
     ;;
   *)
-    echo "This script requires Operator SDK v0.17.x. Please install the correct version to continue"
+    echo "This script requires Operator SDK v0.17.x. Please install from https://github.com/operator-framework/operator-sdk/releases/tag/v0.17.2 to continue"
     exit 1
     ;;
 esac


### PR DESCRIPTION
18292 - switch to use quay copies of docker.io images

fix for eclipse/che#18292

Change-Id: I8503ce14a8821007e9cdb3f6542cbc37e044cb7c
Signed-off-by: nickboldt <nboldt@redhat.com>