### PR TITLE
https://github.com/eclipse/che/issues/18393...

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,15 @@
 # This Workflow performs a full release of che-operator
-
-name: release
-
+name: Release Che Operator
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'version'
-        default: '7.x.y'
-
+        description: 'The version that is going to be released. Should be in format 7.y.z'
+        required: true
+        default: '7.y.z'
 jobs:
   build:
     runs-on: ubuntu-20.04
-
     steps:
       - uses: actions/checkout@v2
         with: 
@@ -21,14 +18,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
-      - name: Install operator courier
+      - name: Install operator courier, yq, and base32 wrapper
         run: |
           python -m pip install --upgrade pip
           pip install operator-courier==2.1.7
           pip install yq
-
-      - name: Install base32
-        run: |
           # get base32 util from che-release project
           wget https://raw.githubusercontent.com/eclipse/che-release/master/utils/base32
           # copy base32 python-based helper script into dir that's accessed from PATH (so it's accessible to this and other called scripts) 
@@ -36,36 +30,29 @@ jobs:
           sudo chmod +x /usr/local/bin/base32
           #remove base32 from current directory to avoid it being commited during release
           rm $(pwd)/base32 
-
       - name: Release operator
         run: |
           CHE_VERSION=${{ github.event.inputs.version }}
           echo "CHE_VERSION=${CHE_VERSION}"
           BRANCH=${CHE_VERSION%.*}.x
           echo "BRANCH=${BRANCH}"
-          
           git config --global user.name "Mykhailo Kuznietsov"
           git config --global user.email "mkuznets@redhat.com"
           export GITHUB_TOKEN=${{ secrets.CHE_BOT_GITHUB_TOKEN }}
-
           set -e
-
           OP_SDK_DIR=/opt/operator-sdk
           mkdir -p $OP_SDK_DIR
-
           if [[ ${CHE_VERSION%.*} == 7.21 ]];then
             wget https://github.com/operator-framework/operator-sdk/releases/download/v0.10.0/operator-sdk-v0.10.0-x86_64-linux-gnu -O $OP_SDK_DIR/operator-sdk 
           else
             OPERATOR_SDK=$(sed -r 's|operator-sdk:\s*(.*)|\1|' REQUIREMENTS)
             wget https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK}/operator-sdk-${OPERATOR_SDK}-x86_64-linux-gnu -O $OP_SDK_DIR/operator-sdk 
           fi
-
           chmod +x $OP_SDK_DIR/operator-sdk
           export PATH="$PATH:$OP_SDK_DIR"
-
           export QUAY_ECLIPSE_CHE_USERNAME=${{ secrets.QUAY_USERNAME }} 
           export QUAY_ECLIPSE_CHE_PASSWORD=${{ secrets.QUAY_PASSWORD }}
-          
+
           # we usually do not update nightly files during major releases
           if [[ ${CHE_VERSION} == *".0" ]]; then
             ./make-release.sh ${CHE_VERSION} --release --release-olm-files --update-nightly-olm-files 
@@ -73,18 +60,23 @@ jobs:
             git checkout ${BRANCH}
             bash -x ./make-release.sh ${CHE_VERSION} --release --release-olm-files
           fi
-          
+
           # default robot account on quay does not have permissions for application repos
           # so we provide credentials for accounts that do
           export QUAY_USERNAME_K8S=${{ secrets.QUAY_ECLIPSE_CHE_OPERATOR_KUBERNETES_USERNAME }}
           export QUAY_PASSWORD_K8S=${{ secrets.QUAY_ECLIPSE_CHE_OPERATOR_KUBERNETES_PASSWORD }}
           export QUAY_USERNAME_OS=${{ secrets.QUAY_ECLIPSE_CHE_OPERATOR_OPENSHIFT_USERNAME }}
           export QUAY_PASSWORD_OS=${{ secrets.QUAY_ECLIPSE_CHE_OPERATOR_OPENSHIFT_PASSWORD }}
