### PR TITLE
Remove @davidfestal from code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @nickboldt @tolusha
+* @nickboldt @tolusha @mmorhun @AndrienkoAleksandr @flacatus

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @nickboldt @davidfestal @tolusha
+* @nickboldt @tolusha


### PR DESCRIPTION
### What does this PR do?

Remove @davidfestal from code owners, since it doesn't make sense anymore.
