### PR TITLE
Add note clarifying that the kubernetes image puller operator is comm…

### DIFF
--- a/deploy/crds/org_v1_che_crd.yaml
+++ b/deploy/crds/org_v1_che_crd.yaml
@@ -238,11 +238,15 @@ spec:
               description: Kubernetes Image Puller configuration
               properties:
                 enable:
-                  description: Install and configure the Kubernetes Image Puller Operator.
-                    If true and no spec is provided, it will create a default KubernetesImagePuller
-                    object to be managed by the Operator. If false, the KubernetesImagePuller
-                    object will be deleted, and the operator will be uninstalled,
-                    regardless of whether or not a spec is provided.
+                  description: "Install and configure the Community Supported Kubernetes
+                    Image Puller Operator. If true and no spec is provided, it will
+                    create a default KubernetesImagePuller object to be managed by
+                    the Operator. If false, the KubernetesImagePuller object will
+                    be deleted, and the operator will be uninstalled, regardless of
+                    whether or not a spec is provided. \n Please note that while this
+                    operator and its behavior is community-supported, its payload
+                    may be commercially-supported if you use it for pulling commercially-supported
+                    images."
                   type: boolean
                 spec:
                   description: A KubernetesImagePullerSpec to configure the image

--- a/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
+++ b/deploy/olm-catalog/eclipse-che-preview-kubernetes/manifests/org_v1_che_crd.yaml
@@ -238,11 +238,15 @@ spec:
               description: Kubernetes Image Puller configuration
               properties:
                 enable:
-                  description: Install and configure the Kubernetes Image Puller Operator.
-                    If true and no spec is provided, it will create a default KubernetesImagePuller
-                    object to be managed by the Operator. If false, the KubernetesImagePuller
-                    object will be deleted, and the operator will be uninstalled,
-                    regardless of whether or not a spec is provided.
+                  description: "Install and configure the Community Supported Kubernetes
+                    Image Puller Operator. If true and no spec is provided, it will
+                    create a default KubernetesImagePuller object to be managed by
+                    the Operator. If false, the KubernetesImagePuller object will
+                    be deleted, and the operator will be uninstalled, regardless of
+                    whether or not a spec is provided. \n Please note that while this
+                    operator and its behavior is community-supported, its payload
+                    may be commercially-supported if you use it for pulling commercially-supported
+                    images."
                   type: boolean
                 spec:
                   description: A KubernetesImagePullerSpec to configure the image

--- a/deploy/olm-catalog/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
+++ b/deploy/olm-catalog/eclipse-che-preview-openshift/manifests/org_v1_che_crd.yaml
@@ -239,11 +239,15 @@ spec:
               description: Kubernetes Image Puller configuration
               properties:
                 enable:
-                  description: Install and configure the Kubernetes Image Puller Operator.
-                    If true and no spec is provided, it will create a default KubernetesImagePuller
-                    object to be managed by the Operator. If false, the KubernetesImagePuller
-                    object will be deleted, and the operator will be uninstalled,
-                    regardless of whether or not a spec is provided.
+                  description: "Install and configure the Community Supported Kubernetes\
+                    \ Image Puller Operator. If true and no spec is provided, it will\
+                    \ create a default KubernetesImagePuller object to be managed\
+                    \ by the Operator. If false, the KubernetesImagePuller object\
+                    \ will be deleted, and the operator will be uninstalled, regardless\
+                    \ of whether or not a spec is provided. \n Please note that while\
+                    \ this operator and its behavior is community-supported, its payload\
+                    \ may be commercially-supported if you use it for pulling commercially-supported\
+                    \ images."
                   type: boolean
                 spec:
                   description: A KubernetesImagePullerSpec to configure the image

--- a/pkg/apis/org/v1/che_types.go
+++ b/pkg/apis/org/v1/che_types.go
@@ -532,10 +532,13 @@ type CheClusterSpecMetrics struct {
 // Configuration settings for installation and configuration of the Kubernetes Image Puller
 // See https://github.com/che-incubator/kubernetes-image-puller-operator
 type CheClusterSpecImagePuller struct {
-	// Install and configure the Kubernetes Image Puller Operator. If true and no spec is provided,
+	// Install and configure the Community Supported Kubernetes Image Puller Operator. If true and no spec is provided,
 	// it will create a default KubernetesImagePuller object to be managed by the Operator.
 	// If false, the KubernetesImagePuller object will be deleted, and the operator will be uninstalled,
 	// regardless of whether or not a spec is provided.
+	//
+	// Please note that while this operator and its behavior is community-supported, its payload may be commercially-supported
+	// if you use it for pulling commercially-supported images.
 	Enable bool `json:"enable"`
 	// A KubernetesImagePullerSpec to configure the image puller in the CheCluster
 	// +optional


### PR DESCRIPTION
…unity-supported

Signed-off-by: Tom George <tgeorge@redhat.com>

<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse/che-operator/#development
-->

### What does this PR do?

As part of the discussions around how to best add the kubernetes image puller into the che-operator[1], this PR adds a note that the image puller is considered community supported.

[1] See:

eclipse/che#18569
eclipse/che#18133
#541

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![imagepuller](https://user-images.githubusercontent.com/1291508/104510038-3236f680-55b0-11eb-8b33-96a3dd2446ba.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
eclipse/che#18569
eclipse/che#18133
#541

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [Custom resource definition file is up to date](https://github.com/eclipse/che-operator/blob/master/README.md#updating-custom-resource-definition-file)
- [x] [Nightly OLM bundle is up to date](https://github.com/eclipse/che-operator/blob/master/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
