### PR TITLE
instead of just...

### DIFF
--- a/.github/workflows/release-community-operator-PRs.yml
+++ b/.github/workflows/release-community-operator-PRs.yml
@@ -1,11 +1,11 @@
 # This Workflow creates PRs for the release of the latest che-operator to the community operators in OperatorHub
 name: Release community operator PRs
 on:
-  # workflow_dispatch:
-  #   inputs:
-  #     forceflag:
-  #       description: 'To update an existing PR, use -f or --force flag here'
-  #       default: ''
+  workflow_dispatch:
+    inputs:
+      forceflag:
+        description: 'To update an existing PR, use -f or --force flag here'
+        default: ''
 
   # trigger on commit to master branch of new CSVs, eg.,
   # https://github.com/eclipse/che-operator/pull/571/files
@@ -39,4 +39,4 @@ jobs:
           git config --global user.name "Mykhailo Kuznietsov"
           git config --global user.email "mkuznets@redhat.com"
           export GITHUB_TOKEN=${{ secrets.CHE_BOT_GITHUB_TOKEN }}
-          ./olm/prepare-community-operators-update.sh ${{ github.event.inputs.forceflag }}
+          ./make-release.sh nightly --update-nightly-olm-files --prepare-community-operators-update ${{ github.event.inputs.forceflag }}

--- a/make-release.sh
+++ b/make-release.sh
@@ -23,6 +23,7 @@ init() {
   CREATE_PULL_REQUESTS=false
   RELEASE_OLM_FILES=false
   UPDATE_NIGHTLY_OLM_FILES=false
+  PREPARE_COMMUNITY_OPERATORS_UPDATE=false
   RELEASE_DIR=$(cd "$(dirname "$0")"; pwd)
   FORCE_UPDATE=""
 
@@ -36,6 +37,7 @@ init() {
       '--pull-requests') CREATE_PULL_REQUESTS=true; shift 0;;
       '--release-olm-files') RELEASE_OLM_FILES=true; shift 0;;
       '--update-nightly-olm-files') UPDATE_NIGHTLY_OLM_FILES=true; shift 0;;
+      '--prepare-community-operators-update') PREPARE_COMMUNITY_OPERATORS_UPDATE=true; shift 0;;
       '--force') FORCE_UPDATE="--force"; shift 0;;
     '--help'|'-h') usage; exit;;
     esac
@@ -251,6 +253,9 @@ createPRToMasterBranch() {
   set -e
 }
 
+prepareCommunityOperatorsUpdate() {
+  "${BASE_DIR}/prepare-community-operators-update.sh" $FORCE_UPDATE
+}
 run() {
   checkoutToReleaseBranch
   releaseOperatorCode
@@ -280,4 +285,11 @@ fi
 if [[ $CREATE_PULL_REQUESTS == "true" ]]; then
   createPRToXBranch
   createPRToMasterBranch
+fi
+
+if [[ $PREPARE_COMMUNITY_OPERATORS_UPDATE == "true" ]]; then
+  if [[ $UPDATE_NIGHTLY_OLM_FILES == "true" ]]; then
+    updateNightlyOlmFiles
+  fi
+  prepareCommunityOperatorsUpdate
 fi


### PR DESCRIPTION
instead of just prepare-community-operators-update.sh, run --update-nightly-olm-files and --prepare-community-operators-update; also see if we can enable more than one way of triggering this action (on workflow dispatch and on push)

Change-Id: I82526f3cbea68d452398542c010b6b04894c4a85
Signed-off-by: nickboldt <nboldt@redhat.com>