### PR TITLE
Mount secrets in containers

### DIFF
--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -1151,7 +1151,7 @@ func (r *ReconcileChe) autoEnableOAuth(cr *orgv1.CheCluster, request reconcile.R
 }
 
 // isEclipseCheSecret indicates if there is a secret with
-// the label 'app.kubernetes.io/part-of=che.eclipse.org' in a namespace
+// the label 'app.kubernetes.io/part-of=che.eclipse.org' in a che namespace
 func isEclipseCheSecret(mgr manager.Manager, obj handler.MapObject) (bool, reconcile.Request) {
 	checlusters := &orgv1.CheClusterList{}
 	if err := mgr.GetClient().List(context.TODO(), checlusters, &client.ListOptions{}); err != nil {

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -173,17 +173,29 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	var toRequestMapper handler.ToRequestsFunc = func(obj handler.MapObject) []reconcile.Request {
+	var toTrustedBundleConfigMapRequestMapper handler.ToRequestsFunc = func(obj handler.MapObject) []reconcile.Request {
 		isTrusted, reconcileRequest := isTrustedBundleConfigMap(mgr, obj)
 		if isTrusted {
 			return []reconcile.Request{reconcileRequest}
 		}
 		return []reconcile.Request{}
 	}
-	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestsFromMapFunc{
-		ToRequests: toRequestMapper,
-	}, onAllExceptGenericEventsPredicate)
-	if err != nil {
+	if err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: toTrustedBundleConfigMapRequestMapper,
+	}, onAllExceptGenericEventsPredicate); err != nil {
+		return err
+	}
+
+	var toEclipseCheMountSecretRequestMapper handler.ToRequestsFunc = func(obj handler.MapObject) []reconcile.Request {
+		isMountSecret, reconcileRequest := isEclipseCheMountSecret(mgr, obj)
+		if isMountSecret {
+			return []reconcile.Request{reconcileRequest}
+		}
+		return []reconcile.Request{}
+	}
+	if err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: toEclipseCheMountSecretRequestMapper,
+	}, onAllExceptGenericEventsPredicate); err != nil {
 		return err
 	}
 
@@ -311,7 +323,7 @@ func (r *ReconcileChe) Reconcile(request reconcile.Request) (reconcile.Result, e
 	}
 
 	// delete oAuthClient before CR is deleted
