### PR TITLE
`cd /home/jboss` before exec into identity provider container

### DIFF
--- a/pkg/deploy/identity-provider/exec.go
+++ b/pkg/deploy/identity-provider/exec.go
@@ -71,9 +71,10 @@ func GetKeycloakProvisionCommand(cr *v1.CheCluster) (command string) {
 		"$cheHost", cr.Spec.Server.CheHost,
 		"$requiredActions", requiredActions)
 	createRealmClientUserCommand := r.Replace(str)
-	command = createRealmClientUserCommand
 	if cheFlavor == "che" {
 		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " + createRealmClientUserCommand
+	} else {
+		command = "export JAVA_TOOL_OPTIONS=-Duser.home=/home/jboss && " + createRealmClientUserCommand
 	}
 	return command
 }
@@ -146,10 +147,10 @@ func GetOpenShiftIdentityProviderProvisionCommand(cr *v1.CheCluster, oAuthClient
 		return "", err
 	}
 
-	command = buffer.String()
-
 	if cheFlavor == "che" {
-		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " + command
+		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " + buffer.String()
+	} else {
+		command = "export JAVA_TOOL_OPTIONS=-Duser.home=/home/jboss  && " + buffer.String()
 	}
 	return command, nil
 }
@@ -175,9 +176,10 @@ func GetDeleteOpenShiftIdentityProviderProvisionCommand(cr *v1.CheCluster, isOpe
 			"--realm master --user " + keycloakUserEnvVar + " --password " + keycloakPasswordEnvVar + " && " +
 			"if " + script + " get identity-provider/instances/" + providerName + " -r " + keycloakRealm + " ; then " +
 			script + " delete identity-provider/instances/" + providerName + " -r " + keycloakRealm + " ; fi"
-	command = deleteOpenShiftIdentityProviderCommand
 	if cheFlavor == "che" {
 		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " + deleteOpenShiftIdentityProviderCommand
+	} else {
+		command = "export JAVA_TOOL_OPTIONS=-Duser.home=/home/jboss  && " + deleteOpenShiftIdentityProviderCommand
 	}
 	return command
 }

--- a/pkg/deploy/identity-provider/exec.go
+++ b/pkg/deploy/identity-provider/exec.go
@@ -74,7 +74,7 @@ func GetKeycloakProvisionCommand(cr *v1.CheCluster) (command string) {
 	if cheFlavor == "che" {
 		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " + createRealmClientUserCommand
 	} else {
-		command = "export JAVA_TOOL_OPTIONS=-Duser.home=/home/jboss && " + createRealmClientUserCommand
+		command = "cd /home/jboss && " + createRealmClientUserCommand
 	}
 	return command
 }
@@ -150,7 +150,7 @@ func GetOpenShiftIdentityProviderProvisionCommand(cr *v1.CheCluster, oAuthClient
 	if cheFlavor == "che" {
 		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " + buffer.String()
 	} else {
-		command = "export JAVA_TOOL_OPTIONS=-Duser.home=/home/jboss  && " + buffer.String()
+		command = "cd /home/jboss && " + buffer.String()
 	}
 	return command, nil
 }
@@ -179,7 +179,7 @@ func GetDeleteOpenShiftIdentityProviderProvisionCommand(cr *v1.CheCluster, isOpe
 	if cheFlavor == "che" {
 		command = "cd /scripts && export JAVA_TOOL_OPTIONS=-Duser.home=. && " + deleteOpenShiftIdentityProviderCommand
 	} else {
-		command = "export JAVA_TOOL_OPTIONS=-Duser.home=/home/jboss  && " + deleteOpenShiftIdentityProviderCommand
+		command = "cd /home/jboss  && " + deleteOpenShiftIdentityProviderCommand
 	}
 	return command
 }


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

### What does this PR do
The latest rh-sso Dockerfile doesn't contain `WORKDIR` instruction. 
```
# Define the working directory
WORKDIR /home/jboss
```
So, we have to `cd /home/jboss` before doing exec.


### Reference issue
https://issues.redhat.com/browse/CRW-1458
