### PR TITLE
gh18864 new GH action to run che-docs...

### DIFF
--- a/.github/workflows/release-che-docs.yml
+++ b/.github/workflows/release-che-docs.yml
@@ -1,0 +1,49 @@
+# This Workflow creates PRs for the release of the latest che-docs
+name: Release che docs
+on:
+  # manual trigger if required
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version that is going to be released. Should be in format 7.y.z'
+        required: true
+        default: '7.y.z'
+      forceflag:
+        description: 'To force creation of .x branch, use --force flag here'
+        default: ''
+  # trigger on commit to master branch of new CSVs, eg., https://github.com/eclipse/che-operator/pull/571/files
+  push:
+    branches: 
+      - master
+    paths:
+      - 'olm/eclipse-che-preview-*/deploy/olm-catalog/eclipse-che-preview-*/eclipse-che-preview-*.package.yaml'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Release che docs PRs
+        run: |
+          hub version
+          git config --global user.name "Mykhailo Kuznietsov"
+          git config --global user.email "mkuznets@redhat.com"
+          export GITHUB_TOKEN=${{ secrets.CHE_BOT_GITHUB_TOKEN }}
+          set -e
+          # if not run manually, need to compute che docs version from latest released CSV
+          if [[ "${{ github.event.inputs.version }}" == "" ]] || [[ "${{ github.event.inputs.version }}" == "7.y.z" ]]; then
+            chedocsVersion=$(cat olm/eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift/eclipse-che-preview-openshift.package.yaml | yq -r '.channels[].currentCSV' | sed -e "s#eclipse-che-preview-openshift.v##")
+          else
+            chedocsVersion="${{ github.event.inputs.version }}"
+          fi
+          cd /tmp
+          # TODO switch to master branch version, not PR version from https://github.com/eclipse/che-docs/pull/1823
+          curl -sSLO https://raw.githubusercontent.com/eclipse/che-docs/f634c1d49b0bc88718dcb593f75d11f45de2ba1c/make-release.sh
+          chmod +x make-release.sh
+          ./make-release.sh --repo git@github.com:eclipse/che-docs --version ${chedocsVersion} ${{ github.event.inputs.forceflag }}

--- a/.github/workflows/release-che-docs.yml
+++ b/.github/workflows/release-che-docs.yml
@@ -42,4 +42,5 @@ jobs:
           # TODO switch to master branch version, not PR version from https://github.com/eclipse/che-docs/pull/1823
           curl -sSLO https://raw.githubusercontent.com/eclipse/che-docs/f634c1d49b0bc88718dcb593f75d11f45de2ba1c/make-release.sh
           chmod +x make-release.sh
-          ./make-release.sh --repo git@github.com:eclipse/che-docs --version ${chedocsVersion} ${{ github.event.inputs.forceflag }}
+          # fetch che-docs code, bump antora playbook file, create .x branch if not exist, and create release tag from that branch
+          ./make-release.sh --repo git@github.com:eclipse/che-docs --version ${chedocsVersion} ${{ github.event.inputs.forceflag }} --trigger-release

--- a/.github/workflows/release-che-docs.yml
+++ b/.github/workflows/release-che-docs.yml
@@ -25,10 +25,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
       - name: Release che docs PRs
         run: |
           hub version


### PR DESCRIPTION
### What does this PR do?

new GH action to run che-docs release when `olm/eclipse-che-preview-*/deploy/olm-catalog/eclipse-che-preview-*/eclipse-che-preview-*.package.yaml` is updated in master branch

NOTE: depends on https://github.com/eclipse/che-docs/pull/1823

Once https://github.com/eclipse/che-docs/pull/1823 is merged, this PR should be updated to use latest che-docs make-release.sh script, rather than the version from the PR - see line 46

Change-Id: Icfb71b6c1e254af4778dcc4f458c4565e94de867
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18864

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.