-	// todo check 
+	// todo check
 	// instance.Status.OpenShiftoAuthProvisioned
 	if util.IsOpenShift && util.IsOAuthEnabled(instance) {
 		if err := r.ReconcileFinalizer(instance); err != nil {
@@ -1071,7 +1083,7 @@ func isTrustedBundleConfigMap(mgr manager.Manager, obj handler.MapObject) (bool,
 		// Check for labels
 
 		// Check for part of Che label
-		if value, exists := obj.Meta.GetLabels()[deploy.PartOfCheLabelKey]; !exists || value != deploy.PartOfCheLabelValue {
+		if value, exists := obj.Meta.GetLabels()[deploy.KubernetesPartOfLabelKey]; !exists || value != deploy.CheEclipseOrg {
 			// Labels do not match
 			return false, reconcile.Request{}
 		}
@@ -1136,4 +1148,28 @@ func (r *ReconcileChe) autoEnableOAuth(cr *orgv1.CheCluster, request reconcile.R
 	}
 
 	return reconcile.Result{}, nil
+}
+
+// isEclipseCheMountSecret detects whether given secret is Eclipse Che mount secret
+func isEclipseCheMountSecret(mgr manager.Manager, obj handler.MapObject) (bool, reconcile.Request) {
+	checlusters := &orgv1.CheClusterList{}
+	if err := mgr.GetClient().List(context.TODO(), checlusters, &client.ListOptions{}); err != nil {
+		return false, reconcile.Request{}
+	}
+
+	if len(checlusters.Items) != 1 {
+		return false, reconcile.Request{}
+	}
+
+	if value, exists := obj.Meta.GetLabels()[deploy.KubernetesPartOfLabelKey]; !exists || value != deploy.CheEclipseOrg {
+		// Labels do not match
+		return false, reconcile.Request{}
+	}
+
+	return true, reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: checlusters.Items[0].Namespace,
+			Name:      checlusters.Items[0].Name,
+		},
+	}
 }

--- a/pkg/controller/che/che_controller.go
+++ b/pkg/controller/che/che_controller.go
@@ -186,15 +186,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	var toEclipseCheMountSecretRequestMapper handler.ToRequestsFunc = func(obj handler.MapObject) []reconcile.Request {
-		isMountSecret, reconcileRequest := isEclipseCheMountSecret(mgr, obj)
-		if isMountSecret {
+	var toEclipseCheSecretRequestMapper handler.ToRequestsFunc = func(obj handler.MapObject) []reconcile.Request {
+		isEclipseCheSecret, reconcileRequest := isEclipseCheSecret(mgr, obj)
+		if isEclipseCheSecret {
 			return []reconcile.Request{reconcileRequest}
 		}
 		return []reconcile.Request{}
 	}
 	if err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestsFromMapFunc{
-		ToRequests: toEclipseCheMountSecretRequestMapper,
+		ToRequests: toEclipseCheSecretRequestMapper,
 	}, onAllExceptGenericEventsPredicate); err != nil {
 		return err
 	}
@@ -1150,8 +1150,9 @@ func (r *ReconcileChe) autoEnableOAuth(cr *orgv1.CheCluster, request reconcile.R
 	return reconcile.Result{}, nil
 }
 
-// isEclipseCheMountSecret detects whether given secret is Eclipse Che mount secret
-func isEclipseCheMountSecret(mgr manager.Manager, obj handler.MapObject) (bool, reconcile.Request) {
+// isEclipseCheSecret indicates if there is a secret with
+// the label 'app.kubernetes.io/part-of=che.eclipse.org' in a namespace
+func isEclipseCheSecret(mgr manager.Manager, obj handler.MapObject) (bool, reconcile.Request) {
 	checlusters := &orgv1.CheClusterList{}
 	if err := mgr.GetClient().List(context.TODO(), checlusters, &client.ListOptions{}); err != nil {
 		return false, reconcile.Request{}

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -102,12 +102,16 @@ const (
 	OldDefaultCodeReadyServerImageTag  = "1.2"
 	OldCrwPluginRegistryUrl            = "https://che-plugin-registry.openshift.io"
 
+	// kubernetes default labels
 	KubernetesComponentLabelKey = "app.kubernetes.io/component"
 	KubernetesPartOfLabelKey    = "app.kubernetes.io/part-of"
-	CheEclipseOrg               = "che.eclipse.org"
-	CheEclipseOrgMountPath      = "che.eclipse.org/mount-path"
-	CheEclipseOrgMountAs        = "che.eclipse.org/mount-as"
-	CheEclipseOrgEnvName        = "che.eclipse.org/env-name"
+
+	CheEclipseOrg = "che.eclipse.org"
+
+	// che.eclipse.org annotations
+	CheEclipseOrgMountPath = "che.eclipse.org/mount-path"
+	CheEclipseOrgMountAs   = "che.eclipse.org/mount-as"
+	CheEclipseOrgEnvName   = "che.eclipse.org/env-name"
 )
 
 func InitDefaults(defaultsPath string) {

--- a/pkg/deploy/defaults.go
+++ b/pkg/deploy/defaults.go
@@ -102,8 +102,12 @@ const (
 	OldDefaultCodeReadyServerImageTag  = "1.2"
 	OldCrwPluginRegistryUrl            = "https://che-plugin-registry.openshift.io"
 
-	PartOfCheLabelKey   = "app.kubernetes.io/part-of"
-	PartOfCheLabelValue = "che.eclipse.org"
+	KubernetesComponentLabelKey = "app.kubernetes.io/component"
+	KubernetesPartOfLabelKey    = "app.kubernetes.io/part-of"
+	CheEclipseOrg               = "che.eclipse.org"
+	CheEclipseOrgMountPath      = "che.eclipse.org/mount-path"
+	CheEclipseOrgMountAs        = "che.eclipse.org/mount-as"
+	CheEclipseOrgEnvName        = "che.eclipse.org/env-name"
 )
 
 func InitDefaults(defaultsPath string) {

--- a/pkg/deploy/deployment.go
+++ b/pkg/deploy/deployment.go
@@ -14,16 +14,24 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"errors"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
-	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var DeploymentDiffOpts = cmp.Options{
@@ -33,6 +41,7 @@ var DeploymentDiffOpts = cmp.Options{
 	cmpopts.IgnoreFields(corev1.Container{}, "TerminationMessagePath", "TerminationMessagePolicy"),
 	cmpopts.IgnoreFields(corev1.PodSpec{}, "DNSPolicy", "SchedulerName", "SecurityContext", "DeprecatedServiceAccount"),
 	cmpopts.IgnoreFields(corev1.ConfigMapVolumeSource{}, "DefaultMode"),
+	cmpopts.IgnoreFields(corev1.SecretVolumeSource{}, "DefaultMode"),
 	cmpopts.IgnoreFields(corev1.VolumeSource{}, "EmptyDir"),
 	cmp.Comparer(func(x, y resource.Quantity) bool {
 		return x.Cmp(y) == 0
@@ -50,6 +59,12 @@ func SyncDeploymentToCluster(
 	clusterDeployment *appsv1.Deployment,
 	additionalDeploymentDiffOpts cmp.Options,
 	additionalDeploymentMerge func(*appsv1.Deployment, *appsv1.Deployment) *appsv1.Deployment) DeploymentProvisioningStatus {
+
+	if err := MountSecrets(specDeployment, deployContext); err != nil {
+		return DeploymentProvisioningStatus{
+			ProvisioningStatus: ProvisioningStatus{Requeue: true, Err: err},
+		}
+	}
 
 	clusterDeployment, err := GetClusterDeployment(specDeployment.Name, specDeployment.Namespace, deployContext.ClusterAPI.Client)
 	if err != nil {
@@ -111,10 +126,102 @@ func GetClusterDeployment(name string, namespace string, client runtimeClient.Cl
 	}
 	err := client.Get(context.TODO(), namespacedName, deployment)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
 	return deployment, nil
+}
+
+func MountSecrets(specDeployment *appsv1.Deployment, deployContext *DeployContext) error {
+	secrets := &corev1.SecretList{}
+
+	kubernetesPartOfLabelSelectorRequirement, _ := labels.NewRequirement(KubernetesPartOfLabelKey, selection.Equals, []string{CheEclipseOrg})
+	kubernetesComponentLabelSelectorRequirement, _ := labels.NewRequirement(KubernetesComponentLabelKey, selection.Equals, []string{specDeployment.Name + "-secret"})
+
+	listOptions := &client.ListOptions{
+		LabelSelector: labels.NewSelector().Add(*kubernetesPartOfLabelSelectorRequirement).Add(*kubernetesComponentLabelSelectorRequirement),
+	}
+	if err := deployContext.ClusterAPI.Client.List(context.TODO(), secrets, listOptions); err != nil {
+		return err
+	}
+
+	// sort secret first to have the same order every time
+	sort.Slice(secrets.Items, func(i, j int) bool {
+		return strings.Compare(secrets.Items[i].Name, secrets.Items[j].Name) < 0
+	})
+
+	for _, secretObj := range secrets.Items {
+		switch secretObj.Annotations[CheEclipseOrgMountAs] {
+		case "file":
+			voluseSource := corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretObj.Name,
+				},
+			}
+
+			volume := corev1.Volume{
+				Name:         secretObj.Name,
+				VolumeSource: voluseSource,
+			}
+
+			volumeMount := corev1.VolumeMount{
+				Name:      secretObj.Name,
+				MountPath: secretObj.Annotations[CheEclipseOrgMountPath],
+			}
+
+			specDeployment.Spec.Template.Spec.Volumes = append(specDeployment.Spec.Template.Spec.Volumes, volume)
+			specDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(specDeployment.Spec.Template.Spec.Containers[0].VolumeMounts, volumeMount)
+
+		case "env":
+			secret, err := GetClusterSecret(secretObj.Name, deployContext.CheCluster.Namespace, deployContext.ClusterAPI)
+			if err != nil {
+				return err
+			} else if secret == nil {
+				return errors.New("Secret " + secretObj.Name + " not found.")
+			}
+
+			// grab all keys and sort first to have the same order every time
+			keys := make([]string, 0)
+			for k := range secret.Data {
+				keys = append(keys, k)
+			}
+			sort.Slice(keys, func(i, j int) bool {
+				return strings.Compare(keys[i], keys[j]) < 0
+			})
+
+			for _, key := range keys {
+				var envName string
+
+				// check if evn name defined explicitly
+				envNameAnnotation := CheEclipseOrg + "/" + key + "_env-name"
+				envName, envNameExists := secretObj.Annotations[envNameAnnotation]
+				if !envNameExists {
+					// check if there is only one env name to mount
+					envName, envNameExists = secretObj.Annotations[CheEclipseOrgEnvName]
+					if len(secret.Data) > 1 {
+						return errors.New("There are more than one environment variable to mount. Use annotation '" + envNameAnnotation + "' to specify a name.")
+					} else if !envNameExists {
+						return errors.New("Environment name to mount secret key not found. Use annotation '" + CheEclipseOrgEnvName + "' to specify a name.")
+					}
+				}
+
+				env := corev1.EnvVar{
+					Name: envName,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							Key: key,
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: secretObj.Name,
+							},
+						},
+					},
+				}
+				specDeployment.Spec.Template.Spec.Containers[0].Env = append(specDeployment.Spec.Template.Spec.Containers[0].Env, env)
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/deploy/deployment.go
+++ b/pkg/deploy/deployment.go
@@ -132,7 +132,7 @@ func GetClusterDeployment(name string, namespace string, client runtimeClient.Cl
 	return deployment, nil
 }
 
-// It mounts secrets into a container as a file or as environment variable.
+// MountSecrets mounts secrets into a container as a file or as environment variable.
 // Secrets are selected by the following labels:
 // - app.kubernetes.io/part-of=che.eclipse.org
 // - app.kubernetes.io/component=<DEPLOYMENT-NAME>-secret

--- a/pkg/deploy/deployment_test.go
+++ b/pkg/deploy/deployment_test.go
@@ -1,0 +1,300 @@
+//
+// Copyright (c) 2012-2019 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package deploy
+
+import (
+	"os"
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+
+	orgv1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"testing"
+)
+
+func TestMountSecret(t *testing.T) {
+	type testCase struct {
+		name               string
+		initDeployment     *appsv1.Deployment
+		expectedDeployment *appsv1.Deployment
+		initObjects        []runtime.Object
+	}
+
+	testCases := []testCase{
+		{
+			name: "Mount secret as file",
+			initDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "che",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{}},
+						},
+					},
+				},
+			},
+			expectedDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "che",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "test-volume",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "test-volume",
+										},
+									},
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "test-volume",
+											MountPath: "/test-path",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			initObjects: []runtime.Object{
+				&corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-volume",
+						Namespace: "eclipse-che",
+						Labels: map[string]string{
+							KubernetesPartOfLabelKey:    CheEclipseOrg,
+							KubernetesComponentLabelKey: "che-secret", // corresponds to deployment name
+						},
+						Annotations: map[string]string{
+							CheEclipseOrgMountAs:   "file",
+							CheEclipseOrgMountPath: "/test-path",
+						},
+					},
+					Data: map[string][]byte{
+						"key": []byte("key-data"),
+					},
+				},
+			},
+		},
+		{
+			name: "Mount env variable",
+			initDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "che",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{}},
+						},
+					},
+				},
+			},
+			expectedDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "che",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name: "ENV_A",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "a",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "test-envs",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			initObjects: []runtime.Object{
+				&corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-envs",
+						Namespace: "eclipse-che",
+						Labels: map[string]string{
+							KubernetesPartOfLabelKey:    CheEclipseOrg,
+							KubernetesComponentLabelKey: "che-secret", // corresponds to deployment name
+						},
+						Annotations: map[string]string{
+							CheEclipseOrgMountAs: "env",
+							CheEclipseOrgEnvName: "ENV_A",
+						},
+					},
+					Data: map[string][]byte{
+						"a": []byte("a-data"),
+					},
+				},
+			},
+		},
+		{
+			name: "Mount several env variables",
+			initDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "che",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{}},
+						},
+					},
+				},
+			},
+			expectedDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "che",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name: "ENV_A",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "a",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "test-envs",
+													},
+												},
+											},
+										},
+										{
+											Name: "ENV_B",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "b",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "test-envs",
+													},
+												},
+											},
+										},
+										{
+											Name: "ENV_C",
+											ValueFrom: &corev1.EnvVarSource{
+												SecretKeyRef: &corev1.SecretKeySelector{
+													Key: "c",
+													LocalObjectReference: corev1.LocalObjectReference{
+														Name: "test-envs",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			initObjects: []runtime.Object{
+				&corev1.Secret{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-envs",
+						Namespace: "eclipse-che",
+						Labels: map[string]string{
+							KubernetesPartOfLabelKey:    CheEclipseOrg,
+							KubernetesComponentLabelKey: "che-secret", // corresponds to deployment name
+						},
+						Annotations: map[string]string{
+							CheEclipseOrgMountAs:          "env",
+							CheEclipseOrg + "/a_env-name": "ENV_A",
+							CheEclipseOrg + "/b_env-name": "ENV_B",
+							CheEclipseOrg + "/c_env-name": "ENV_C",
+						},
+					},
+					Data: map[string][]byte{
+						"b": []byte("a-data"),
+						"a": []byte("b-data"),
+						"c": []byte("c-data"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logf.SetLogger(zap.LoggerTo(os.Stdout, true))
+			orgv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+			testCase.initObjects = append(testCase.initObjects, testCase.initDeployment)
+			cli := fake.NewFakeClientWithScheme(scheme.Scheme, testCase.initObjects...)
+
+			deployContext := &DeployContext{
+				CheCluster: &orgv1.CheCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "eclipse-che",
+					},
+				},
+				ClusterAPI: ClusterAPI{
+					Client: cli,
+					Scheme: scheme.Scheme,
+				},
+			}
+
+			err := MountSecrets(testCase.initDeployment, deployContext)
+			if err != nil {
+				t.Fatalf("Error mounting secret: %v", err)
+			}
+
+			if !reflect.DeepEqual(testCase.expectedDeployment, testCase.initDeployment) {
+				t.Errorf("Expected deployment and deployment returned from API server differ (-want, +got): %v", cmp.Diff(testCase.expectedDeployment, testCase.initDeployment))
+			}
+		})
+	}
+}

--- a/pkg/deploy/tls.go
+++ b/pkg/deploy/tls.go
@@ -552,7 +552,7 @@ func SyncAdditionalCACertsConfigMapToCluster(cr *orgv1.CheCluster, deployContext
 	if err != nil {
 		return nil, err
 	}
-	mergedCAConfigMapSpec.ObjectMeta.Labels[PartOfCheLabelKey] = PartOfCheLabelValue
+	mergedCAConfigMapSpec.ObjectMeta.Labels[KubernetesPartOfLabelKey] = CheEclipseOrg
 
 	if mergedCAConfigMapSpec.ObjectMeta.Annotations == nil {
 		mergedCAConfigMapSpec.ObjectMeta.Annotations = make(map[string]string)
@@ -573,7 +573,7 @@ func getCACertsConfigMaps(deployContext *DeployContext) ([]corev1.ConfigMap, err
 	CACertsConfigMapList := &corev1.ConfigMapList{}
 
 	caBundleLabelSelectorRequirement, _ := labels.NewRequirement(CheCACertsConfigMapLabelKey, selection.Equals, []string{CheCACertsConfigMapLabelValue})
-	cheComponetLabelSelectorRequirement, _ := labels.NewRequirement(PartOfCheLabelKey, selection.Equals, []string{PartOfCheLabelValue})
+	cheComponetLabelSelectorRequirement, _ := labels.NewRequirement(KubernetesPartOfLabelKey, selection.Equals, []string{CheEclipseOrg})
 	listOptions := &client.ListOptions{
 		LabelSelector: labels.NewSelector().Add(*cheComponetLabelSelectorRequirement).Add(*caBundleLabelSelectorRequirement),
 	}


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

### Reference issue
https://github.com/eclipse/che/issues/18607

### What does this PR do
Allows to mount secrets as file or env variable in che/postgres/keycloak/registries containers.