### PR TITLE
Allow to use internal host name for CHE_WEBSOCKET_ENDPOINT and CHE_WEBSOCKET_ENDPOINT__MINOR

### DIFF
--- a/pkg/deploy/server/che_configmap.go
+++ b/pkg/deploy/server/che_configmap.go
@@ -14,6 +14,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 
@@ -123,10 +124,8 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 	namespaceAllowUserDefined := strconv.FormatBool(deployContext.CheCluster.Spec.Server.AllowUserDefinedWorkspaceNamespaces)
 	tlsSupport := deployContext.CheCluster.Spec.Server.TlsSupport
 	protocol := "http"
-	wsprotocol := "ws"
 	if tlsSupport {
 		protocol = "https"
-		wsprotocol = "wss"
 		tls = "true"
 	}
 
@@ -177,7 +176,7 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 	workspaceNamespaceDefault := util.GetWorkspaceNamespaceDefault(deployContext.CheCluster)
 
 	cheAPI := protocol + "://" + cheHost + "/api"
-	var keycloakInternalURL, pluginRegistryInternalURL, devfileRegistryInternalURL, cheInternalAPI string
+	var keycloakInternalURL, pluginRegistryInternalURL, devfileRegistryInternalURL, cheInternalAPI, webSocketEndpoint, webSocketEndpointMinor string
 
 	if deployContext.CheCluster.Spec.Server.UseInternalClusterSVCNames && !deployContext.CheCluster.Spec.Auth.ExternalIdentityProvider {
 		keycloakInternalURL = deployContext.InternalService.KeycloakHost
@@ -199,8 +198,25 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 
 	if deployContext.CheCluster.Spec.Server.UseInternalClusterSVCNames {
 		cheInternalAPI = deployContext.InternalService.CheHost + "/api"
+
+		u, err := url.Parse(deployContext.InternalService.CheHost)
+		if err != nil {
+			return nil, err
+		}
+
+		webSocketEndpoint = "ws://" + u.Host + "/api/websocket"
+		webSocketEndpointMinor = "ws://" + u.Host + "/api/websocket-minor"
 	} else {
 		cheInternalAPI = cheAPI
+
+		wsprotocol := "ws"
+
+		if tlsSupport {
+			wsprotocol = "wss"
+		}
+
+		webSocketEndpoint = wsprotocol + "://" + cheHost + "/api/websocket"
+		webSocketEndpointMinor = wsprotocol + "://" + cheHost + "/api/websocket-minor"
 	}
 
 	data := &CheConfigMap{
@@ -209,8 +225,8 @@ func GetCheConfigMapData(deployContext *deploy.DeployContext) (cheEnv map[string
 		ChePort:                                "8080",
 		CheApi:                                 cheAPI,
 		CheApiInternal:                         cheInternalAPI,
-		CheWebSocketEndpoint:                   wsprotocol + "://" + cheHost + "/api/websocket",
-		WebSocketEndpointMinor:                 wsprotocol + "://" + cheHost + "/api/websocket-minor",
+		CheWebSocketEndpoint:                   webSocketEndpoint,
+		WebSocketEndpointMinor:                 webSocketEndpointMinor,
 		CheDebugServer:                         cheDebug,
 		CheInfrastructureActive:                infra,
 		CheInfraKubernetesServiceAccountName:   "che-workspace",


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
che-operator Development Guide: https://github.com/eclipse/che-operator/#development
-->

### What does this PR do?

Resolve partially https://github.com/eclipse/che/issues/18872#issuecomment-767376941

Currently, che always communicates with theia and plugin broker via public endpoint.

This PR fixes for plugin broker.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse/che-operator/blob/master/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse/che-operator/blob/master/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
