### PR TITLE
Do not fail if imagePuller CRD does not exist

### DIFF
--- a/pkg/deploy/kubernetes_image_puller.go
+++ b/pkg/deploy/kubernetes_image_puller.go
@@ -257,22 +257,24 @@ func SubscriptionsAreEqual(expected *operatorsv1alpha1.Subscription, actual *ope
 // foundKubernetesImagePullerAPI - true if the server discovers the che.eclipse.org API
 // error - any error returned by the call to discoveryClient.ServerGroups()
 func CheckNeededImagePullerApis(ctx *DeployContext) (bool, bool, bool, error) {
-	groupList, err := ctx.ClusterAPI.DiscoveryClient.ServerGroups()
+	groupList, resourcesList, err := ctx.ClusterAPI.DiscoveryClient.ServerGroupsAndResources()
 	if err != nil {
 		return false, false, false, err
 	}
-	groups := groupList.Groups
 	foundPackagesAPI := false
 	foundOperatorsAPI := false
 	foundKubernetesImagePullerAPI := false
-	for _, group := range groups {
+	for _, group := range groupList {
 		if group.Name == packagesv1.SchemeGroupVersion.Group {
 			foundPackagesAPI = true
 		}
 		if group.Name == operatorsv1alpha1.SchemeGroupVersion.Group {
 			foundOperatorsAPI = true
 		}
-		if group.Name == chev1alpha1.SchemeGroupVersion.Group {
+	}
+
+	for _, r := range resourcesList {
+		if r.Kind == "KubernetesImagePuller" {
 			foundKubernetesImagePullerAPI = true
 		}
 	}

--- a/pkg/deploy/kubernetes_image_puller.go
+++ b/pkg/deploy/kubernetes_image_puller.go
@@ -275,7 +275,7 @@ func CheckNeededImagePullerApis(ctx *DeployContext) (bool, bool, bool, error) {
 
 	for _, l := range resourcesList {
 		for _, r := range l.APIResources {
-			if r.Kind == "KubernetesImagePuller" {
+			if l.GroupVersion == chev1alpha1.SchemeGroupVersion.String() && r.Kind == "KubernetesImagePuller" {
 				foundKubernetesImagePullerAPI = true
 			}
 		}

--- a/pkg/deploy/kubernetes_image_puller.go
+++ b/pkg/deploy/kubernetes_image_puller.go
@@ -273,9 +273,11 @@ func CheckNeededImagePullerApis(ctx *DeployContext) (bool, bool, bool, error) {
 		}
 	}
 
-	for _, r := range resourcesList {
-		if r.Kind == "KubernetesImagePuller" {
-			foundKubernetesImagePullerAPI = true
+	for _, l := range resourcesList {
+		for _, r := range l.APIResources {
+			if r.Kind == "KubernetesImagePuller" {
+				foundKubernetesImagePullerAPI = true
+			}
 		}
 	}
 	return foundPackagesAPI, foundOperatorsAPI, foundKubernetesImagePullerAPI, nil


### PR DESCRIPTION
### What does this PR do?
Do not fail if imagePuller CRD does not exist.

I did the minimal changes which should fix the issue but that logic in general it seems complex and may have other bugs.

### What issues does this PR fix or reference?
It fixes https://github.com/eclipse/che/issues/19207 on my RHPDS instance.

### How to test this PR?
I tested only deploying Che with imagePuller disabled, before it failed with 
```
"Error uninstalling Image Puller: no matches for kind \"KubernetesImagePuller\" in version \"che.eclipse.org/v1alpha1\""
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [Custom resource definition file is up to date](https://github.com/eclipse/che-operator/blob/master/README.md#updating-custom-resource-definition-file)
- [ ] [Nightly OLM bundle is up to date](https://github.com/eclipse/che-operator/blob/master/README.md#update-nightly-olm-bundle)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
