### PR TITLE
Move stable tests to release branches

### DIFF
--- a/.github/workflows/minikube-stable-updates.yaml
+++ b/.github/workflows/minikube-stable-updates.yaml
@@ -11,7 +11,10 @@
 #
 
 name: Minikube
-on: pull_request
+on:
+  pull_request:
+    branches:
+     - 7.*
 jobs:
   minikube-e2e:
     name: Testing stable versions updates

--- a/.github/workflows/minishift-stable-updates.yaml
+++ b/.github/workflows/minishift-stable-updates.yaml
@@ -11,7 +11,10 @@
 #
 
 name: Minishift
-on: pull_request
+on:
+  pull_request:
+    branches:
+     - 7.*
 jobs:
   minishift-update:
     name: Testing stable versions updates


### PR DESCRIPTION
There is no sense to run stable tests in every PR. Move stable tests to release branches and run only when a new release it is created.

Ref issue: https://github.com/eclipse/che/issues/18293
Signed-off-by: Flavius Lacatusu <flacatus@redhat.com>