### PR TITLE
tweak GIT_REMOTE_FORK_CLEAN so it's a more...

### DIFF
--- a/olm/prepare-community-operators-update.sh
+++ b/olm/prepare-community-operators-update.sh
@@ -36,7 +36,7 @@ if [[ ! ${GITHUB_TOKEN} ]]; then
 fi
 
 GIT_REMOTE_FORK="https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${fork_org}/community-operators.git"
-GIT_REMOTE_FORK_CLEAN="https://${GITHUB_USER}:***@github.com/${fork_org}/community-operators.git"
+GIT_REMOTE_FORK_CLEAN="https://github.com/${fork_org}/community-operators.git"
 
 usage ()
 {


### PR DESCRIPTION
tweak GIT_REMOTE_FORK_CLEAN so it's a more clickable link when echoing warning to console about hub not being installed

Change-Id: I81295419b687aecd12bab66f7299c0fcc4d231e2
Signed-off-by: nickboldt <nboldt@redhat.com>