-          
-          # uncomment after https://github.com/eclipse/che/issues/18393 fix
-          # git checkout ${CHE_VERSION}-release
-          # ./make-release.sh ${CHE_VERSION} --push-olm-files
-          
+          # echo "[DEBUG] Using credentials:"
+          # echo "[DEBUG] QUAY_USERNAME_K8S = ${QUAY_USERNAME_K8S} and"
+          # echo "[DEBUG] QUAY_USERNAME_OS = ${QUAY_USERNAME_OS}"
+
+          # publish quay applications to:
+          # https://quay.io/application/eclipse-che-operator-kubernetes/eclipse-che-preview-kubernetes?tab=releases and
+          # https://quay.io/application/eclipse-che-operator-openshift/eclipse-che-preview-openshift?tab=releases
+          git checkout ${CHE_VERSION}-release
+          ./make-release.sh ${CHE_VERSION} --push-olm-files
+
           # perform extra checkouts to ensure branches exist locally
           git checkout ${BRANCH}
           git checkout ${CHE_VERSION}-release

--- a/olm/push-olm-files-to-quay.sh
+++ b/olm/push-olm-files-to-quay.sh
@@ -59,12 +59,13 @@ do
   esac
   if [ -z "${QUAY_ECLIPSE_CHE_USERNAME}" ] || [ -z "${QUAY_ECLIPSE_CHE_PASSWORD}" ]
   then
-    echo "#### ERROR: "
-    echo "You should have set ${QUAY_USERNAME_PLATFORM_VAR} and ${QUAY_PASSWORD_PLATFORM_VAR} environment variables"
-    echo "with a user that has write access to the following Quay.io namespace: ${quayNamespace}"
-    echo "or QUAY_ECLIPSE_CHE_USERNAME and QUAY_ECLIPSE_CHE_PASSWORD if the same user can access both namespaces 'eclipse-che-operator-kubernetes' and 'eclipse-che-operator-openshift'"
+    echo "[ERROR] Must set ${QUAY_USERNAME_PLATFORM_VAR} and ${QUAY_PASSWORD_PLATFORM_VAR} environment variables"
+    echo "[ERROR] with a user that has write access to the following Quay.io application namespace: ${quayNamespace}"
+    echo "[ERROR] or QUAY_ECLIPSE_CHE_USERNAME and QUAY_ECLIPSE_CHE_PASSWORD if the same user can access both "
+    echo "[ERROR] application namespaces 'eclipse-che-operator-kubernetes' and 'eclipse-che-operator-openshift'"
     exit 1
   fi
+  # echo "[DEBUG] Authenticating with: QUAY_ECLIPSE_CHE_USERNAME = ${QUAY_ECLIPSE_CHE_USERNAME}"
   AUTH_TOKEN=$(curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '
 {
     "user": {
@@ -72,7 +73,7 @@ do
         "password": "'"${QUAY_ECLIPSE_CHE_PASSWORD}"'"
     }
 }' | jq -r '.token')
-
+  # if [[ ${AUTH_TOKEN} ]]; then echo "[DEBUG] Got token"; fi
   operator-courier push generated/flatten "${quayNamespace}" "${packageName}" "${applicationVersion}" "${AUTH_TOKEN}"
 done
 cd "${CURRENT_DIR}"


### PR DESCRIPTION
turns out this already works using the exising user/pwd config:
    secrets.QUAY_ECLIPSE_CHE_OPERATOR_KUBERNETES_USERNAME and 
    secrets.QUAY_ECLIPSE_CHE_OPERATOR_OPENSHIFT_USERNAME
clean up debugging steps (comment out in case needed again in future)
fix comment re: https://github.com/eclipse/che/issues/18393

Change-Id: I35aa6102a233776818ba937587033937ce68505b
Signed-off-by: nickboldt <nboldt@redhat.com>