### PR TITLE
Revert golang version to 1.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@
 #  Contributors:
 #    Red Hat, Inc. - initial API and implementation
 #
-name: Che operator image build check
+name: Eclipse Che operator image
 on: [pull_request, push]
 jobs:
   build:
@@ -20,15 +20,16 @@ jobs:
     - name: Build the Docker image
       run: docker build .
   buildx:
+    name: Multi-platform build
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v1
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-    - name: Build and push images
+    - name: Build images
       uses: docker/build-push-action@v2
       with:
         file: Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,25 @@
 name: Che operator image build check
 on: [pull_request, push]
 jobs:
-
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
-
     - name: Build the Docker image
       run: docker build .
+  buildx:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Build and push images
+      uses: docker/build-push-action@v2
+      with:
+        file: Dockerfile
+        platforms: linux/amd64,linux/ppc64le,linux/s390x
+        tags: quay.io/eclipse/che-operator:nightly

--- a/.github/workflows/nightly-image-build.yaml
+++ b/.github/workflows/nightly-image-build.yaml
@@ -16,21 +16,21 @@ on:
     - cron:  '0 0 * * *'
 jobs:
   build-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-    - name: Checkout che-machine-exec source code
+    - name: Checkout source code
       uses: actions/checkout@v2
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to quay.io
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v1
       with:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
         registry: quay.io
-    - name: Build and push nightly
+    - name: Build and push images
       uses: docker/build-push-action@v2
       with:
         file: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # NOTE: using registry.redhat.io/rhel8/go-toolset requires login, which complicates automation
 # NOTE: since updateBaseImages.sh does not support other registries than RHCC, update to RHEL8
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/devtools/go-toolset-rhel7
-FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.14.12-4  as builder
+FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.14.9-2  as builder
 ENV PATH=/opt/rh/go-toolset-1.14/root/usr/bin:${PATH} \
     GOPATH=/go/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@
 # NOTE: using registry.redhat.io/rhel8/go-toolset requires login, which complicates automation
 # NOTE: since updateBaseImages.sh does not support other registries than RHCC, update to RHEL8
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/devtools/go-toolset-rhel7
-FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.14.9-2  as builder
-ENV PATH=/opt/rh/go-toolset-1.14/root/usr/bin:${PATH} \
+FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.13.4-18  as builder
+ENV PATH=/opt/rh/go-toolset-1.13/root/usr/bin:${PATH} \
     GOPATH=/go/
 
 USER root

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eclipse/che-operator
 
-go 1.14
+go 1.13
 
 require (
 	github.com/che-incubator/kubernetes-image-puller-operator v0.0.0-20200901231735-f852a5a3ea5c

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -12,7 +12,6 @@ github.com/blang/semver
 # github.com/cespare/xxhash/v2 v2.1.0
 github.com/cespare/xxhash/v2
 # github.com/che-incubator/kubernetes-image-puller-operator v0.0.0-20200901231735-f852a5a3ea5c
-## explicit
 github.com/che-incubator/kubernetes-image-puller-operator/pkg/apis
 github.com/che-incubator/kubernetes-image-puller-operator/pkg/apis/che/v1alpha1
 # github.com/davecgh/go-spew v1.1.1
@@ -38,7 +37,6 @@ github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/go-cmp v0.4.0
-## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
@@ -69,27 +67,23 @@ github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
 # github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible => github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad
-## explicit
 github.com/openshift/api/config/v1
 github.com/openshift/api/console/v1
 github.com/openshift/api/oauth/v1
 github.com/openshift/api/route/v1
 github.com/openshift/api/user/v1
 # github.com/operator-framework/api v0.3.20
-## explicit
 github.com/operator-framework/api/pkg/lib/version
 github.com/operator-framework/api/pkg/operators
 github.com/operator-framework/api/pkg/operators/v1
 github.com/operator-framework/api/pkg/operators/v1alpha1
 # github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-16619cd27fa5
-## explicit
 github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators
 github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1
 github.com/operator-framework/operator-lifecycle-manager/pkg/lib/version
 github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators
 github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1
 # github.com/operator-framework/operator-sdk v0.15.2
-## explicit
 github.com/operator-framework/operator-sdk/pkg/k8sutil
 github.com/operator-framework/operator-sdk/pkg/leader
 github.com/operator-framework/operator-sdk/pkg/ready
@@ -103,7 +97,6 @@ github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.7.0
-## explicit
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/log
@@ -113,7 +106,6 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/sirupsen/logrus v1.4.2
-## explicit
 github.com/sirupsen/logrus
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
@@ -131,7 +123,6 @@ go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914
-## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/http/httpguts
@@ -180,10 +171,8 @@ gopkg.in/fsnotify.v1
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.8
-## explicit
 gopkg.in/yaml.v2
 # k8s.io/api v0.18.2 => k8s.io/api v0.0.0-20191016110408-35e52d86657a
-## explicit
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
@@ -224,7 +213,6 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.18.2 => k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8
-## explicit
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/api/resource
@@ -273,7 +261,6 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.0.0-20191016111102-bec269661e48
-## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
@@ -401,7 +388,6 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/trace
 # sigs.k8s.io/controller-runtime v0.6.0 => sigs.k8s.io/controller-runtime v0.4.0
-## explicit
 sigs.k8s.io/controller-runtime/pkg/cache
 sigs.k8s.io/controller-runtime/pkg/cache/internal
 sigs.k8s.io/controller-runtime/pkg/client
@@ -438,27 +424,3 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/certwatcher
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# k8s.io/api => k8s.io/api v0.0.0-20191016110408-35e52d86657a
-# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20191016113550-5357c4baaf65
-# k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8
-# k8s.io/apiserver => k8s.io/apiserver v0.0.0-20191016112112-5190913f932d
-# k8s.io/cli-runtime => k8s.io/cli-runtime v0.0.0-20191016114015-74ad18325ed5
-# k8s.io/client-go => k8s.io/client-go v0.0.0-20191016111102-bec269661e48
-# k8s.io/cloud-provider => k8s.io/cloud-provider v0.0.0-20191016115326-20453efc2458
-# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.0.0-20191016115129-c07a134afb42
-# k8s.io/code-generator => k8s.io/code-generator v0.0.0-20191004115455-8e001e5d1894
-# k8s.io/component-base => k8s.io/component-base v0.0.0-20191016111319-039242c015a9
-# k8s.io/cri-api => k8s.io/cri-api v0.0.0-20190828162817-608eb1dad4ac
-# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.0.0-20191016115521-756ffa5af0bd
-# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.0.0-20191016112429-9587704a8ad4
-# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.0.0-20191016114939-2b2b218dc1df
-# k8s.io/kube-proxy => k8s.io/kube-proxy v0.0.0-20191016114407-2e83b6f20229
-# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.0.0-20191016114748-65049c67a58b
-# k8s.io/kubectl => k8s.io/kubectl v0.0.0-20191016120415-2ed914427d51
-# k8s.io/kubelet => k8s.io/kubelet v0.0.0-20191016114556-7841ed97f1b2
-# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.0.0-20191016115753-cf0698c3a16b
-# k8s.io/metrics => k8s.io/metrics v0.0.0-20191016113814-3b1a734dba6e
-# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.0.0-20191016112829-06bb3c9d77c9
-# sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.4.0
-# github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309
-# github.com/openshift/api => github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

### What does this PR do
 - Reverts golang version from 1.14 to 1.13 (1.14 causes failed build on different platforms)
 - Added github action to check multi-platform build

### Reference issue
https://github.com/eclipse/che/issues/18768