### PR TITLE
prevent spurious warnings about diff...

### DIFF
--- a/olm/push-olm-files-to-quay.sh
+++ b/olm/push-olm-files-to-quay.sh
@@ -74,6 +74,14 @@ do
     }
 }' | jq -r '.token')
   # if [[ ${AUTH_TOKEN} ]]; then echo "[DEBUG] Got token"; fi
+
+  # move all diff files away so we don't get warnings about invalid file names
+  find . -name "*.yaml.diff" -exec rm -f {} \; || true
+
+  # push new applications to quay.io/application/eclipse-che-operator-*
   operator-courier push generated/flatten "${quayNamespace}" "${packageName}" "${applicationVersion}" "${AUTH_TOKEN}"
+
+  # now put them back
+  git checkout . || true
 done
 cd "${CURRENT_DIR}"


### PR DESCRIPTION
### What does this PR do?

prevent spurious warnings about diff files

Change-Id: Ia2f7bf470b2627e7f670e6d5972d4ffedb939394
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

This fixes the dozens of warnings like this:

```
WARNING:operatorcourier.flatten:Ignoring /home/nboldt/50/che-operator/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/7.17.2/eclipse-che-preview-kubernetes.crd.yaml.diff as the file does not end with .yaml or .yml
```

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.