### PR TITLE
Refresh oauth client

### DIFF
--- a/pkg/controller/che/che_controller_test.go
+++ b/pkg/controller/che/che_controller_test.go
@@ -13,10 +13,11 @@ package che
 
 import (
 	"context"
-	identity_provider "github.com/eclipse/che-operator/pkg/deploy/identity-provider"
 	"io/ioutil"
 	"os"
 	"time"
+
+	identity_provider "github.com/eclipse/che-operator/pkg/deploy/identity-provider"
 
 	"github.com/eclipse/che-operator/pkg/deploy"
 
@@ -190,7 +191,7 @@ func TestCheController(t *testing.T) {
 	if err = r.client.Get(context.TODO(), types.NamespacedName{Name: cheCR.Name, Namespace: cheCR.Namespace}, cheCR); err != nil {
 		t.Errorf("Failed to get the Che custom resource %s: %s", cheCR.Name, err)
 	}
-	if err = identity_provider.CreateIdentityProviderItems(deployContext, "che"); err != nil {
+	if err = identity_provider.SyncIdentityProviderItems(deployContext, "che"); err != nil {
 		t.Errorf("Failed to create the items for the identity provider: %s", err)
 	}
 	oAuthClientName := cheCR.Spec.Auth.OAuthClientName

--- a/pkg/deploy/gateway/gateway.go
+++ b/pkg/deploy/gateway/gateway.go
@@ -13,7 +13,6 @@ package gateway
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/eclipse/che-operator/pkg/deploy"
@@ -22,7 +21,6 @@ import (
 	"github.com/eclipse/che-operator/pkg/util"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -67,37 +65,37 @@ func SyncGatewayToCluster(deployContext *deploy.DeployContext) error {
 func syncAll(deployContext *deploy.DeployContext) error {
 	instance := deployContext.CheCluster
 	sa := getGatewayServiceAccountSpec(instance)
-	if err := sync(deployContext, &sa, serviceAccountDiffOpts); err != nil {
+	if err := deploy.Sync(deployContext, &sa, serviceAccountDiffOpts); err != nil {
 		return err
 	}
 
 	role := getGatewayRoleSpec(instance)
-	if err := sync(deployContext, &role, roleDiffOpts); err != nil {
+	if err := deploy.Sync(deployContext, &role, roleDiffOpts); err != nil {
 		return err
 	}
 
 	roleBinding := getGatewayRoleBindingSpec(instance)
-	if err := sync(deployContext, &roleBinding, roleBindingDiffOpts); err != nil {
+	if err := deploy.Sync(deployContext, &roleBinding, roleBindingDiffOpts); err != nil {
 		return err
 	}
 
 	traefikConfig := getGatewayTraefikConfigSpec(instance)
-	if err := sync(deployContext, &traefikConfig, configMapDiffOpts); err != nil {
+	if err := deploy.Sync(deployContext, &traefikConfig, configMapDiffOpts); err != nil {
 		return err
 	}
 
 	depl := getGatewayDeploymentSpec(instance)
-	if err := sync(deployContext, &depl, deploy.DeploymentDiffOpts); err != nil {
+	if err := deploy.Sync(deployContext, &depl, deploymentDiffOpts); err != nil {
 		return err
 	}
 
 	service := getGatewayServiceSpec(instance)
-	if err := sync(deployContext, &service, serviceDiffOpts); err != nil {
+	if err := deploy.Sync(deployContext, &service, serviceDiffOpts); err != nil {
 		return err
 	}
 
 	serverConfig := getGatewayServerConfigSpec(deployContext)
-	if err := sync(deployContext, &serverConfig, configMapDiffOpts); err != nil {
+	if err := deploy.Sync(deployContext, &serverConfig, configMapDiffOpts); err != nil {
 		return err
 	}
 
@@ -169,108 +167,6 @@ func deleteAll(deployContext *deploy.DeployContext) error {
 	}
 
 	return nil
-}
-
-// sync syncs the blueprint to the cluster in a generic (as much as Go allows) manner.
-func sync(deployContext *deploy.DeployContext, blueprint metav1.Object, diffOpts cmp.Option) error {
-	clusterAPI := deployContext.ClusterAPI
-
-	blueprintObject, ok := blueprint.(runtime.Object)
-	if !ok {
-		return fmt.Errorf("object %T is not a runtime.Object. Cannot sync it", blueprint)
-	}
-
-	key := client.ObjectKey{Name: blueprint.GetName(), Namespace: blueprint.GetNamespace()}
-
-	actual := blueprintObject.DeepCopyObject()
-
-	if getErr := deployContext.ClusterAPI.Client.Get(context.TODO(), key, actual); getErr != nil {
-		if statusErr, ok := getErr.(*errors.StatusError); !ok || statusErr.Status().Reason != metav1.StatusReasonNotFound {
-			return getErr
-		}
-		actual = nil
-	}
-
-	kind := blueprintObject.GetObjectKind().GroupVersionKind().Kind
-
-	if actual == nil {
-		logrus.Infof("Creating a new object: %s, name %s", kind, blueprint.GetName())
-		obj, err := setOwnerReferenceAndConvertToRuntime(deployContext, blueprint)
-		if err != nil {
-			return err
-		}
-
-		err = clusterAPI.Client.Create(context.TODO(), obj)
-		if err != nil {
-			if !errors.IsAlreadyExists(err) {
-				return err
-			}
-
-			// ok, we got an already-exists error. So let's try to load the object into "actual".
-			// if we fail this retry for whatever reason, just give up rather than retrying this in a loop...
-			// the reconciliation loop will lead us here again in the next round.
-			if getErr := deployContext.ClusterAPI.Client.Get(context.TODO(), key, actual); getErr != nil {
-				return getErr
-			}
-		}
-	}
-
-	if actual != nil {
-		actualMeta := actual.(metav1.Object)
-
-		diff := cmp.Diff(actual, blueprint, diffOpts)
-		if len(diff) > 0 {
-			logrus.Infof("Updating existing object: %s, name: %s", kind, actualMeta.GetName())
-			fmt.Printf("Difference:\n%s", diff)
-
-			if isUpdateUsingDeleteCreate(actual.GetObjectKind().GroupVersionKind().Kind) {
-				err := clusterAPI.Client.Delete(context.TODO(), actual)
-				if err != nil {
-					return err
-				}
-
-				obj, err := setOwnerReferenceAndConvertToRuntime(deployContext, blueprint)
-				if err != nil {
-					return err
-				}
-
-				err = clusterAPI.Client.Create(context.TODO(), obj)
-				if err != nil {
-					return err
-				}
-			} else {
-				obj, err := setOwnerReferenceAndConvertToRuntime(deployContext, blueprint)
-				if err != nil {
-					return err
-				}
-
-				err = clusterAPI.Client.Update(context.TODO(), obj)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func isUpdateUsingDeleteCreate(kind string) bool {
-	return "Service" == kind || "Ingress" == kind || "Route" == kind
-}
-
-func setOwnerReferenceAndConvertToRuntime(deployContext *deploy.DeployContext, obj metav1.Object) (runtime.Object, error) {
-	err := controllerutil.SetControllerReference(deployContext.CheCluster, obj, deployContext.ClusterAPI.Scheme)
-	if err != nil {
-		return nil, err
-	}
-
-	robj, ok := obj.(runtime.Object)
-	if !ok {
-		return nil, fmt.Errorf("object %T is not a runtime.Object. Cannot sync it", obj)
-	}
-
-	return robj, nil
 }
 
 func delete(clusterAPI deploy.ClusterAPI, obj metav1.Object) error {

--- a/pkg/deploy/gateway/gateway.go
+++ b/pkg/deploy/gateway/gateway.go
@@ -65,37 +65,37 @@ func SyncGatewayToCluster(deployContext *deploy.DeployContext) error {
 func syncAll(deployContext *deploy.DeployContext) error {
 	instance := deployContext.CheCluster
 	sa := getGatewayServiceAccountSpec(instance)
-	if err := deploy.Sync(deployContext, &sa, serviceAccountDiffOpts); err != nil {
+	if _, err := deploy.Sync(deployContext, &sa, serviceAccountDiffOpts); err != nil {
 		return err
 	}
 
 	role := getGatewayRoleSpec(instance)
-	if err := deploy.Sync(deployContext, &role, roleDiffOpts); err != nil {
+	if _, err := deploy.Sync(deployContext, &role, roleDiffOpts); err != nil {
 		return err
 	}
 
 	roleBinding := getGatewayRoleBindingSpec(instance)
-	if err := deploy.Sync(deployContext, &roleBinding, roleBindingDiffOpts); err != nil {
+	if _, err := deploy.Sync(deployContext, &roleBinding, roleBindingDiffOpts); err != nil {
 		return err
 	}
 
 	traefikConfig := getGatewayTraefikConfigSpec(instance)
-	if err := deploy.Sync(deployContext, &traefikConfig, configMapDiffOpts); err != nil {
+	if _, err := deploy.Sync(deployContext, &traefikConfig, configMapDiffOpts); err != nil {
 		return err
 	}
 
 	depl := getGatewayDeploymentSpec(instance)
-	if err := deploy.Sync(deployContext, &depl, deploy.DeploymentDiffOpts); err != nil {
+	if _, err := deploy.Sync(deployContext, &depl, deploy.DeploymentDiffOpts); err != nil {
 		return err
 	}
 
 	service := getGatewayServiceSpec(instance)
-	if err := deploy.Sync(deployContext, &service, serviceDiffOpts); err != nil {
+	if _, err := deploy.Sync(deployContext, &service, serviceDiffOpts); err != nil {
 		return err
 	}
 
 	serverConfig := getGatewayServerConfigSpec(deployContext)
-	if err := deploy.Sync(deployContext, &serverConfig, configMapDiffOpts); err != nil {
+	if _, err := deploy.Sync(deployContext, &serverConfig, configMapDiffOpts); err != nil {
 		return err
 	}
 

--- a/pkg/deploy/gateway/gateway.go
+++ b/pkg/deploy/gateway/gateway.go
@@ -85,7 +85,7 @@ func syncAll(deployContext *deploy.DeployContext) error {
 	}
 
 	depl := getGatewayDeploymentSpec(instance)
-	if err := deploy.Sync(deployContext, &depl, deploymentDiffOpts); err != nil {
+	if err := deploy.Sync(deployContext, &depl, deploy.DeploymentDiffOpts); err != nil {
 		return err
 	}
 

--- a/pkg/deploy/identity-provider/identity_provider.go
+++ b/pkg/deploy/identity-provider/identity_provider.go
@@ -165,7 +165,7 @@ func CreateIdentityProviderItems(deployContext *deploy.DeployContext, cheFlavor 
 	keycloakURL := instance.Spec.Auth.IdentityProviderURL
 	keycloakRealm := util.GetValue(instance.Spec.Auth.IdentityProviderRealm, cheFlavor)
 	oAuthClient := deploy.NewOAuthClient(oAuthClientName, oauthSecret, keycloakURL, keycloakRealm, isOpenShift4)
-	if err := deploy.Sync(deployContext, oAuthClient, oAuthClientDiffOpts); err != nil {
+	if _, err := deploy.Sync(deployContext, oAuthClient, oAuthClientDiffOpts); err != nil {
 		return err
 	}
 

--- a/pkg/deploy/identity-provider/identity_provider.go
+++ b/pkg/deploy/identity-provider/identity_provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/eclipse/che-operator/pkg/deploy/expose"
 
 	"github.com/eclipse/che-operator/pkg/util"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	oauth "github.com/openshift/api/oauth/v1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -27,6 +28,10 @@ import (
 
 const (
 	Keycloak = "keycloak"
+)
+
+var (
+	oAuthClientDiffOpts = cmpopts.IgnoreFields(oauth.OAuthClient{}, "TypeMeta", "ObjectMeta")
 )
 
 // SyncIdentityProviderToCluster instantiates the identity provider (Keycloak) in the cluster. Returns true if
@@ -123,11 +128,8 @@ func SyncIdentityProviderToCluster(deployContext *deploy.DeployContext) (bool, e
 	if isOpenShift {
 		doInstallOpenShiftoAuthProvider := instance.Spec.Auth.OpenShiftoAuth
 		if doInstallOpenShiftoAuthProvider {
-			openShiftIdentityProviderStatus := instance.Status.OpenShiftoAuthProvisioned
-			if !openShiftIdentityProviderStatus {
-				if err := CreateIdentityProviderItems(deployContext, cheFlavor); err != nil {
-					return false, err
-				}
+			if err := CreateIdentityProviderItems(deployContext, cheFlavor); err != nil {
+				return false, err
 			}
 		}
 	}
@@ -141,12 +143,14 @@ func CreateIdentityProviderItems(deployContext *deploy.DeployContext, cheFlavor 
 	isOpenShift4 := util.IsOpenShift4
 	keycloakDeploymentName := KeycloakDeploymentName
 	oAuthClientName := instance.Spec.Auth.OAuthClientName
+	initializeKeycloak := false
 	if len(oAuthClientName) < 1 {
 		oAuthClientName = instance.Name + "-openshift-identity-provider-" + strings.ToLower(util.GeneratePasswd(6))
 		instance.Spec.Auth.OAuthClientName = oAuthClientName
 		if err := deploy.UpdateCheCRSpec(deployContext, "oAuthClient name", oAuthClientName); err != nil {
 			return err
 		}
+		initializeKeycloak = true
 	}
 	oauthSecret := instance.Spec.Auth.OAuthSecret
 	if len(oauthSecret) < 1 {
@@ -155,16 +159,17 @@ func CreateIdentityProviderItems(deployContext *deploy.DeployContext, cheFlavor 
 		if err := deploy.UpdateCheCRSpec(deployContext, "oAuthC secret name", oauthSecret); err != nil {
 			return err
 		}
+		initializeKeycloak = true
 	}
 
 	keycloakURL := instance.Spec.Auth.IdentityProviderURL
 	keycloakRealm := util.GetValue(instance.Spec.Auth.IdentityProviderRealm, cheFlavor)
 	oAuthClient := deploy.NewOAuthClient(oAuthClientName, oauthSecret, keycloakURL, keycloakRealm, isOpenShift4)
-	if err := createNewOauthClient(deployContext, oAuthClient); err != nil {
+	if err := deploy.Sync(deployContext, oAuthClient, oAuthClientDiffOpts); err != nil {
 		return err
 	}
 
-	if !tests {
+	if !tests && initializeKeycloak {
 		openShiftIdentityProviderCommand, err := GetOpenShiftIdentityProviderProvisionCommand(instance, oAuthClientName, oauthSecret, isOpenShift4)
 		if err != nil {
 			logrus.Errorf("Failed to build identity provider provisioning command")
@@ -188,25 +193,6 @@ func CreateIdentityProviderItems(deployContext *deploy.DeployContext, cheFlavor 
 				break
 			}
 		}
-	}
-	return nil
-}
-
-func createNewOauthClient(deployContext *deploy.DeployContext, oAuthClient *oauth.OAuthClient) error {
-	oAuthClientFound := &oauth.OAuthClient{}
-	err := deployContext.ClusterAPI.Client.Get(context.TODO(), types.NamespacedName{Name: oAuthClient.Name, Namespace: oAuthClient.Namespace}, oAuthClientFound)
-	if err != nil && errors.IsNotFound(err) {
-		logrus.Infof("Creating a new object: %s, name: %s", oAuthClient.Kind, oAuthClient.Name)
-		err = deployContext.ClusterAPI.Client.Create(context.TODO(), oAuthClient)
-		if err != nil {
-			logrus.Errorf("Failed to create %s %s: %s", oAuthClient.Kind, oAuthClient.Name, err)
-			return err
-		}
-		return nil
-	} else if err != nil {
-		logrus.Errorf("An error occurred: %s", err)
-
-		return err
 	}
 	return nil
 }

--- a/pkg/deploy/sync.go
+++ b/pkg/deploy/sync.go
@@ -1,0 +1,128 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// Sync syncs the blueprint to the cluster in a generic (as much as Go allows) manner. The sync is always done using
+// a delete and re-creation.
+func Sync(deployContext *DeployContext, blueprint metav1.Object, diffOpts cmp.Option) error {
+	clusterAPI := deployContext.ClusterAPI
+
+	blueprintObject, ok := blueprint.(runtime.Object)
+	if !ok {
+		return fmt.Errorf("object %T is not a runtime.Object. Cannot sync it", blueprint)
+	}
+
+	key := client.ObjectKey{Name: blueprint.GetName(), Namespace: blueprint.GetNamespace()}
+
+	actual := blueprintObject.DeepCopyObject()
+
+	if getErr := deployContext.ClusterAPI.Client.Get(context.TODO(), key, actual); getErr != nil {
+		if statusErr, ok := getErr.(*errors.StatusError); !ok || statusErr.Status().Reason != metav1.StatusReasonNotFound {
+			return getErr
+		}
+		actual = nil
+	}
+
+	kind := blueprintObject.GetObjectKind().GroupVersionKind().Kind
+
+	if actual == nil {
+		logrus.Infof("Creating a new object: %s, name %s", kind, blueprint.GetName())
+		obj, err := setOwnerReferenceAndConvertToRuntime(deployContext, blueprint)
+		if err != nil {
+			return err
+		}
+
+		err = clusterAPI.Client.Create(context.TODO(), obj)
+		if err != nil {
+			if !errors.IsAlreadyExists(err) {
+				return err
+			}
+
+			// ok, we got an already-exists error. So let's try to load the object into "actual".
+			// if we fail this retry for whatever reason, just give up rather than retrying this in a loop...
+			// the reconciliation loop will lead us here again in the next round.
+			if getErr := deployContext.ClusterAPI.Client.Get(context.TODO(), key, actual); getErr != nil {
+				return getErr
+			}
+		}
+	}
+
+	if actual != nil {
+		actualMeta := actual.(metav1.Object)
+
+		diff := cmp.Diff(actual, blueprint, diffOpts)
+		if len(diff) > 0 {
+			logrus.Infof("Updating existing object: %s, name: %s", kind, actualMeta.GetName())
+			fmt.Printf("Difference:\n%s", diff)
+
+			if isUpdateUsingDeleteCreate(actual.GetObjectKind().GroupVersionKind().Kind) {
+				err := clusterAPI.Client.Delete(context.TODO(), actual)
+				if err != nil {
+					return err
+				}
+
+				obj, err := setOwnerReferenceAndConvertToRuntime(deployContext, blueprint)
+				if err != nil {
+					return err
+				}
+
+				err = clusterAPI.Client.Create(context.TODO(), obj)
+				if err != nil {
+					return err
+				}
+			} else {
+				obj, err := setOwnerReferenceAndConvertToRuntime(deployContext, blueprint)
+				if err != nil {
+					return err
+				}
+
+				// to be able to update, we need to set the resource version of the object that we know of
+				obj.(metav1.Object).SetResourceVersion(actualMeta.GetResourceVersion())
+
+				err = clusterAPI.Client.Update(context.TODO(), obj)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func isUpdateUsingDeleteCreate(kind string) bool {
+	return "Service" == kind || "Ingress" == kind || "Route" == kind
+}
+
+func shouldSetOwnerReference(kind string) bool {
+	return "OAuthClient" != kind
+}
+
+func setOwnerReferenceAndConvertToRuntime(deployContext *DeployContext, obj metav1.Object) (runtime.Object, error) {
+	robj, ok := obj.(runtime.Object)
+	if !ok {
+		return nil, fmt.Errorf("object %T is not a runtime.Object. Cannot sync it", obj)
+	}
+
+	if !shouldSetOwnerReference(robj.GetObjectKind().GroupVersionKind().Kind) {
+		return robj, nil
+	}
+
+	err := controllerutil.SetControllerReference(deployContext.CheCluster, obj, deployContext.ClusterAPI.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return robj, nil
+}


### PR DESCRIPTION
When changing the `serverExposureStrategy` between `multi-host` and `single-host`, the URL of the keycloak server changes. This must be reflected in the OAuthClient object on OpenShift when using OpenShift OAuth otherwise OpenShift won't allow the users to login.

This fixes eclipse/che#17886.